### PR TITLE
Update chart values.yaml to refer to main image for now

### DIFF
--- a/charts/kviklet/values.yaml
+++ b/charts/kviklet/values.yaml
@@ -30,6 +30,7 @@ image:
   registry: ghcr.io
   repository: kviklet/kviklet
   pullPolicy: IfNotPresent
+  tag: main
 
 service:
   type: ClusterIP


### PR DESCRIPTION
The helm chart actually relies on the health endpoint which is only present in the latest releases and not app version 0.5.1. Whoopsies
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `charts/kviklet/values.yaml` to use `main` image tag for health endpoint availability.
> 
>   - **Behavior**:
>     - Update `tag` in `charts/kviklet/values.yaml` to `main` to ensure the health endpoint is available.
>   - **Reason**:
>     - The health endpoint is only present in the latest releases, not in version 0.5.1.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 0590617fb44a1609cb106e1fd5cd9950667a590d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->