### PR TITLE
Fix SSO after user route protection

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/User.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/User.kt
@@ -157,7 +157,9 @@ class UserAdapter(
     }
 
     fun createOrUpdateUser(user: User): User {
-        val userEntity = userRepository.findByIdOrNull(user.getId())
+        val userEntity = user.getId()?.let {
+            userRepository.findByIdOrNull(it)
+        }
 
         if (userEntity == null) {
             return createUser(user)


### PR DESCRIPTION
accidentally calling findOrNull with a null id leads to a nullpointer in the SSO flow right now :(

Don't have tests for this because it's hard to mock all the moving parts in the Google SSO flow.