### PR TITLE
Add /api to saml paths for in docker deployments

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/Config.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/Config.kt
@@ -22,8 +22,9 @@ import javax.sql.DataSource
 
 @Component
 @ConfigurationProperties("app")
-class MyProperties {
+class ApplicationProperties {
     lateinit var name: String
+    var inDocker: Boolean = false
 }
 
 data class ErrorResponse(val code: Int, val type: String, val message: String, val detail: String? = null)

--- a/backend/src/main/resources/application-test.properties
+++ b/backend/src/main/resources/application-test.properties
@@ -7,3 +7,4 @@ spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDri
 logging.level.org.springframework.security=DEBUG
 server.tomcat.accesslog.enabled=true
 server.tomcat.accesslog.pattern=%t %a "%r" %s (%D ms)
+app.in-docker=false

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -20,3 +20,4 @@ server:
         secure: true
 app:
   name: "Kviklet"
+  in-docker: true


### PR DESCRIPTION
Somehow the {basepath} does not contain the requests path which is inconsistent with e.g. the OIDC modules :(
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add conditional SAML URL paths in `SamlConfig` for Docker deployments using `inDocker` property.
> 
>   - **Behavior**:
>     - Adds conditional logic in `SamlConfig` to prepend `/api` to SAML URLs if `inDocker` is true.
>     - Updates `assertionConsumerServiceLocation`, `entityId`, and `singleLogoutServiceLocation` in `SamlConfig`.
>   - **Configuration**:
>     - Adds `inDocker` property to `ApplicationProperties` in `Config.kt`.
>     - Sets `app.in-docker` to `true` in `application.yaml` and `false` in `application-test.properties`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for d3a14a86fd2e3dfd5ea890a498ed8fac5bfa5384. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->