### PR TITLE
Add lazy initialization to default config

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 logging.level.org.hibernate.SQL=DEBUG
 #logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 spring.session.store-type=jdbc
+spring.main.lazy-initialization=true
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.session.jdbc.initialize-schema=ALWAYS
 logging.level.org.springframework.security=DEBUG


### PR DESCRIPTION
This seems to for some reason fix the OIDC problem, although I don't fully understand why yet. There basically has to be a race condition somewhere during initialization, but I couldn't find it yet.

Spring security also makes it hard to find this, because it continues to swallow exceptions even with log level trace on. Simply redirecting to a non existant error page instead. The course of action here would be:
-> Fix this error behaviour and get the actual exception (what bean is missing where and when)
-> Then try disable the lazy loading
-> Figure out what configuration is in the wrong order and fix it

For now I'll prioritize some MongoDB cleanup and documentation for the upcoming 0.5 release though.