### PR TITLE
Don't reset reviews on temporary access requests after failed statement

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
@@ -176,7 +176,10 @@ data class ExecutionRequestDetails(val request: ExecutionRequest, val events: Mu
 
     fun latestResetTimestamp(): LocalDateTime {
         val latestEdit = events.filter { it.type == EventType.EDIT }.sortedBy { it.createdAt }.lastOrNull()
-
+        val latestEditTimeStamp = latestEdit?.createdAt ?: LocalDateTime.MIN
+        if (request.type == RequestType.TemporaryAccess) {
+            return latestEditTimeStamp
+        }
         // Find the latest execution with error
         val latestExecutionError = events.filter { it.type == EventType.EXECUTE }
             .mapNotNull { it as? ExecuteEvent }
@@ -184,7 +187,6 @@ data class ExecutionRequestDetails(val request: ExecutionRequest, val events: Mu
             .maxByOrNull { it.createdAt }
 
         // Use the latest of either edit or execution error timestamp
-        val latestEditTimeStamp = latestEdit?.createdAt ?: LocalDateTime.MIN
         val latestErrorTimeStamp = latestExecutionError?.createdAt ?: LocalDateTime.MIN
         val latestResetTimeStamp = if (latestEditTimeStamp.isAfter(
                 latestErrorTimeStamp,

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/helper/Helpers.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/helper/Helpers.kt
@@ -286,7 +286,7 @@ class ExecutionRequestHelper(
     fun createExecutionRequest(
         dbcontainer: JdbcDatabaseContainer<*>? = null,
         author: User,
-        statement: String = "SELECT 1;",
+        statement: String? = "SELECT 1;",
         connection: Connection? = null,
         description: String = "A test execution request",
         requestType: RequestType = RequestType.SingleExecution,
@@ -295,7 +295,7 @@ class ExecutionRequestHelper(
         return executionRequestAdapter.createExecutionRequest(
             connectionId = requestConnection.id,
             title = "Test Execution",
-            type = RequestType.SingleExecution,
+            type = requestType,
             description = description,
             statement = statement,
             executionStatus = "PENDING",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent review reset for `TemporaryAccess` requests after failed statements and add tests to verify behavior.
> 
>   - **Behavior**:
>     - Modify `latestResetTimestamp()` in `ExecutionRequest.kt` to prevent resetting reviews for `TemporaryAccess` requests after a failed statement.
>     - Ensure `TemporaryAccess` requests maintain `ACTIVE` status after execution errors.
>   - **Tests**:
>     - Add test `temporary access request should not change status after a failed statement` in `ErrorExecutionLimitTest.kt` to verify behavior.
>   - **Helpers**:
>     - Update `createExecutionRequest()` in `Helpers.kt` to allow `statement` to be nullable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 19523f97c4be874173c2702da07f44747f2ca28d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->