### PR TITLE
Allow sections of code to not be MIT licensed

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,24 @@
-Copyright 2024 Jascha Beste
+# Kviklet Licensing
+
+Kviklet is generally licensed under the MIT license.
+However, some components are licensed under other licenses or not licensed at all. The author retains all rights to the code.
+
+The parts of the code that are not made available under the MIT license are clearly marked with a comment either at the top of the file or in the file itself.
+
+Any code that is not marked as such is licensed under the MIT license.
+
+## MIT License
+
+Copyright 2025 Jascha Beste
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## Explanation of the licensing situation
+
+The idea of reserving some code as not licensed is to allow for a paid version of Kviklet. You can acquire the right to use the code by paying for Kviklet Enterprise. This requires a separate license agreement.
+
+In the software this will be handled via a license key. Without this key, you are running the MIT licensed version of Kviklet.


### PR DESCRIPTION
Note: this does not change anything about the existing code. It just allows future features to be locked behind e.g. a license key or similar setup.
I don't intend to cut out existing features and also plan to continue developing open source features. I just want to also enable Kviklet supporting itself in the future.