### PR TITLE
Extending functionality of the LiveSession experimental feature to en…

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/LiveSession.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/LiveSession.kt
@@ -2,12 +2,7 @@ package dev.kviklet.kviklet.service.dto
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
-import dev.kviklet.kviklet.security.Permission
-import dev.kviklet.kviklet.security.PolicyGrantedAuthority
-import dev.kviklet.kviklet.security.Resource
-import dev.kviklet.kviklet.security.SecuredDomainId
-import dev.kviklet.kviklet.security.SecuredDomainObject
-import dev.kviklet.kviklet.security.UserDetailsWithId
+import dev.kviklet.kviklet.security.*
 import java.io.Serializable
 
 data class LiveSession(

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/websocket/SessionService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/websocket/SessionService.kt
@@ -44,7 +44,7 @@ class SessionService(
         )
     }
 
-    @Policy(Permission.EXECUTION_REQUEST_EXECUTE)
+    @Policy(Permission.EXECUTION_REQUEST_EDIT)
     fun updateContent(sessionId: LiveSessionId, consoleContent: String): LiveSession =
         sessionAdapter.updateLiveSession(sessionId, consoleContent)
 

--- a/backend/src/main/resources/changelog/000-changelog.yaml
+++ b/backend/src/main/resources/changelog/000-changelog.yaml
@@ -71,3 +71,6 @@ databaseChangeLog:
   - include:
       file: 025-add-live-session-table.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 026-add-reviewer-to-execution-request.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/changelog/026-add-reviewer-to-execution-request.yaml
+++ b/backend/src/main/resources/changelog/026-add-reviewer-to-execution-request.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 026-add-reviewer-to-execution-request
+      author: David
+      changes:
+        - addColumn:
+            tableName: execution_request
+            columns:
+              - column:
+                  name: reviewer_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk_live_session_reviewer
+                    references: user(id)

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/executor/MysqlJDBCExecutorTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/executor/MysqlJDBCExecutorTest.kt
@@ -27,7 +27,7 @@ class MysqlJDBCExecutorTest(@Autowired override val JDBCExecutorService: JDBCExe
             .withDatabaseName("")
 
         init {
-            db.start()
+            db.start()/**/
         }
     }
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/helper/ExecutionRequestFactory.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/helper/ExecutionRequestFactory.kt
@@ -133,6 +133,7 @@ class ExecutionRequestFactory : Factory() {
         createdAt,
         author ?: userFactory.createUser(),
         temporaryAccessDuration,
+        null
     )
 }
 


### PR DESCRIPTION
Extending functionality of the LiveSession experimental feature to enforce 4 eyes behaviour. Added reviewer to ExecutionRequest.kt and set it when approving a LiveSession Access, the reviewer is then the only user that can run commands in that session, while the author is the only one that can write