### PR TITLE
Use /bin/bash instead of /bin/sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ COPY --chown=nginx:nginx --chmod=755 ./run.sh .
 
 EXPOSE 8080
 
-CMD ["/usr/bin/sh", "./run.sh"]
+CMD ["/usr/bin/bash", "./run.sh"]


### PR DESCRIPTION
wait -n does not seem to be supported in sh in some environments