### PR TITLE
Add test connection button and multi create for postgres

### DIFF
--- a/frontend/src/api/DatasourceApi.tsx
+++ b/frontend/src/api/DatasourceApi.tsx
@@ -50,6 +50,12 @@ const connectionResponseSchema = z.union([
   kubernetesConnectionResponseSchema,
 ]);
 
+const testConnectionResponseSchema = z.object({
+  success: z.boolean(),
+  details: z.string(),
+  accessibleDatabases: z.array(z.string()),
+});
+
 const databaseConnectionPayloadSchema = z
   .object({
     displayName: z.coerce.string(),
@@ -140,6 +146,8 @@ type KubernetesConnectionPayload = z.infer<
   typeof kubernetesConnectionPayloadSchema
 >;
 
+type TestConnectionResponse = z.infer<typeof testConnectionResponseSchema>;
+
 const addConnection = async (
   payload: ConnectionPayload,
 ): Promise<ApiResponse<ConnectionResponse>> => {
@@ -154,6 +162,23 @@ const addConnection = async (
       body: JSON.stringify(payload),
     },
     connectionResponseSchema,
+  );
+};
+
+const testConnection = async (
+  payload: ConnectionPayload,
+): Promise<ApiResponse<TestConnectionResponse>> => {
+  return fetchWithErrorHandling(
+    `${baseUrl}/connections/test`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify(payload),
+    },
+    testConnectionResponseSchema,
   );
 };
 
@@ -207,6 +232,7 @@ const getConnection = async (
 
 export {
   addConnection,
+  testConnection,
   connectionResponseSchema,
   AuthenticationType,
   patchConnection,
@@ -217,6 +243,7 @@ export {
 };
 
 export type {
+  TestConnectionResponse,
   ConnectionResponse,
   ConnectionPayload,
   PatchConnectionPayload,

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -4,6 +4,7 @@ function Button(props: {
   children: React.ReactNode;
   className?: string;
   size?: "sm" | "md" | "lg";
+  textSize?: "sm" | "md" | "lg";
   type?:
     | "button"
     | "submit"
@@ -25,7 +26,9 @@ function Button(props: {
   const disabled = props.type == "disabled" ? true : undefined;
   const submit = props.type == "submit" ? "submit" : undefined;
 
-  const size = props.size == "sm" ? "px-2 py-1 text-xs" : "px-4 py-2 text-md";
+  const size = props.size == "sm" ? "px-2 py-1" : "px-4 py-2";
+
+  const textSize = (props.textSize || props.size) == "sm" ? "text-sm" : "text-base";
 
   return (
     <button
@@ -33,7 +36,7 @@ function Button(props: {
       onClick={props.onClick}
       type={submit}
       disabled={disabled}
-      className={`${props.className} ${size} ${
+      className={`${props.className} ${size} ${textSize} ${
         (props.type == "submit" && submitStyle) ||
         (props.type == "disabled" && disabledStyle) ||
         (props.type == "danger" && dangerStyle) ||

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -27,8 +27,8 @@ function Button(props: {
   const submit = props.type == "submit" ? "submit" : undefined;
 
   const size = props.size == "sm" ? "px-2 py-1" : "px-4 py-2";
-
-  const textSize = (props.textSize || props.size) == "sm" ? "text-sm" : "text-base";
+  const textSize =
+    (props.textSize || props.size) == "sm" ? "text-sm" : "text-base";
 
   return (
     <button

--- a/frontend/src/routes/settings/connection/ConnectionSettings.tsx
+++ b/frontend/src/routes/settings/connection/ConnectionSettings.tsx
@@ -115,7 +115,8 @@ const ConnectionSettings = () => {
           {showAddConnectionModal && (
             <Modal setVisible={setShowAddConnectionModal}>
               <DatabaseConnectionForm
-                handleCreateConnection={handleCreateConnection}
+                createConnection={createConnection}
+                closeModal={() => setShowAddConnectionModal(false)}
               />
             </Modal>
           )}


### PR DESCRIPTION
### Summary

This pull request adds a test connection button and multi-create functionality for Postgres connections.

### Details

- **New Feature:** Added a `testConnection` endpoint to the `ConnectionController` that allows users to test the connection credentials of a Postgres database.
- **New Feature:** Added a `TestConnectionResult` data class to the `ConnectionService` to represent the result of a connection test.
- **New Feature:** Added a `TestConnectionResponse` data class to the `ConnectionController` to return the result of a connection test to the frontend.
- **New Feature:** Added a `testConnection` function to the `Executor` service to test the connection credentials of a Postgres database.
- **New Feature:** Added a `getAccessibleDatabasesPostgres` function to the `Executor` service to retrieve a list of accessible databases for a given Postgres connection.
- **New Feature:** Added a `testConnection` function to the `DataSourceApi` service in the frontend to handle the connection test request.
- **New Feature:** Added a `TestConnectionResponse` type to the `DataSourceApi` service in the frontend to represent the response from the connection test.
- **Refactoring:** Updated the `ConnectionService` to use the `Executor` service for connection testing.
- **Refactoring:** Updated the `Executor` service to include a `testCredentials` function to test the connection credentials of a database.
- **Refactoring:** Updated the `ConnectionController` to use the `TestConnectionResponse` data class to return the result of a connection test to the frontend.
- **Refactoring:** Updated the `ConnectionSettings` component in the frontend to include a test connection button and to handle the connection test response.


> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

