### PR TITLE
Add LDAP support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,7 @@ We currently support **Postgres**, **MySQL** and **MS SQL Server**.
 Kviklet ships with a variety of features that an engineering team needs to manage their production database access in a **simple but secure** manner:
 
 - **SSO (Google)**: Log into Kviklet without the need for a username or password. No more shared credentials for DB access.
+- **Or LDAP Support**: Log into Kviklet with your LDAP credentials.
 - **Review/Approval Flow**: Leave Comments and Suggestions on other developers data requests.
 - **Temporary Access (1h)**: Execute any statement on a db for 1h after having been approved
 - **Single Query**: Execute a singular statement. Allows the reviewer to review your query before execution.
@@ -124,6 +125,37 @@ After setting those environment variables the login page should show a Login wit
 
 Other OIDC providers should work similarly to Keycloak, note that the `redirect URI` will change depending on they type you choose, so if you choose `gitlab` it will be `https://[kviklet_host]/api/login/oauth2/code/gitlab`.
 If you run into issues feel free to create an issue, we have not tried every single OIDC provider out there (yet) and there might be slight differences in the implementation that might require updates on Kviklets side.
+
+### LDAP
+
+Kviklet supports LDAP authentication. To enable and configure LDAP, you need to set the following environment variables:
+
+```
+LDAP_ENABLED=true
+LDAP_URL=ldap://your-ldap-server:389
+LDAP_BASE=dc=your,dc=domain,dc=com
+LDAP_PRINCIPAL=cn=admin,dc=your,dc=domain,dc=com
+LDAP_PASSWORD=your-admin-password
+LDAP_UNIQUE_IDENTIFIER_ATTRIBUTE=uid
+LDAP_EMAIL_ATTRIBUTE=mail
+LDAP_FULL_NAME_ATTRIBUTE=cn
+LDAP_USER_OU=people
+```
+
+Here's what each setting means:
+
+- `LDAP_ENABLED`: Set to `true` to enable LDAP authentication.
+- `LDAP_URL`: The URL of your LDAP server.
+- `LDAP_BASE`: The base DN for LDAP searches.
+- `LDAP_PRINCIPAL`: The DN of the admin user for binding to the LDAP server.
+- `LDAP_PASSWORD`: The password for the admin user.
+- `LDAP_UNIQUE_IDENTIFIER_ATTRIBUTE`: The LDAP attribute used as the unique identifier for users (default: "uid").
+- `LDAP_EMAIL_ATTRIBUTE`: The LDAP attribute that contains the user's email address (default: "mail").
+- `LDAP_FULL_NAME_ATTRIBUTE`: The LDAP attribute that contains the user's full name (default: "cn").
+- `LDAP_USER_OU`: The Organizational Unit (OU) where user accounts are stored (default: "people").
+
+You can customize these attributes to match your LDAP schema. After configuring LDAP, users will be able to log in using their LDAP credentials. The first time an LDAP user logs in, a corresponding user account will be created in Kviklet with default permissions. An admin will need to assign appropriate roles to these users after their first login.
+
 
 ## Configuration
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -47,6 +47,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.session:spring-session-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-websocket")
+    implementation("org.springframework.security:spring-security-ldap")
+    implementation("org.springframework.ldap:spring-ldap-core")
 
     implementation("org.springframework.security:spring-security-acl")
     implementation("org.springframework.security:spring-security-config")

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/User.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/User.kt
@@ -146,6 +146,7 @@ class UserAdapter(private val userRepository: UserRepository, private val roleRe
 
     fun createUser(user: User): User {
         val userEntity = UserEntity(
+            ldapIdentifier = user.ldapIdentifier,
             fullName = user.fullName,
             password = user.password,
             subject = user.subject,

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/LDAPProperties.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/LDAPProperties.kt
@@ -1,0 +1,36 @@
+package dev.kviklet.kviklet.security
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.ldap.core.LdapTemplate
+import org.springframework.ldap.core.support.LdapContextSource
+
+@ConfigurationProperties(prefix = "ldap")
+@Configuration
+class LdapProperties {
+    var uniqueIdentifierAttribute: String = "uid"
+    var emailAttribute: String = "mail"
+    var fullNameAttribute: String = "cn"
+    var userDnPattern: String = "uid={0},ou=people"
+    var base: String = "dc=kviklet,dc=dev"
+    var url: String = "ldap://localhost:389"
+    var enabled: Boolean = false
+    var principal = "cn=admin,dc=kviklet,dc=dev"
+    var password = "admin"
+
+    @Bean
+    fun ldapTemplate(contextSource: LdapContextSource): LdapTemplate = LdapTemplate(contextSource)
+
+    @Bean
+    fun contextSource(): LdapContextSource {
+        val contextSource = LdapContextSource()
+        contextSource.setUrl(url)
+        contextSource.setBase(base)
+        contextSource.userDn = principal
+        contextSource.password = password
+        contextSource.afterPropertiesSet()
+
+        return contextSource
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/LDAPProperties.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/LDAPProperties.kt
@@ -12,7 +12,6 @@ class LdapProperties {
     var uniqueIdentifierAttribute: String = "uid"
     var emailAttribute: String = "mail"
     var fullNameAttribute: String = "cn"
-    var userDnPattern: String = "uid={0},ou=people"
     var base: String = "dc=kviklet,dc=dev"
     var url: String = "ldap://localhost:389"
     var enabled: Boolean = false

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/LdapProperties.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/LdapProperties.kt
@@ -9,6 +9,7 @@ import org.springframework.ldap.core.support.LdapContextSource
 @ConfigurationProperties(prefix = "ldap")
 @Configuration
 class LdapProperties {
+    var userOu: String = "people"
     var uniqueIdentifierAttribute: String = "uid"
     var emailAttribute: String = "mail"
     var fullNameAttribute: String = "cn"

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/LoginController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/LoginController.kt
@@ -1,22 +1,14 @@
 package dev.kviklet.kviklet.security
 
-import dev.kviklet.kviklet.db.RoleAdapter
-import dev.kviklet.kviklet.db.User
-import dev.kviklet.kviklet.db.UserAdapter
-import dev.kviklet.kviklet.service.EmailAlreadyExistsException
-import dev.kviklet.kviklet.service.dto.Role
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.ldap.core.LdapTemplate
-import org.springframework.ldap.query.LdapQueryBuilder
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.ldap.userdetails.LdapUserDetails
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository
 import org.springframework.security.web.context.SecurityContextRepository
@@ -25,19 +17,11 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import javax.naming.AuthenticationException
-import javax.naming.directory.Attributes
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 @RestController
-class LoginController(
-    private val authenticationManager: AuthenticationManager,
-    private val customAuthenticationProvider: CustomAuthenticationProvider,
-    private val userAdapter: UserAdapter,
-    private val ldapTemplate: LdapTemplate,
-    private val ldapProperties: LdapProperties,
-    private val roleAdapter: RoleAdapter,
-) {
+class LoginController(private val authenticationManager: AuthenticationManager) {
 
     private val securityContextHolderStrategy = SecurityContextHolder
         .getContextHolderStrategy()
@@ -56,11 +40,6 @@ class LoginController(
             val authenticationToken = UsernamePasswordAuthenticationToken(credentials.email, credentials.password)
             val authentication = authenticationManager.authenticate(authenticationToken)
             if (authentication.isAuthenticated) {
-                // Check if it's an LDAP authentication
-                if (authentication.principal is LdapUserDetails) {
-                    val ldapUser = authentication.principal as LdapUserDetails
-                    createOrUpdateLdapUser(ldapUser)
-                }
                 val session = request.getSession(true)
                 val sessionId = session?.id ?: throw IllegalStateException("Session was not created")
                 val context: SecurityContext = this.securityContextHolderStrategy.createEmptyContext()
@@ -74,51 +53,6 @@ class LoginController(
         } catch (e: AuthenticationException) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         }
-    }
-
-    private fun createOrUpdateLdapUser(ldapUser: LdapUserDetails) {
-        val loginFieldInput = ldapUser.username
-        var user = userAdapter.findByLdapIdentifier(loginFieldInput)
-
-        // Fetch additional attributes from LDAP
-        val searchResults = ldapTemplate.search(
-            LdapQueryBuilder.query().where(ldapProperties.uniqueIdentifierAttribute).`is`(loginFieldInput),
-        ) { attrs: Attributes ->
-            mapOf(
-                "uid" to attrs.get(ldapProperties.uniqueIdentifierAttribute)?.get()?.toString(),
-                "email" to attrs.get(ldapProperties.emailAttribute)?.get()?.toString(),
-                "fullName" to attrs.get(ldapProperties.fullNameAttribute)?.get()?.toString(),
-            )
-        }.firstOrNull()
-        if (searchResults == null) {
-            throw IllegalStateException("LDAP user not found")
-        }
-
-        val email = searchResults["email"] ?: throw IllegalStateException("mail attribute in LDAP user not found")
-        val fullName = searchResults["fullName"]
-            ?: throw IllegalStateException("Full Name attribute in LDAP user not found")
-        val uniqueId = searchResults["uid"] ?: throw IllegalStateException("uid attribute in LDAP user not found")
-
-        if (user == null) {
-            userAdapter.findByEmail(email)?.let {
-                // This means a password or sso user with the same email already exists
-                throw EmailAlreadyExistsException(email)
-            }
-            val defaultRole = roleAdapter.findById(Role.DEFAULT_ROLE_ID)
-
-            user = User(
-                ldapIdentifier = uniqueId,
-                email = email,
-                fullName = fullName,
-                roles = setOf(defaultRole),
-            )
-        } else {
-            user = user.copy(
-                email = email,
-                fullName = fullName,
-            )
-        }
-        userAdapter.createOrUpdateUser(user)
     }
 }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/LoginController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/LoginController.kt
@@ -1,13 +1,22 @@
 package dev.kviklet.kviklet.security
 
+import dev.kviklet.kviklet.db.RoleAdapter
+import dev.kviklet.kviklet.db.User
+import dev.kviklet.kviklet.db.UserAdapter
+import dev.kviklet.kviklet.service.EmailAlreadyExistsException
+import dev.kviklet.kviklet.service.dto.Role
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.ldap.core.LdapTemplate
+import org.springframework.ldap.query.LdapQueryBuilder
+import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.ldap.userdetails.LdapUserDetails
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository
 import org.springframework.security.web.context.SecurityContextRepository
@@ -16,11 +25,19 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import javax.naming.AuthenticationException
+import javax.naming.directory.Attributes
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 @RestController
-class LoginController(private val customAuthenticationProvider: CustomAuthenticationProvider) {
+class LoginController(
+    private val authenticationManager: AuthenticationManager,
+    private val customAuthenticationProvider: CustomAuthenticationProvider,
+    private val userAdapter: UserAdapter,
+    private val ldapTemplate: LdapTemplate,
+    private val ldapProperties: LdapProperties,
+    private val roleAdapter: RoleAdapter,
+) {
 
     private val securityContextHolderStrategy = SecurityContextHolder
         .getContextHolderStrategy()
@@ -37,19 +54,71 @@ class LoginController(private val customAuthenticationProvider: CustomAuthentica
         // This handles username/password authentication. For Oauth see CustomOidcUserService
         try {
             val authenticationToken = UsernamePasswordAuthenticationToken(credentials.email, credentials.password)
-            val authentication = customAuthenticationProvider.authenticate(authenticationToken)
-
-            val session = request.getSession(true)
-            val sessionId = session?.id ?: throw IllegalStateException("Session was not created")
-            val context: SecurityContext = this.securityContextHolderStrategy.createEmptyContext()
-            context.authentication = authentication
-            this.securityContextHolderStrategy.context = context
-            this.securityContextRepository.saveContext(context, request, response)
-
-            return ResponseEntity.ok(LoginResponse(Base64.encode(sessionId.toByteArray())))
+            val authentication = authenticationManager.authenticate(authenticationToken)
+            if (authentication.isAuthenticated) {
+                // Check if it's an LDAP authentication
+                if (authentication.principal is LdapUserDetails) {
+                    val ldapUser = authentication.principal as LdapUserDetails
+                    createOrUpdateLdapUser(ldapUser)
+                }
+                val session = request.getSession(true)
+                val sessionId = session?.id ?: throw IllegalStateException("Session was not created")
+                val context: SecurityContext = this.securityContextHolderStrategy.createEmptyContext()
+                context.authentication = authentication
+                this.securityContextHolderStrategy.context = context
+                this.securityContextRepository.saveContext(context, request, response)
+                return ResponseEntity.ok(LoginResponse(Base64.encode(sessionId.toByteArray())))
+            } else {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+            }
         } catch (e: AuthenticationException) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         }
+    }
+
+    private fun createOrUpdateLdapUser(ldapUser: LdapUserDetails) {
+        val loginFieldInput = ldapUser.username
+        var user = userAdapter.findByLdapIdentifier(loginFieldInput)
+
+        // Fetch additional attributes from LDAP
+        val searchResults = ldapTemplate.search(
+            LdapQueryBuilder.query().where(ldapProperties.uniqueIdentifierAttribute).`is`(loginFieldInput),
+        ) { attrs: Attributes ->
+            mapOf(
+                "uid" to attrs.get(ldapProperties.uniqueIdentifierAttribute)?.get()?.toString(),
+                "email" to attrs.get(ldapProperties.emailAttribute)?.get()?.toString(),
+                "fullName" to attrs.get(ldapProperties.fullNameAttribute)?.get()?.toString(),
+            )
+        }.firstOrNull()
+        if (searchResults == null) {
+            throw IllegalStateException("LDAP user not found")
+        }
+
+        val email = searchResults["email"] ?: throw IllegalStateException("mail attribute in LDAP user not found")
+        val fullName = searchResults["fullName"]
+            ?: throw IllegalStateException("Full Name attribute in LDAP user not found")
+        val uniqueId = searchResults["uid"] ?: throw IllegalStateException("uid attribute in LDAP user not found")
+
+        if (user == null) {
+            userAdapter.findByEmail(email)?.let {
+                // This means a password or sso user with the same email already exists
+                throw EmailAlreadyExistsException(email)
+            }
+            val defaultRole = roleAdapter.findById(Role.DEFAULT_ROLE_ID)
+
+            user = User(
+                ldapIdentifier = uniqueId,
+                email = email,
+                fullName = fullName,
+                roles = setOf(defaultRole),
+            )
+        } else {
+            user = user.copy(
+                email = email,
+                fullName = fullName,
+            )
+        }
+        userAdapter.createOrUpdateUser(user)
     }
 }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
@@ -80,7 +80,7 @@ class SecurityConfig(
     @Bean
     fun ldapAuthenticationProvider(): LdapAuthenticationProvider {
         val userSearch = FilterBasedLdapUserSearch(
-            "ou=people",
+            "ou=${ldapProperties.userOu}",
             "(${ldapProperties.uniqueIdentifierAttribute}={0})",
             contextSource,
         )

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
@@ -81,7 +81,7 @@ class SecurityConfig(
     fun ldapAuthenticationProvider(): LdapAuthenticationProvider {
         val userSearch = FilterBasedLdapUserSearch(
             "ou=people",
-            "(uid={0})",
+            "(${ldapProperties.uniqueIdentifierAttribute}={0})",
             contextSource,
         )
 
@@ -95,7 +95,7 @@ class SecurityConfig(
                     ctx: DirContextOperations,
                     username: String,
                     authorities: MutableCollection<out GrantedAuthority>,
-                ): UserDetails = userDetailsService.loadUserByUsername(username)
+                ): UserDetails = userDetailsService.loadUserByLdapIdentifier(username)
 
                 override fun mapUserToContext(user: UserDetails, ctx: DirContextAdapter) {
                     // This method is typically used when writing back to LDAP.

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
@@ -14,6 +14,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
+import org.springframework.ldap.core.DirContextAdapter
+import org.springframework.ldap.core.DirContextOperations
+import org.springframework.ldap.core.support.LdapContextSource
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.AuthenticationProvider
@@ -27,8 +30,13 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.ldap.authentication.BindAuthenticator
+import org.springframework.security.ldap.authentication.LdapAuthenticationProvider
+import org.springframework.security.ldap.search.FilterBasedLdapUserSearch
+import org.springframework.security.ldap.userdetails.UserDetailsContextMapper
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService
 import org.springframework.security.oauth2.core.oidc.OidcIdToken
@@ -64,12 +72,45 @@ class SecurityConfig(
     private val customAuthenticationProvider: CustomAuthenticationProvider,
     private val customOidcUserService: CustomOidcUserService,
     private val idpProperties: IdentityProviderProperties,
+    private val ldapProperties: LdapProperties,
+    private val contextSource: LdapContextSource,
+    private val userDetailsService: UserDetailsServiceImpl,
 ) {
+
+    @Bean
+    fun ldapAuthenticationProvider(): LdapAuthenticationProvider {
+        val userSearch = FilterBasedLdapUserSearch(
+            "ou=people",
+            "(uid={0})",
+            contextSource,
+        )
+
+        val authenticator = BindAuthenticator(contextSource).apply {
+            setUserSearch(userSearch)
+        }
+
+        return LdapAuthenticationProvider(authenticator).apply {
+            setUserDetailsContextMapper(object : UserDetailsContextMapper {
+                override fun mapUserFromContext(
+                    ctx: DirContextOperations,
+                    username: String,
+                    authorities: MutableCollection<out GrantedAuthority>,
+                ): UserDetails = userDetailsService.loadUserByUsername(username)
+
+                override fun mapUserToContext(user: UserDetails, ctx: DirContextAdapter) {
+                    // This method is typically used when writing back to LDAP.
+                    // We don't need to implement it for our use case.
+                }
+            })
+        }
+    }
 
     @Bean
     fun authManager(http: HttpSecurity): AuthenticationManager {
         val authenticationManagerBuilder = http.getSharedObject(AuthenticationManagerBuilder::class.java)
-        authenticationManagerBuilder.authenticationProvider(customAuthenticationProvider)
+        val builder = authenticationManagerBuilder
+            .authenticationProvider(customAuthenticationProvider)
+        if (ldapProperties.enabled) builder.authenticationProvider(ldapAuthenticationProvider())
         return authenticationManagerBuilder.build()
     }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/UserDetailsServiceImpl.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/UserDetailsServiceImpl.kt
@@ -1,26 +1,83 @@
 package dev.kviklet.kviklet.security
 
+import dev.kviklet.kviklet.db.RoleAdapter
 import dev.kviklet.kviklet.db.UserAdapter
+import dev.kviklet.kviklet.service.dto.Role
+import org.springframework.ldap.core.LdapTemplate
+import org.springframework.ldap.query.LdapQueryBuilder
 import org.springframework.security.core.GrantedAuthority
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.stereotype.Service
 import java.io.Serializable
+import javax.naming.directory.Attributes
 
 @Service
-class UserDetailsServiceImpl(private val userAdapter: UserAdapter) : UserDetailsService {
+class UserDetailsServiceImpl(
+    private val userAdapter: UserAdapter,
+    private val ldapProperties: LdapProperties,
+    private val ldapTemplate: LdapTemplate,
+    private val roleAdapter: RoleAdapter,
+) : UserDetailsService {
 
-    override fun loadUserByUsername(email: String): UserDetails {
-        val user = userAdapter.findByEmail(email)
-            ?: throw UsernameNotFoundException("User '$email' not found.")
+    override fun loadUserByUsername(username: String): UserDetails {
+        val user = if (ldapProperties.enabled && isLdapAuthentication()) {
+            loadLdapUser(username)
+        } else {
+            loadDatabaseUser(username)
+        }
 
-        val authorities = listOf(SimpleGrantedAuthority("USERS"))
+        val authorities = user.roles.flatMap { it.policies }.map { PolicyGrantedAuthority(it) }
 
         return UserDetailsWithId(user.getId()!!, user.email, user.password, authorities)
     }
+
+    private fun loadDatabaseUser(email: String): dev.kviklet.kviklet.db.User = userAdapter.findByEmail(email)
+        ?: throw UsernameNotFoundException("User '$email' not found.")
+
+    private fun loadLdapUser(username: String): dev.kviklet.kviklet.db.User {
+        val ldapUser = loadLdapUserAttributes(username)
+        return findOrCreateLdapUser(ldapUser)
+    }
+
+    private fun loadLdapUserAttributes(username: String): Map<String, String?> = ldapTemplate.search(
+        LdapQueryBuilder.query().where(ldapProperties.uniqueIdentifierAttribute).`is`(username),
+    ) { attrs: Attributes ->
+        mapOf(
+            "uid" to attrs.get(ldapProperties.uniqueIdentifierAttribute)?.get()?.toString(),
+            "email" to attrs.get(ldapProperties.emailAttribute)?.get()?.toString(),
+            "fullName" to attrs.get(ldapProperties.fullNameAttribute)?.get()?.toString(),
+        )
+    }.firstOrNull() ?: throw UsernameNotFoundException("LDAP user '$username' not found.")
+
+    private fun findOrCreateLdapUser(ldapUser: Map<String, String?>): dev.kviklet.kviklet.db.User {
+        val email = ldapUser["email"] ?: throw IllegalStateException("Email attribute in LDAP user not found")
+        val fullName = ldapUser["fullName"] ?: throw IllegalStateException("Full Name attribute in LDAP user not found")
+        val uniqueId = ldapUser["uid"] ?: throw IllegalStateException("UID attribute in LDAP user not found")
+
+        var user = userAdapter.findByLdapIdentifier(uniqueId)
+
+        if (user == null) {
+            val defaultRole = roleAdapter.findById(Role.DEFAULT_ROLE_ID)
+            user = dev.kviklet.kviklet.db.User(
+                ldapIdentifier = uniqueId,
+                email = email,
+                fullName = fullName,
+                roles = setOf(defaultRole),
+            )
+        } else {
+            user = user.copy(
+                email = email,
+                fullName = fullName,
+            )
+        }
+
+        return userAdapter.createOrUpdateUser(user)
+    }
+
+    private fun isLdapAuthentication(): Boolean = true
 }
 
 class UserDetailsWithId(val id: String, email: String, password: String?, authorities: Collection<GrantedAuthority>) :

--- a/backend/src/main/resources/changelog/000-changelog.yaml
+++ b/backend/src/main/resources/changelog/000-changelog.yaml
@@ -47,3 +47,6 @@ databaseChangeLog:
   - include:
       file: 017-drop-readonly-column.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 018-add-ldap-identifier-column.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/changelog/018-add-ldap-identifier-column.yaml
+++ b/backend/src/main/resources/changelog/018-add-ldap-identifier-column.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 018-add-ldap-identifier-column
+      author: Jascha
+      changes:
+        - addColumn:
+            tableName: user
+            columns:
+              - column:
+                  name: ldap_identifier
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: true
+                    unique: true

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/helper/ExecutionRequestFactory.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/helper/ExecutionRequestFactory.kt
@@ -172,6 +172,7 @@ class UserFactory : Factory() {
         fullName: String? = "Test User " + nextId(),
         password: String? = "password",
         subject: String? = null,
+        ldapIdentifier: String? = null,
         email: String = "test" + nextId() + "@user.com",
         roles: Set<Role>? = null,
     ): User = User(
@@ -179,6 +180,7 @@ class UserFactory : Factory() {
         fullName,
         password,
         subject,
+        ldapIdentifier,
         email,
         roles ?: setOf(roleFactory.createRole()),
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,3 +59,20 @@ services:
       - INITIAL_USER_PASSWORD=admin
     depends_on:
       - kviklet-postgres
+
+  ldap:
+    image: osixia/openldap:1.1.8
+    ports:
+      - "389:389"
+    environment:
+      - LDAP_ORGANISATION=Kviklet
+      - LDAP_DOMAIN=kviklet.dev
+      - LDAP_ADMIN_PASSWORD=admin
+      - LDAP_CONFIG_PASSWORD=config
+  ldapmyadmin:
+    image: osixia/phpldapadmin:0.9.0
+    ports:
+      - "80:80"
+    environment:
+      - PHPLDAPADMIN_LDAP_HOSTS=ldap
+      - PHPLDAPADMIN_HTTPS=false

--- a/frontend/src/api/ConfigApi.tsx
+++ b/frontend/src/api/ConfigApi.tsx
@@ -4,6 +4,7 @@ import { ApiResponse, fetchWithErrorHandling } from "./Errors";
 
 const ConfigResponseSchema = z.object({
   oauthProvider: z.string().nullable().optional(),
+  ldapEnabled: z.boolean(),
   teamsUrl: z.string().nullable().optional(),
   slackUrl: z.string().nullable().optional(),
 });

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -109,7 +109,7 @@ const Login = () => {
             <form onSubmit={(e) => void login(e)}>
               <div className="flex flex-col">
                 <label className="py-2 text-sm" htmlFor="email">
-                  {config?.ldapEnabled && "LDAP login" || "Email"}
+                  {(config?.ldapEnabled && "LDAP login") || "Email"}
                 </label>
                 <StyledInput
                   name="email"

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -109,7 +109,7 @@ const Login = () => {
             <form onSubmit={(e) => void login(e)}>
               <div className="flex flex-col">
                 <label className="py-2 text-sm" htmlFor="email">
-                  Email
+                  {config?.ldapEnabled && "LDAP login" || "Email"}
                 </label>
                 <StyledInput
                   name="email"


### PR DESCRIPTION
```
LDAP_ENABLED=true
LDAP_URL=ldap://your-ldap-server:389
LDAP_BASE=dc=your,dc=domain,dc=com
LDAP_PRINCIPAL=cn=admin,dc=your,dc=domain,dc=com
LDAP_PASSWORD=your-admin-password
LDAP_UNIQUE_IDENTIFIER_ATTRIBUTE=uid
LDAP_EMAIL_ATTRIBUTE=mail
LDAP_FULL_NAME_ATTRIBUTE=cn
LDAP_USER_OU=people
```

Here's what each setting means:

- `LDAP_ENABLED`: Set to `true` to enable LDAP authentication.
- `LDAP_URL`: The URL of your LDAP server.
- `LDAP_BASE`: The base DN for LDAP searches.
- `LDAP_PRINCIPAL`: The DN of the admin user for binding to the LDAP server.
- `LDAP_PASSWORD`: The password for the admin user.
- `LDAP_UNIQUE_IDENTIFIER_ATTRIBUTE`: The LDAP attribute used as the unique identifier for users (default: "uid").
- `LDAP_EMAIL_ATTRIBUTE`: The LDAP attribute that contains the user's email address (default: "mail").
- `LDAP_FULL_NAME_ATTRIBUTE`: The LDAP attribute that contains the user's full name (default: "cn").
- `LDAP_USER_OU`: The Organizational Unit (OU) where user accounts are stored (default: "people").

You can customize these attributes to match your LDAP schema. After configuring LDAP, users will be able to log in using their LDAP credentials. The first time an LDAP user logs in, a corresponding user account will be created in Kviklet with default permissions. An admin will need to assign appropriate roles to these users after their first login.
