### PR TITLE
Allow configuration of host url for notifications, ignore health check in url introspection

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ServerUrlInterceptor.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ServerUrlInterceptor.kt
@@ -19,6 +19,13 @@ class ServerUrlInterceptor : HandlerInterceptor {
         if (serverUrl == null) {
             synchronized(this) {
                 if (serverUrl == null) {
+                    val targetPath = request.servletPath
+                    if (targetPath.startsWith("/health")) {
+                        // Skip setting serverUrl for health check endpoint as this is not a user-facing URL
+                        // and likely wont contain the correct server URL.
+                        return true
+                    }
+
                     val scheme = request.scheme // http or https
                     val serverName = request.serverName // hostname or IP address
                     val serverPort = request.serverPort // port number

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/NotificationHandler.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/NotificationHandler.kt
@@ -8,6 +8,7 @@ import dev.kviklet.kviklet.service.dto.ReviewStatus
 import dev.kviklet.kviklet.service.notifications.SlackApiClient
 import dev.kviklet.kviklet.service.notifications.TeamsApiClient
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
@@ -20,6 +21,9 @@ class NotificationHandler(
     private val teamsClient: TeamsApiClient,
     private val slackClient: SlackApiClient,
 ) {
+
+    @Value("\${kviklet.server.baseUrl:#{null}}")
+    private var serverBaseUrl: String? = null
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -36,7 +40,7 @@ class NotificationHandler(
     @EventListener
     fun handleExecutionRequestCreated(event: RequestCreatedEvent) {
         try {
-            val host = ServerUrlInterceptor.getServerUrl()
+            val host = serverBaseUrl.takeIf { !it.isNullOrBlank() } ?: ServerUrlInterceptor.getServerUrl()
             if (event.necessaryReviews > 0) {
                 val message = Message(
                     title = "New Request: \"${event.title}\"",
@@ -54,7 +58,7 @@ class NotificationHandler(
     @EventListener
     fun handleReviewStatusUpdated(event: ReviewStatusUpdatedEvent) {
         try {
-            val host = ServerUrlInterceptor.getServerUrl()
+            val host = serverBaseUrl.takeIf { !it.isNullOrBlank() } ?: ServerUrlInterceptor.getServerUrl()
             if (event.status == ReviewStatus.AWAITING_APPROVAL) {
                 val message = Message(
                     title = "Review Status Updated",

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/NotificationHandler.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/NotificationHandler.kt
@@ -22,7 +22,7 @@ class NotificationHandler(
     private val slackClient: SlackApiClient,
 ) {
 
-    @Value("\${kviklet.server.baseUrl:#{null}}")
+    @Value("\${kviklet.baseUrl:#{null}}")
     private var serverBaseUrl: String? = null
 
     private val logger = LoggerFactory.getLogger(javaClass)

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/NotificationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/NotificationTest.kt
@@ -146,7 +146,7 @@ class NotificationTest {
     @Test
     fun `calls notification apis with configured base url`() {
         val baseUrl = "https://kviklet.example.com"
-        System.setProperty("kviklet.server.baseUrl", baseUrl)
+        System.setProperty("kviklet.baseUrl", baseUrl)
         try {
             val config = Configuration(
                 teamsUrl = "https://teams.com",
@@ -212,7 +212,7 @@ class NotificationTest {
                 )
             }
         } finally {
-            System.clearProperty("kviklet.server.baseUrl")
+            System.clearProperty("kviklet.baseUrl")
         }
     }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/NotificationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/NotificationTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -144,6 +145,7 @@ class NotificationTest {
     }
 
     @Test
+    @DirtiesContext
     fun `calls notification apis with configured base url`() {
         val baseUrl = "https://kviklet.example.com"
         System.setProperty("kviklet.baseUrl", baseUrl)

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/NotificationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/NotificationTest.kt
@@ -128,9 +128,91 @@ class NotificationTest {
             teamsApiClient.sendMessage(
                 webhookUrl = "https://teams.com",
                 "New Request: \"Test Execution\"",
-                any(),
+                match {
+                    it.contains("http://")
+                },
             )
         }
-        verify { slackApiClient.sendMessage(webhookUrl = "https://slack.com", any()) }
+        verify {
+            slackApiClient.sendMessage(
+                webhookUrl = "https://slack.com",
+                match {
+                    it.contains("http://")
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `calls notification apis with configured base url`() {
+        val baseUrl = "https://kviklet.example.com"
+        System.setProperty("kviklet.server.baseUrl", baseUrl)
+        try {
+            val config = Configuration(
+                teamsUrl = "https://teams.com",
+                slackUrl = "https://slack.com",
+                liveSessionEnabled = false,
+            )
+            configService.setConfiguration(config)
+            val connection = datasourceConnectionAdapter.createDatasourceConnection(
+                ConnectionId("ds-conn-test"),
+                "Test Connection",
+                AuthenticationType.USER_PASSWORD,
+                "test",
+                1,
+                "username",
+                "password",
+                "A test connection",
+                ReviewConfig(
+                    numTotalRequired = 1,
+                ),
+                3306,
+                "postgres",
+                DatasourceType.POSTGRESQL,
+                DatabaseProtocol.POSTGRESQL,
+                additionalJDBCOptions = "",
+                dumpsEnabled = false,
+                temporaryAccessEnabled = true,
+                explainEnabled = false,
+            )
+            userHelper.createUser(permissions = listOf("*"))
+            val cookie = userHelper.login(mockMvc = mockMvc)
+
+            mockMvc.perform(
+                MockMvcRequestBuilders.post("/execution-requests/").cookie(cookie).content(
+                    """
+                    {
+                        "connectionId": "${connection.id}",
+                        "title": "Test Execution",
+                        "type": "SingleExecution",
+                        "statement": "SELECT * FROM test",
+                        "description": "A test execution request",
+                        "readOnly": true,
+                        "connectionType": "DATASOURCE"
+                    }
+                    """.trimIndent(),
+                ).contentType("application/json"),
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+
+            verify {
+                teamsApiClient.sendMessage(
+                    webhookUrl = "https://teams.com",
+                    "New Request: \"Test Execution\"",
+                    match {
+                        it.contains(baseUrl)
+                    },
+                )
+            }
+            verify {
+                slackApiClient.sendMessage(
+                    webhookUrl = "https://slack.com",
+                    match {
+                        it.contains(baseUrl)
+                    },
+                )
+            }
+        } finally {
+            System.clearProperty("kviklet.server.baseUrl")
+        }
     }
 }


### PR DESCRIPTION
With this change any url used in health check calls is not cached for teams and slack notifications as these likely use internal ips or similar.

It also adds the option to configure a baseURL explicitly via the property
`kviklet.server.baseUrl` or as env var `KVIKLET_SERVER_BASEURL`.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds base URL configuration for notifications and excludes health check URLs from caching in `ServerUrlInterceptor`.
> 
>   - **Behavior**:
>     - Excludes URLs starting with `/health` from being cached in `ServerUrlInterceptor`.
>     - Adds configuration option `kviklet.server.baseUrl` for setting a base URL in `NotificationHandler`.
>     - Uses `serverBaseUrl` if set, otherwise falls back to `ServerUrlInterceptor.getServerUrl()`.
>   - **Tests**:
>     - Adds test `calls notification apis with configured base url` in `NotificationTest.kt` to verify notifications use the configured base URL.
>     - Modifies existing test to check for default URL behavior when base URL is not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 6e3d6dd474d5291dafa8ddd263a6b54ed59c91be. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->