### PR TITLE
Ensure password is not accidentally reset when not edited

### DIFF
--- a/frontend/src/api/DatasourceApi.tsx
+++ b/frontend/src/api/DatasourceApi.tsx
@@ -117,13 +117,12 @@ type AllNullableExcept<T, K extends keyof T> = {
   [P in keyof T]: P extends K ? T[P] : T[P] | undefined;
 };
 
-type PatchDatabaseConnectionPayload = Omit<
-  AllNullableExcept<
-    DatabaseConnection,
-    "connectionType" | "authenticationType"
-  >,
-  "id"
->;
+// Use a distributive conditional type to preserve the union structure
+type PatchDatabaseConnectionPayload = DatabaseConnection extends infer T
+  ? T extends DatabaseConnection
+    ? Omit<AllNullableExcept<T, "connectionType" | "authenticationType">, "id">
+    : never
+  : never;
 
 type PatchKubernetesConnectionPayload = Omit<
   AllNullableExcept<KubernetesConnection, "connectionType">,

--- a/frontend/src/hooks/connections.ts
+++ b/frontend/src/hooks/connections.ts
@@ -49,34 +49,10 @@ const useConnections = () => {
     }
   };
 
-  const editConnection = async (
-    connectionId: string,
-    connection: PatchConnectionPayload,
-  ) => {
-    const response = await patchConnection(connection, connectionId);
-    if (isApiErrorResponse(response)) {
-      addNotification({
-        title: "Failed to edit connection",
-        text: response.message,
-        type: "error",
-      });
-      return;
-    } else {
-      const newConnections = connections.map((connection) => {
-        if (connection.id === response.id) {
-          return response;
-        }
-        return connection;
-      });
-      setConnections(newConnections);
-    }
-  };
-
   return {
     loading,
     connections,
     createConnection,
-    editConnection,
   };
 };
 
@@ -110,6 +86,14 @@ const useConnection = (id: string) => {
       return;
     }
     setLoading(true);
+    if (
+      patchedConnection.connectionType === "DATASOURCE" &&
+      patchedConnection.authenticationType === "USER_PASSWORD" &&
+      patchedConnection.password === ""
+    ) {
+      // ensure that the password is not updated if the user didn't provide a new one
+      patchedConnection.password = undefined;
+    }
     const response = await patchConnection(patchedConnection, connection.id);
     if (isApiErrorResponse(response)) {
       addNotification({

--- a/frontend/src/routes/settings/connection/ConnectionSettings.tsx
+++ b/frontend/src/routes/settings/connection/ConnectionSettings.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import {
   ConnectionPayload,
   ConnectionResponse,
-  PatchConnectionPayload,
 } from "../../../api/DatasourceApi";
 import Button from "../../../components/Button";
 import Modal from "../../../components/Modal";
@@ -41,10 +40,6 @@ function ConnectionSettingsList(props: {
   connections: ConnectionResponse[];
   addConnectionHandler: () => void;
   addKubnernetesConnectionHandler: () => void;
-  editConnectionHandler: (
-    connectionId: string,
-    connection: PatchConnectionPayload,
-  ) => Promise<void>;
 }) {
   return (
     <div className="flex max-h-[calc(100vh-theme(spacing.52))] w-full flex-col border-l pl-4 dark:border-slate-700  dark:bg-slate-950">
@@ -76,8 +71,7 @@ function ConnectionSettingsList(props: {
 }
 
 const ConnectionSettings = () => {
-  const { loading, connections, createConnection, editConnection } =
-    useConnections();
+  const { loading, connections, createConnection } = useConnections();
 
   const [showAddConnectionModal, setShowAddConnectionModal] =
     useState<boolean>(false);
@@ -104,9 +98,6 @@ const ConnectionSettings = () => {
               connections={connections}
               addConnectionHandler={() => {
                 setShowAddConnectionModal(true);
-              }}
-              editConnectionHandler={async (connectionId, connection) => {
-                await editConnection(connectionId, connection);
               }}
               addKubnernetesConnectionHandler={() => {
                 setShowAddKubernetesConnectionModal(true);

--- a/frontend/src/routes/settings/connection/details/UpdateDatasourceConnectionForm.tsx
+++ b/frontend/src/routes/settings/connection/details/UpdateDatasourceConnectionForm.tsx
@@ -420,7 +420,7 @@ const AuthSection = ({
           <InputField
             id="password"
             label="Password"
-            placeholder="Password"
+            placeholder="Unchanged"
             type="password"
             {...register("password")}
             error={(errors as FieldErrors<BasicAuthFormType>).password?.message}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes issue where password could be reset unintentionally by ensuring it's not updated if not provided during edit.
> 
>   - **Behavior**:
>     - Prevents accidental password reset by setting `patchedConnection.password` to `undefined` if empty in `editConnection()` in `connections.ts`.
>     - Updates password placeholder to "Unchanged" in `UpdateDatasourceConnectionForm.tsx`.
>   - **Type Definitions**:
>     - Modifies `PatchDatabaseConnectionPayload` in `DatasourceApi.tsx` to use a distributive conditional type.
>   - **Code Cleanup**:
>     - Removes unused `editConnection` function in `useConnections` in `connections.ts`.
>     - Removes `editConnectionHandler` prop in `ConnectionSettings.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 6e4c99defb4f5cfbd8cc187b25672034702b1a55. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->