### PR TITLE
Allow configurable java memory management via JAVA_OPTS env

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
-# Set default JAVA_OPTS if not already set
-JAVA_OPTS=${JAVA_OPTS:-"-Xmx64m -Xms64m"}
-
 # Start Nginx
 nginx -g 'daemon off;' &
 NGINX_PID=$!
 
 # Start Spring Boot Service
-java $JAVA_OPTS -jar /app/app.jar &
+# If JAVA_OPTS is set, use it. Otherwise, JVM uses its container-aware defaults
+java ${JAVA_OPTS} -jar /app/app.jar &
 SPRING_PID=$!
 
 # Wait for either process to exit


### PR DESCRIPTION
This introduce support for configurable Java memory settings through the `JAVA_OPTS` environment variable. This change enables more flexible memory tuning without modifying the codebase or deployment manifests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for configurable Java memory settings via `JAVA_OPTS` in `run.sh`, with default values if not set.
> 
>   - **Behavior**:
>     - Adds support for configurable Java memory settings via `JAVA_OPTS` in `run.sh`.
>     - Sets default `JAVA_OPTS` to `-Xmx64m` and `-Xms64m` if not defined.
>   - **Execution**:
>     - Modifies Java execution command to include `$JAVA_OPTS` in `run.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 27ef74a2dc32a59400840e3499f524f5af225262. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->