### PR TITLE
Allow users to disable temp access by connection

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConnectionController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConnectionController.kt
@@ -87,7 +87,7 @@ data class CreateDatasourceConnectionRequest(
     val additionalJDBCOptions: String = "",
     val dumpsEnabled: Boolean = false,
     val authenticationType: AuthenticationType = AuthenticationType.USER_PASSWORD,
-
+    val temporaryAccessEnabled: Boolean = true,
 ) : ConnectionRequest()
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "connectionType")
@@ -132,6 +132,8 @@ data class UpdateDatasourceConnectionRequest(
     val authenticationType: AuthenticationType? = null,
 
     val dumpsEnabled: Boolean? = null,
+
+    val temporaryAccessEnabled: Boolean? = null,
 ) : UpdateConnectionRequest()
 
 data class UpdateKubernetesConnectionRequest(
@@ -179,6 +181,7 @@ data class DatasourceConnectionResponse(
     val reviewConfig: ReviewConfigResponse,
     val additionalJDBCOptions: String,
     val dumpsEnabled: Boolean,
+    val temporaryAccessEnabled: Boolean,
 ) : ConnectionResponse(ConnectionType.DATASOURCE) {
     companion object {
         fun fromDto(datasourceConnection: DatasourceConnection) = DatasourceConnectionResponse(
@@ -198,6 +201,7 @@ data class DatasourceConnectionResponse(
             ),
             additionalJDBCOptions = datasourceConnection.additionalOptions,
             dumpsEnabled = datasourceConnection.dumpsEnabled,
+            temporaryAccessEnabled = datasourceConnection.temporaryAccessEnabled,
         )
     }
 }
@@ -263,6 +267,7 @@ class ConnectionController(val connectionService: ConnectionService) {
             additionalJDBCOptions = request.additionalJDBCOptions,
             maxExecutions = request.maxExecutions,
             dumpsEnabled = request.dumpsEnabled,
+            temporaryAccessEnabled = request.temporaryAccessEnabled,
         )
 
     private fun testDatabaseConnection(request: CreateDatasourceConnectionRequest): TestConnectionResult =
@@ -282,6 +287,7 @@ class ConnectionController(val connectionService: ConnectionService) {
             maxExecutions = request.maxExecutions,
             dumpsEnabled = request.dumpsEnabled,
             authenticationType = request.authenticationType,
+            temporaryAccessEnabled = request.temporaryAccessEnabled,
         )
 
     private fun createKubernetesConnection(request: CreateKubernetesConnectionRequest): Connection =

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/Connection.kt
@@ -75,6 +75,7 @@ class ConnectionEntity(
     @Column(name = "additional_jdbc_options")
     var additionalJDBCOptions: String? = null,
     var dumpsEnabled: Boolean = false,
+    var temporaryAccessEnabled: Boolean = true,
 ) {
 
     override fun toString(): String = ToStringBuilder(this, SHORT_PREFIX_STYLE)
@@ -178,6 +179,7 @@ class ConnectionAdapter(
         protocol: DatabaseProtocol,
         additionalJDBCOptions: String,
         dumpsEnabled: Boolean,
+        temporaryAccessEnabled: Boolean,
     ): Connection = decryptCredentialsIfNeeded(
         save(
             ConnectionEntity(
@@ -198,6 +200,7 @@ class ConnectionAdapter(
                 connectionType = ConnectionType.DATASOURCE,
                 additionalJDBCOptions = additionalJDBCOptions,
                 dumpsEnabled = dumpsEnabled,
+                temporaryAccessEnabled = temporaryAccessEnabled,
             ),
         ),
     )
@@ -217,6 +220,7 @@ class ConnectionAdapter(
         reviewConfig: ReviewConfig,
         additionalJDBCOptions: String,
         dumpsEnabled: Boolean,
+        temporaryAccessEnabled: Boolean,
     ): Connection {
         val datasourceConnection = connectionRepository.findByIdOrNull(id.toString())
             ?: throw EntityNotFound(
@@ -244,6 +248,7 @@ class ConnectionAdapter(
         datasourceConnection.additionalJDBCOptions = additionalJDBCOptions
         datasourceConnection.isEncrypted = false
         datasourceConnection.dumpsEnabled = dumpsEnabled
+        datasourceConnection.temporaryAccessEnabled = temporaryAccessEnabled
 
         return decryptCredentialsIfNeeded(save(datasourceConnection))
     }
@@ -328,6 +333,7 @@ class ConnectionAdapter(
                 protocol = connection.protocol ?: connection.datasourceType!!.toProtocol(),
                 additionalOptions = connection.additionalJDBCOptions ?: "",
                 dumpsEnabled = connection.dumpsEnabled,
+                temporaryAccessEnabled = connection.temporaryAccessEnabled,
             )
         ConnectionType.KUBERNETES ->
             KubernetesConnection(

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ConnectionService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ConnectionService.kt
@@ -64,6 +64,7 @@ class ConnectionService(
             } ?: connection.reviewConfig,
             request.additionalJDBCOptions ?: connection.additionalOptions,
             dumpsEnabled = request.dumpsEnabled ?: connection.dumpsEnabled,
+            temporaryAccessEnabled = request.temporaryAccessEnabled ?: connection.temporaryAccessEnabled,
         )
     }
 
@@ -153,6 +154,7 @@ class ConnectionService(
         protocol: DatabaseProtocol,
         additionalJDBCOptions: String,
         dumpsEnabled: Boolean,
+        temporaryAccessEnabled: Boolean = true,
     ): Connection {
         if (authenticationType == AuthenticationType.USER_PASSWORD && password == null) {
             throw IllegalArgumentException("Password is required for USER_PASSWORD authentication")
@@ -175,6 +177,7 @@ class ConnectionService(
             protocol,
             additionalJDBCOptions,
             dumpsEnabled,
+            temporaryAccessEnabled,
         )
     }
 
@@ -195,6 +198,7 @@ class ConnectionService(
         additionalJDBCOptions: String,
         dumpsEnabled: Boolean,
         authenticationType: AuthenticationType,
+        temporaryAccessEnabled: Boolean,
     ): TestConnectionResult {
         val connection = DatasourceConnection(
             connectionId,
@@ -214,6 +218,7 @@ class ConnectionService(
             protocol,
             additionalJDBCOptions,
             dumpsEnabled,
+            temporaryAccessEnabled,
         )
         val accessibleDatabases = mutableListOf<String>()
         if (!databaseName.isNullOrBlank()) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -101,7 +101,12 @@ class ExecutionRequestService(
         }
         if (request.type == RequestType.Dump) {
             if (!connection.dumpsEnabled) {
-                throw RuntimeException("Dumps are not enabled for this connection")
+                throw IllegalStateException("Dumps are not enabled for this connection")
+            }
+        }
+        if (request.type == RequestType.TemporaryAccess) {
+            if (!connection.temporaryAccessEnabled) {
+                throw IllegalStateException("Temporary access is not enabled for this connection")
             }
         }
         return executionRequestAdapter.createExecutionRequest(

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/Connection.kt
@@ -88,6 +88,7 @@ data class DatasourceConnection(
     val protocol: DatabaseProtocol,
     val additionalOptions: String,
     val dumpsEnabled: Boolean,
+    val temporaryAccessEnabled: Boolean,
 ) : Connection(id, displayName, description, reviewConfig, maxExecutions) {
     fun getConnectionString(): String = when (auth) {
         is AuthenticationDetails.UserPassword -> when (type) {

--- a/backend/src/main/resources/changelog/000-changelog.yaml
+++ b/backend/src/main/resources/changelog/000-changelog.yaml
@@ -1,7 +1,7 @@
 databaseChangeLog:
   - include:
-     file: 001-initial.yaml
-     relativeToChangelogFile: true
+      file: 001-initial.yaml
+      relativeToChangelogFile: true
   - include:
       file: 002-add-database-name.yaml
       relativeToChangelogFile: true
@@ -70,4 +70,7 @@ databaseChangeLog:
       relativeToChangelogFile: true
   - include:
       file: 025-add-live-session-table.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: 026-add-temporary-access-enabled-column.yaml
       relativeToChangelogFile: true

--- a/backend/src/main/resources/changelog/026-add-temporary-access-enabled-column.yaml
+++ b/backend/src/main/resources/changelog/026-add-temporary-access-enabled-column.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 026-add-temporary-access-enabled-column
+      author: jascha
+      changes:
+        - addColumn:
+            tableName: connection
+            columns:
+              - column:
+                  name: temporary_access_enabled
+                  type: boolean
+                  defaultValue: true
+                  constraints:
+                    nullable: false

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ConnectionEncryptionTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ConnectionEncryptionTest.kt
@@ -74,6 +74,7 @@ class ConnectionEncryptionTest(
         protocol = protocol,
         additionalJDBCOptions = "",
         dumpsEnabled = false,
+        temporaryAccessEnabled = true,
     ) as DatasourceConnection
 
     @Test
@@ -183,6 +184,7 @@ class ConnectionEncryptionTest(
             reviewConfig = ReviewConfig(numTotalRequired = 1),
             additionalJDBCOptions = "",
             dumpsEnabled = false,
+            temporaryAccessEnabled = true,
         )
 
         val updatedStoredConnection = connectionRepository.findById(connection.id.toString()).get()

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ConnectionTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ConnectionTest.kt
@@ -297,4 +297,109 @@ class ConnectionTest(
         editedConnection.username shouldBe "postgres"
         editedConnection.displayName shouldBe "Postgres Connection"
     }
+
+    @Test
+    fun `test temporary access flag`() {
+        // Create a connection with temporary access disabled
+        val connection = datasourceConnectionController.createConnection(
+            CreateDatasourceConnectionRequest(
+                id = "temp-access-conn",
+                displayName = "Temp Access Test Connection",
+                username = "root",
+                password = "root",
+                reviewConfig = ReviewConfigRequest(
+                    numTotalRequired = 1,
+                ),
+                type = DatasourceType.MYSQL,
+                hostname = "localhost",
+                port = 3306,
+                temporaryAccessEnabled = false,
+            ),
+        ) as DatasourceConnectionResponse
+
+        // Verify the flag is false in the created connection
+        connection.temporaryAccessEnabled shouldBe false
+
+        // Get the connection and verify the flag is still false
+        val retrievedConnection = datasourceConnectionController.getConnection(
+            "temp-access-conn",
+        ) as DatasourceConnectionResponse
+        retrievedConnection.temporaryAccessEnabled shouldBe false
+
+        // Update the connection to enable temporary access
+        val updatedConnection = datasourceConnectionController.updateConnection(
+            "temp-access-conn",
+            UpdateDatasourceConnectionRequest(
+                temporaryAccessEnabled = true,
+            ),
+        ) as DatasourceConnectionResponse
+
+        // Verify the flag is now true
+        updatedConnection.temporaryAccessEnabled shouldBe true
+
+        // Get all connections and verify the flag is correct
+        val allConnections = datasourceConnectionController.getDatasourceConnections()
+        val ourConnection = allConnections.find {
+            (it as DatasourceConnectionResponse).id.toString() ==
+                "temp-access-conn"
+        } as DatasourceConnectionResponse
+        ourConnection.temporaryAccessEnabled shouldBe true
+    }
+
+    @Test
+    fun `test temporary access execution requests are not allowed on connections with temporary access disabled`() {
+        // Create a connection with temporary access disabled
+        val connection = datasourceConnectionController.createConnection(
+            CreateDatasourceConnectionRequest(
+                id = "temp-access-conn",
+                displayName = "Temp Access Test Connection",
+                username = "root",
+                password = "root",
+                reviewConfig = ReviewConfigRequest(
+                    numTotalRequired = 1,
+                ),
+                type = DatasourceType.MYSQL,
+                hostname = "localhost",
+                port = 3306,
+                temporaryAccessEnabled = false,
+            ),
+        ) as DatasourceConnectionResponse
+
+        // Create a test user
+        val testUser = userHelper.createUser(listOf("*"))
+        val testUserDetails = UserDetailsWithId(
+            id = testUser.getId()!!,
+            email = testUser.email,
+            password = testUser.password,
+            authorities = emptyList(),
+        )
+
+        // Attempt to create a temporary access execution request
+        val exception = org.junit.jupiter.api.assertThrows<IllegalStateException> {
+            executionRequestController.create(
+                CreateDatasourceExecutionRequestRequest(
+                    connectionId = ConnectionId("temp-access-conn"),
+                    title = "Test Temporary Access",
+                    description = "This should fail",
+                    statement = "SELECT 1",
+                    type = RequestType.TemporaryAccess,
+                ),
+                userDetails = testUserDetails,
+            )
+        }
+
+        exception.message shouldBe "Temporary access is not enabled for this connection"
+
+        // Try to create a normal execution request
+        executionRequestController.create(
+            CreateDatasourceExecutionRequestRequest(
+                connectionId = ConnectionId("temp-access-conn"),
+                title = "Test Normal Execution",
+                description = "This should succeed",
+                statement = "SELECT 1",
+                type = RequestType.SingleExecution,
+            ),
+            userDetails = testUserDetails,
+        )
+    }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/NotificationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/NotificationTest.kt
@@ -96,13 +96,13 @@ class NotificationTest {
             ReviewConfig(
                 numTotalRequired = 1,
             ),
-
             3306,
             "postgres",
             DatasourceType.POSTGRESQL,
             DatabaseProtocol.POSTGRESQL,
             additionalJDBCOptions = "",
             dumpsEnabled = false,
+            temporaryAccessEnabled = true,
         )
         userHelper.createUser(permissions = listOf("*"))
         val cookie = userHelper.login(mockMvc = mockMvc)

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/executor/MysqlIAMAuthExecutorTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/executor/MysqlIAMAuthExecutorTest.kt
@@ -68,6 +68,7 @@ class MysqlIAMAuthExecutorTest(
             protocol = DatabaseProtocol.MYSQL,
             additionalOptions = "",
             dumpsEnabled = false,
+            temporaryAccessEnabled = true,
         )
 
         val result = executeQueryWithIam(connection.getConnectionString(), "SELECT 1 as col1, '2' as col2")

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/executor/PostgresIAMAuthExecutorTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/executor/PostgresIAMAuthExecutorTest.kt
@@ -67,6 +67,7 @@ class PostgresIAMAuthExecutorTest(
             protocol = DatabaseProtocol.POSTGRESQL,
             additionalOptions = "",
             dumpsEnabled = false,
+            temporaryAccessEnabled = true,
         )
 
         val result = executeQueryWithIam(connection.getConnectionString(), "SELECT 1 as col1, '2' as col2")

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/helper/ExecutionRequestFactory.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/helper/ExecutionRequestFactory.kt
@@ -154,6 +154,7 @@ class ConnectionFactory : Factory() {
         protocol: DatabaseProtocol = DatabaseProtocol.MYSQL,
         additionalJDBCOptions: String = "",
         dumpEnabled: Boolean = false,
+        temporaryAccessEnabled: Boolean = false,
     ): DatasourceConnection = DatasourceConnection(
         id,
         displayName,
@@ -169,6 +170,7 @@ class ConnectionFactory : Factory() {
         protocol,
         additionalJDBCOptions,
         dumpEnabled,
+        temporaryAccessEnabled,
     )
 }
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/helper/Helpers.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/helper/Helpers.kt
@@ -187,6 +187,7 @@ class ConnectionHelper(private val connectionAdapter: ConnectionAdapter) {
         DatabaseProtocol.POSTGRESQL,
         additionalJDBCOptions = "",
         dumpsEnabled = false,
+        temporaryAccessEnabled = true,
     )
 
     @Transactional
@@ -203,13 +204,13 @@ class ConnectionHelper(private val connectionAdapter: ConnectionAdapter) {
             ReviewConfig(
                 numTotalRequired = 1,
             ),
-
             container.getMappedPort(5432),
             container.host,
             DatasourceType.POSTGRESQL,
             DatabaseProtocol.POSTGRESQL,
             additionalJDBCOptions = "",
             dumpsEnabled = false,
+            temporaryAccessEnabled = true,
         )
 
     @Transactional
@@ -232,6 +233,7 @@ class ConnectionHelper(private val connectionAdapter: ConnectionAdapter) {
             DatabaseProtocol.MONGODB,
             additionalJDBCOptions = "",
             dumpsEnabled = false,
+            temporaryAccessEnabled = true,
         )
 
     @Transactional

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,18 +25,18 @@ services:
     volumes:
       - ./kviklet-postgres-data:/var/lib/postgresql/data
 
-  kviklet:
-    image: ghcr.io/kviklet/kviklet:main
-    ports:
-      - "80:8080"
-    environment:
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://kviklet-postgres:5432/kviklet
-      - SPRING_DATASOURCE_USERNAME=postgres
-      - SPRING_DATASOURCE_PASSWORD=postgres
-      - INITIAL_USER_EMAIL=admin@admin.com
-      - INITIAL_USER_PASSWORD=admin
-    depends_on:
-      - kviklet-postgres
+  #kviklet:
+  #  image: ghcr.io/kviklet/kviklet:main
+  #  ports:
+  #    - "80:8080"
+  #  environment:
+  #    - SPRING_DATASOURCE_URL=jdbc:postgresql://kviklet-postgres:5432/kviklet
+  #    - SPRING_DATASOURCE_USERNAME=postgres
+  #    - SPRING_DATASOURCE_PASSWORD=postgres
+  #    - INITIAL_USER_EMAIL=admin@admin.com
+  #    - INITIAL_USER_PASSWORD=admin
+  #  depends_on:
+  #    - kviklet-postgres
 
   #mongodb:
   #  image: mongo:jammy
@@ -78,19 +78,19 @@ services:
   #  volumes:
   #    - ./mssql-data:/var/opt/mssql
 
-  # ldap:
-  #   image: osixia/openldap:1.1.8
-  #   ports:
-  #     - "389:389"
-  #   environment:
-  #     - LDAP_ORGANISATION=Kviklet
-  #     - LDAP_DOMAIN=kviklet.dev
-  #     - LDAP_ADMIN_PASSWORD=admin
-  #     - LDAP_CONFIG_PASSWORD=config
-  # ldapmyadmin:
-  #   image: osixia/phpldapadmin:0.9.0
-  #   ports:
-  #     - "80:80"
-  #   environment:
-  #     - PHPLDAPADMIN_LDAP_HOSTS=ldap
-  #     - PHPLDAPADMIN_HTTPS=false
+  ldap:
+    image: osixia/openldap:1.1.8
+    ports:
+      - "389:389"
+    environment:
+      - LDAP_ORGANISATION=Kviklet
+      - LDAP_DOMAIN=kviklet.dev
+      - LDAP_ADMIN_PASSWORD=admin
+      - LDAP_CONFIG_PASSWORD=config
+  ldapmyadmin:
+    image: osixia/phpldapadmin:0.9.0
+    ports:
+      - "80:80"
+    environment:
+      - PHPLDAPADMIN_LDAP_HOSTS=ldap
+      - PHPLDAPADMIN_HTTPS=false

--- a/freeipa_setup/docker-compose.yml
+++ b/freeipa_setup/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3"
+services:
+  freeipa:
+    image: freeipa/freeipa-server:almalinux-9
+    platform: linux/arm64
+    container_name: freeipa-server
+    hostname: ipa.example.test
+    environment:
+      - IPA_SERVER_HOSTNAME=ipa.example.test
+      - IPA_SERVER_IP=172.20.0.2
+      - DEBUG_TRACE=1
+      - DEBUG_NO_EXIT=1
+      - PASSWORD=Secret123
+    command:
+      - ipa-server-install
+      - -U
+      - --domain=example.test
+      - --realm=EXAMPLE.TEST
+      - --ds-password=directory_password
+      - --admin-password=admin_password
+      - --no-ntp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ipa-data:/data:Z
+    networks:
+      ipa_network:
+        ipv4_address: 172.20.0.2
+    privileged: true
+    dns:
+      - 172.20.0.2
+    dns_search:
+      - example.test
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
+
+networks:
+  ipa_network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/24
+
+volumes:
+  ipa-data:

--- a/frontend/src/api/DatasourceApi.tsx
+++ b/frontend/src/api/DatasourceApi.tsx
@@ -46,6 +46,7 @@ const databaseConnectionResponseSchema = withType(
     }),
     additionalJDBCOptions: z.string().optional(),
     dumpsEnabled: z.boolean(),
+    temporaryAccessEnabled: z.boolean(),
   }),
   "DATASOURCE",
 );

--- a/frontend/src/routes/NewRequest.tsx
+++ b/frontend/src/routes/NewRequest.tsx
@@ -258,6 +258,10 @@ export default function ConnectionChooser() {
                               connection._type === "DATASOURCE" &&
                               connection.dumpsEnabled
                             }
+                            temporaryAccessEnabled={
+                              connection._type === "DATASOURCE" &&
+                              connection.temporaryAccessEnabled
+                            }
                           ></Card>
                         );
                       })}
@@ -791,6 +795,7 @@ interface CardProps {
   clickSQLDump: () => void;
   connectionType: "DATASOURCE" | "KUBERNETES";
   sqlDumpEnabled: boolean;
+  temporaryAccessEnabled: boolean;
 }
 
 const Card = (props: CardProps) => {
@@ -836,21 +841,22 @@ const Card = (props: CardProps) => {
               {props.connectionType === "DATASOURCE" ? "Query" : "Command"}
             </button>
           </div>
-          {props.connectionType === "DATASOURCE" && (
-            <div className="-ml-px flex w-0 flex-1">
-              <button
-                onClick={props.clickAccess}
-                className="relative inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-br-lg border border-transparent py-4 text-sm font-semibold text-slate-900 hover:bg-slate-100 dark:text-slate-50 dark:hover:bg-slate-800"
-                data-testid={`access-button-${props.header}`}
-              >
-                <CommandLineIcon
-                  className="h-5 w-5 text-slate-400 dark:text-slate-500"
-                  aria-hidden="true"
-                />
-                Access
-              </button>
-            </div>
-          )}
+          {props.connectionType === "DATASOURCE" &&
+            props.temporaryAccessEnabled && (
+              <div className="-ml-px flex w-0 flex-1">
+                <button
+                  onClick={props.clickAccess}
+                  className="relative inline-flex w-0 flex-1 items-center justify-center gap-x-3 rounded-br-lg border border-transparent py-4 text-sm font-semibold text-slate-900 hover:bg-slate-100 dark:text-slate-50 dark:hover:bg-slate-800"
+                  data-testid={`access-button-${props.header}`}
+                >
+                  <CommandLineIcon
+                    className="h-5 w-5 text-slate-400 dark:text-slate-500"
+                    aria-hidden="true"
+                  />
+                  Access
+                </button>
+              </div>
+            )}
           {props.connectionType === "DATASOURCE" && props.sqlDumpEnabled && (
             <div className="-ml-px flex w-0 flex-1">
               <button

--- a/frontend/src/routes/settings/connection/DatabaseConnectionForm.tsx
+++ b/frontend/src/routes/settings/connection/DatabaseConnectionForm.tsx
@@ -48,6 +48,7 @@ const baseConnectionSchema = z.object({
   additionalJDBCOptions: z.string(),
   maxExecutions: z.coerce.number().nullable(),
   dumpsEnabled: z.boolean(),
+  temporaryAccessEnabled: z.boolean().default(true),
   connectionType: z.literal("DATASOURCE").default("DATASOURCE"),
 });
 
@@ -165,6 +166,7 @@ export default function DatabaseConnectionForm(props: {
     setValue("authenticationType", "USER_PASSWORD");
     setValue("maxExecutions", 1);
     setValue("dumpsEnabled", false);
+    setValue("temporaryAccessEnabled", true);
   }, []);
 
   const updatePortIfNotTouched = (port: number) => {
@@ -379,7 +381,7 @@ export default function DatabaseConnectionForm(props: {
                             htmlFor="dumpsEnabled"
                             className="my-auto mr-auto flex items-center text-sm font-medium text-slate-700 dark:text-slate-200"
                           >
-                            Dumps Enabled
+                            Enable Dumps
                           </label>
                           <input
                             type="checkbox"
@@ -388,6 +390,19 @@ export default function DatabaseConnectionForm(props: {
                           />
                         </div>
                       )}
+                      <div className="flex w-full justify-between">
+                        <label
+                          htmlFor="temporaryAccessEnabled"
+                          className="my-auto mr-auto flex items-center text-sm font-medium text-slate-700 dark:text-slate-200"
+                        >
+                          Enable Temporary Access
+                        </label>
+                        <input
+                          type="checkbox"
+                          className="my-auto h-4 w-4"
+                          {...register("temporaryAccessEnabled")}
+                        />
+                      </div>
                       <TestingConnectionFragment
                         handleSubmit={handleSubmit}
                         type={watchType}

--- a/frontend/src/routes/settings/connection/details/UpdateDatasourceConnectionForm.tsx
+++ b/frontend/src/routes/settings/connection/details/UpdateDatasourceConnectionForm.tsx
@@ -38,6 +38,7 @@ const baseConnectionFormSchema = z.object({
   }),
   additionalJDBCOptions: z.string(),
   dumpsEnabled: z.boolean(),
+  temporaryAccessEnabled: z.boolean(),
   connectionType: z.literal("DATASOURCE").default("DATASOURCE"),
 });
 
@@ -122,6 +123,7 @@ export default function UpdateDatasourceConnectionForm({
       connectionType: "DATASOURCE",
       authenticationType: connection.authenticationType,
       dumpsEnabled: connection.dumpsEnabled,
+      temporaryAccessEnabled: connection.temporaryAccessEnabled,
     },
     schema: connectionFormSchema,
     onSubmit: editConnection,
@@ -293,6 +295,19 @@ export default function UpdateDatasourceConnectionForm({
                           type="checkbox"
                           className="my-auto h-4 w-4"
                           {...register("dumpsEnabled")}
+                        />
+                      </div>
+                      <div className="flex w-full justify-between">
+                        <label
+                          htmlFor="temporaryAccessEnabled"
+                          className="my-auto mr-auto text-sm font-medium text-slate-700 dark:text-slate-200"
+                        >
+                          Temporary Access Enabled
+                        </label>
+                        <input
+                          type="checkbox"
+                          className="my-auto h-4 w-4"
+                          {...register("temporaryAccessEnabled")}
                         />
                       </div>
                     </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for enabling/disabling temporary access per datasource connection, with backend, frontend, and database schema updates.
> 
>   - **Backend**:
>     - Add `temporaryAccessEnabled` boolean field to `CreateDatasourceConnectionRequest`, `UpdateDatasourceConnectionRequest`, and `DatasourceConnectionResponse` in `ConnectionController.kt`.
>     - Update `ConnectionEntity` and `ConnectionAdapter` in `Connection.kt` to handle `temporaryAccessEnabled`.
>     - Modify `ConnectionService.kt` to include `temporaryAccessEnabled` in connection creation and update logic.
>     - Update `ExecutionRequestService.kt` to check `temporaryAccessEnabled` before allowing temporary access requests.
>     - Add Liquibase changelog `026-add-temporary-access-enabled-column.yaml` to add `temporary_access_enabled` column to the database.
>   - **Frontend**:
>     - Update `DatasourceApi.tsx` to include `temporaryAccessEnabled` in API schema.
>     - Modify `NewRequest.tsx` to conditionally enable temporary access options based on `temporaryAccessEnabled`.
>     - Update `DatabaseConnectionForm.tsx` and `UpdateDatasourceConnectionForm.tsx` to include a checkbox for `temporaryAccessEnabled`.
>   - **Tests**:
>     - Add tests in `ConnectionTest.kt` to verify behavior of `temporaryAccessEnabled`.
>     - Update various test files to include `temporaryAccessEnabled` in connection setup and assertions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for c536449ed37e3185497aa17419f1c3d0e27db219. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->