### PR TITLE
Indentation of "externalSecretName" is wrong

### DIFF
--- a/charts/kviklet/values.yaml
+++ b/charts/kviklet/values.yaml
@@ -21,9 +21,9 @@ config:
       userOu: "people"
       searchBase: "ou=people"
 
-  # Name of the secret containing the kviklets configuration
-  # See README.md or the demo deployment for examples
-  externalSecretName: "kviklet-secret"
+# Name of the secret containing the kviklets configuration
+# See README.md or the demo deployment for examples
+externalSecretName: "kviklet-secret"
 
 # Application deployment configuration
 image:


### PR DESCRIPTION
The indentation of the external secret is wrong, because it has to be indented otherwise it wont work and will give following error if you want to install it with helm:

```
helm install kviklet-github-issue -n kviklet --create-namespace .     

Error: INSTALLATION FAILED: 1 error occurred:
        * Deployment.apps "kviklet-github-issue" is invalid: spec.template.spec.containers[0].envFrom[0].secretRef.name: Required value
```