### PR TITLE
Allow sending cookies cross origin

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -13,5 +13,10 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 server:
   port: 8081
+  servlet:
+    session:
+      cookie:
+        same-site: none
+        secure: true
 app:
   name: "Kviklet"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Configure cross-origin cookie sharing in `application.yaml` by setting `same-site` to `none` and `secure` to `true`.
> 
>   - **Configuration**:
>     - In `application.yaml`, set `server.servlet.session.cookie.same-site` to `none` to allow cross-origin cookie sharing.
>     - Set `server.servlet.session.cookie.secure` to `true` to ensure cookies are sent over HTTPS.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 289b3799c5779a79dcd6baa3697530f43c6e04e3. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->