### PR TITLE
Make csv download on error display error message and not retry

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/JDBCExecutor.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/JDBCExecutor.kt
@@ -159,7 +159,7 @@ class JDBCExecutor {
                     }
                 }
             } catch (e: SQLException) {
-                throw IllegalStateException("Error executing query", e)
+                throw IllegalStateException("Error executing query: ${e.message}", e)
             }
         }
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance CSV download error handling to display error messages and log errors in `ExecutionRequestService` and `ExecutionRequestController`.
> 
>   - **Behavior**:
>     - In `ExecutionRequestController.kt`, `downloadCsv()` now catches `IllegalStateException` and other exceptions, resets response, and writes error messages to the response stream.
>     - In `ExecutionRequestService.kt`, `streamResultsAsCsv()` logs errors using `eventService.addResultLogs()` when exceptions occur.
>   - **Error Handling**:
>     - `JDBCExecutor.kt` modifies error message in `IllegalStateException` to include SQL exception message.
>   - **Tests**:
>     - In `ExecutionTest.kt`, adds test `when downloading CSV with invalid query then return useful error` to verify error message is returned for invalid queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 4dfe54ee742e014b0f253e4d2b809ecf5af7499c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->