### PR TITLE
Reset execution and approval count on error

### DIFF
--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ErrorExecutionLimitTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ErrorExecutionLimitTest.kt
@@ -1,0 +1,163 @@
+package dev.kviklet.kviklet
+
+import dev.kviklet.kviklet.db.User
+import dev.kviklet.kviklet.helper.ConnectionHelper
+import dev.kviklet.kviklet.helper.ExecutionRequestHelper
+import dev.kviklet.kviklet.helper.RoleHelper
+import dev.kviklet.kviklet.helper.UserHelper
+import dev.kviklet.kviklet.service.dto.Connection
+import jakarta.servlet.http.Cookie
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+class ErrorExecutionLimitTest {
+
+    @Container
+    val postgres = PostgreSQLContainer(DockerImageName.parse("postgres:11.1"))
+        .withUsername("root")
+        .withPassword("root")
+        .withReuse(true)
+        .withDatabaseName("test_db")
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var connectionHelper: ConnectionHelper
+
+    @Autowired
+    private lateinit var userHelper: UserHelper
+
+    @Autowired
+    private lateinit var roleHelper: RoleHelper
+
+    @Autowired
+    private lateinit var executionRequestHelper: ExecutionRequestHelper
+
+    private lateinit var testConnection: Connection
+    private lateinit var testUser: User
+    private lateinit var testReviewer: User
+    private lateinit var userCookie: Cookie
+    private lateinit var reviewerCookie: Cookie
+
+    @BeforeEach
+    fun setUp() {
+        postgres.start()
+        testConnection = connectionHelper.createPostgresConnection(postgres, maxExecutions = 1)
+        testUser = userHelper.createUser(permissions = listOf("*"))
+        testReviewer = userHelper.createUser(permissions = listOf("*"))
+        userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+        reviewerCookie = userHelper.login(email = testReviewer.email, mockMvc = mockMvc)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        executionRequestHelper.deleteAll()
+        connectionHelper.deleteAll()
+        userHelper.deleteAll()
+        roleHelper.deleteAll()
+    }
+
+    @Test
+    fun `when execution errors it should not count toward the execution limit`() {
+        // Create an execution request with a failing query
+        val executionRequest = executionRequestHelper.createExecutionRequest(
+            author = testUser,
+            statement = "SELECT * FROM non_existent_table;",
+            connection = testConnection,
+        )
+
+        // Approve the request
+        approveRequest(executionRequest.getId(), "Approved", reviewerCookie)
+
+        // Execute the request (should fail but still allow retry)
+        executeErrorRequestAndAssert(executionRequest.getId(), userCookie)
+
+        // Verify the execution status is still EXECUTABLE
+        mockMvc.perform(
+            get("/execution-requests/${executionRequest.getId()}").cookie(userCookie),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.executionStatus").value("EXECUTABLE"))
+
+        // Update the execution request with a valid query
+        mockMvc.perform(
+            patch("/execution-requests/${executionRequest.getId()}")
+                .cookie(userCookie)
+                .content(
+                    """
+                    {
+                        "statement": "SELECT 1 AS value;"
+                    }
+                    """.trimIndent(),
+                )
+                .contentType("application/json"),
+        ).andExpect(status().isOk)
+
+        // Approve the request again
+        approveRequest(executionRequest.getId(), "Approved after fix", reviewerCookie)
+
+        // Execute the request (should succeed)
+        mockMvc.perform(
+            post("/execution-requests/${executionRequest.getId()}/execute")
+                .cookie(userCookie)
+                .contentType("application/json"),
+        ).andExpect(status().isOk)
+
+        // Verify the execution status is now EXECUTED
+        mockMvc.perform(
+            get("/execution-requests/${executionRequest.getId()}").cookie(userCookie),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.executionStatus").value("EXECUTED"))
+    }
+
+    private fun approveRequest(executionRequestId: String, comment: String, cookie: Cookie) = mockMvc.perform(
+        post("/execution-requests/$executionRequestId/reviews")
+            .cookie(cookie)
+            .content(
+                """
+                    {
+                        "action": "APPROVE",
+                        "comment": "$comment"
+                    }
+                """.trimIndent(),
+            )
+            .contentType("application/json"),
+    ).andExpect(status().isOk)
+
+    private fun executeErrorRequestAndAssert(executionRequestId: String, cookie: Cookie) {
+        mockMvc.perform(
+            post("/execution-requests/$executionRequestId/execute")
+                .cookie(cookie)
+                .contentType("application/json"),
+        ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.results[0].errorCode").value(0))
+            .andExpect(
+                jsonPath(
+                    "$.results[0].message",
+                ).value(containsString("relation \"non_existent_table\" does not exist")),
+            )
+            .andExpect(jsonPath("$.results[0].type").value("ERROR"))
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionRequestTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionRequestTest.kt
@@ -78,4 +78,21 @@ class ExecutionRequestTest {
         )
         assert(details.resolveReviewStatus() == ReviewStatus.CHANGE_REQUESTED)
     }
+
+    @Test
+    fun `test review status with approval and then execution error`() {
+        val request = executionRequestFactory.createDatasourceExecutionRequest()
+        val reviewer = userFactory.createUser()
+        val executor = userFactory.createUser()
+        val t3 = LocalDateTime.of(2021, 1, 3, 0, 0)
+        val events = mutableSetOf<Event>(
+            eventFactory.createReviewApprovedEvent(request = request, author = reviewer, createdAt = t1),
+            eventFactory.createExecuteEventWithError(request = request, author = executor, createdAt = t3),
+        )
+        val details = executionRequestDetailsFactory.createExecutionRequestDetails(
+            request = request,
+            events = events,
+        )
+        assert(details.resolveReviewStatus() == ReviewStatus.AWAITING_APPROVAL)
+    }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
@@ -640,8 +640,8 @@ class ExecutionTest {
         mockMvc.perform(
             get("/execution-requests/$executionRequestId").cookie(cookie),
         ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.executionStatus").value("EXECUTED"))
-            .andExpect(jsonPath("$.reviewStatus").value("APPROVED"))
+            .andExpect(jsonPath("$.executionStatus").value("EXECUTABLE"))
+            .andExpect(jsonPath("$.reviewStatus").value("AWAITING_APPROVAL"))
             .andExpect(jsonPath("$.events", hasSize<Collection<*>>(2)))
             .andExpect(jsonPath("$.events[0].type").value("REVIEW"))
             .andExpect(jsonPath("$.events[1].type").value("EXECUTE"))

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/MongoDBExecutionTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/MongoDBExecutionTest.kt
@@ -276,8 +276,8 @@ class MongoDBExecutionTest {
         mockMvc.perform(
             get("/execution-requests/$executionRequestId").cookie(cookie),
         ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.executionStatus").value("EXECUTED"))
-            .andExpect(jsonPath("$.reviewStatus").value("APPROVED"))
+            .andExpect(jsonPath("$.executionStatus").value("EXECUTABLE"))
+            .andExpect(jsonPath("$.reviewStatus").value("AWAITING_APPROVAL"))
             .andExpect(jsonPath("$.events", hasSize<Collection<*>>(2)))
             .andExpect(jsonPath("$.events[0].type").value("REVIEW"))
             .andExpect(jsonPath("$.events[1].type").value("EXECUTE"))

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/helper/ExecutionRequestFactory.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/helper/ExecutionRequestFactory.kt
@@ -10,14 +10,17 @@ import dev.kviklet.kviklet.service.dto.DatabaseProtocol
 import dev.kviklet.kviklet.service.dto.DatasourceConnection
 import dev.kviklet.kviklet.service.dto.DatasourceExecutionRequest
 import dev.kviklet.kviklet.service.dto.DatasourceType
+import dev.kviklet.kviklet.service.dto.ErrorResultLog
 import dev.kviklet.kviklet.service.dto.Event
 import dev.kviklet.kviklet.service.dto.EventId
+import dev.kviklet.kviklet.service.dto.ExecuteEvent
 import dev.kviklet.kviklet.service.dto.ExecutionRequest
 import dev.kviklet.kviklet.service.dto.ExecutionRequestDetails
 import dev.kviklet.kviklet.service.dto.ExecutionRequestId
 import dev.kviklet.kviklet.service.dto.Policy
 import dev.kviklet.kviklet.service.dto.PolicyEffect
 import dev.kviklet.kviklet.service.dto.RequestType
+import dev.kviklet.kviklet.service.dto.ResultLog
 import dev.kviklet.kviklet.service.dto.ReviewAction
 import dev.kviklet.kviklet.service.dto.ReviewEvent
 import dev.kviklet.kviklet.service.dto.Role
@@ -105,6 +108,38 @@ class EventFactory : Factory() {
         createdAt = createdAt,
         comment = comment,
         action = ReviewAction.REQUEST_CHANGE,
+    )
+
+    fun createExecuteEvent(
+        id: EventId = EventId("test-event " + nextId()),
+        request: ExecutionRequest? = null,
+        createdAt: LocalDateTime = utcTimeNow(),
+        author: User? = null,
+        query: String = "SELECT 1;",
+        results: List<ResultLog> = emptyList(),
+    ): ExecuteEvent = ExecuteEvent(
+        eventId = id,
+        request = request ?: executionRequestFactory.createDatasourceExecutionRequest(),
+        author = author ?: userFactory.createUser(),
+        createdAt = createdAt,
+        query = query,
+        results = results,
+    )
+
+    fun createExecuteEventWithError(
+        id: EventId = EventId("test-event " + nextId()),
+        request: ExecutionRequest? = null,
+        createdAt: LocalDateTime = utcTimeNow(),
+        author: User? = null,
+        query: String = "SELECT 1;",
+        errorMessage: String = "Execution failed",
+    ): ExecuteEvent = ExecuteEvent(
+        eventId = id,
+        request = request ?: executionRequestFactory.createDatasourceExecutionRequest(),
+        author = author ?: userFactory.createUser(),
+        createdAt = createdAt,
+        query = query,
+        results = listOf(ErrorResultLog(errorCode = 0, message = errorMessage)),
     )
 }
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/helper/Helpers.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/helper/Helpers.kt
@@ -198,13 +198,17 @@ class ConnectionHelper(private val connectionAdapter: ConnectionAdapter) {
     }
 
     @Transactional
-    fun createPostgresConnection(container: JdbcDatabaseContainer<*>, explainEnabled: Boolean = true): Connection {
+    fun createPostgresConnection(
+        container: JdbcDatabaseContainer<*>,
+        explainEnabled: Boolean = true,
+        maxExecutions: Int = 1,
+    ): Connection {
         val connection = connectionAdapter.createDatasourceConnection(
             ConnectionId("ds-conn-test-$connectionCount"),
             "Test Connection $connectionCount",
             AuthenticationType.USER_PASSWORD,
             container.databaseName,
-            1,
+            maxExecutions,
             container.username,
             container.password,
             "A test connection",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reset execution and approval counts on execution errors and update tests to verify this behavior.
> 
>   - **Behavior**:
>     - Reset execution and approval counts on execution errors in `ExecutionRequest.kt`.
>     - Modify `getApprovalCount()` to use `latestResetTimestamp()` for filtering reviews.
>     - Update `resolveExecutionStatus()` to exclude error executions from counting towards limits.
>   - **Functions**:
>     - Add `latestResetTimestamp()` in `ExecutionRequestDetails` to determine the latest reset time based on edits or execution errors.
>   - **Tests**:
>     - Add `ErrorExecutionLimitTest.kt` to verify execution errors do not count towards execution limits.
>     - Update `ExecutionRequestTest.kt` and `ExecutionTest.kt` to check review status and execution status after errors.
>     - Modify `MongoDBExecutionTest.kt` to handle execution errors gracefully.
>     - Extend `ExecutionRequestFactory.kt` with `createExecuteEventWithError()` for error simulation in tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 1b2b2b7dbcba242ebb11d899d2a2990b4763b2bd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->