### PR TITLE
Add Feature Download as JSON for specified connection MongoDB

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
@@ -213,6 +213,10 @@ sealed class ExecutionRequestDetailResponse(open val id: ExecutionRequestId, ope
                         allowed = dto.csvDownloadAllowed().first,
                         reason = dto.csvDownloadAllowed().second,
                     ),
+                    jsonDownload = JSONDownloadableResponse(
+                        allowed = dto.jsonDownloadAllowed().first,
+                        reason = dto.jsonDownloadAllowed().second,
+                    ),
                     temporaryAccessDuration = dto.request.temporaryAccessDuration?.toMinutes(),
                     liveSessionEnabled = liveSessionEnabled,
                 )
@@ -250,6 +254,7 @@ data class DatasourceExecutionRequestDetailResponse(
     val executionStatus: ExecutionStatus,
     val createdAt: LocalDateTime = utcTimeNow(),
     val csvDownload: CSVDownloadableResponse,
+    val jsonDownload: JSONDownloadableResponse,
     override val events: List<EventResponse>,
     val temporaryAccessDuration: Long? = null,
     val liveSessionEnabled: Boolean,
@@ -259,6 +264,8 @@ data class DatasourceExecutionRequestDetailResponse(
 )
 
 data class CSVDownloadableResponse(val allowed: Boolean, val reason: String)
+
+data class JSONDownloadableResponse(val allowed: Boolean, val reason: String)
 
 data class KubernetesExecutionRequestDetailResponse(
     override val id: ExecutionRequestId,
@@ -669,6 +676,24 @@ class ExecutionRequestController(
             response.status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR
             response.outputStream.use { it.write("An error occurred: ${e.message}".toByteArray()) }
         }
+    }
+
+    @Operation(
+        summary = "Execute Execution Request and Download as JSON (MongoDB only)",
+        description = "Run the query and download results as JSON after the Execution Request has been approved. Only supported for MongoDB connections.",
+    )
+    @GetMapping("/{executionRequestId}/download-json")
+    fun downloadJson(
+        @PathVariable executionRequestId: ExecutionRequestId,
+        @CurrentUser userDetails: UserDetailsWithId,
+        response: HttpServletResponse,
+        @RequestParam(required = false) query: String?,
+    ) {
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        val fileName = "${executionRequestId}.json"
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"$fileName\"")
+        val outputStream = response.outputStream
+        executionRequestService.streamResultsAsJson(executionRequestId, userDetails.id, outputStream, query)
     }
 
     @Operation(

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
@@ -680,7 +680,7 @@ class ExecutionRequestController(
 
     @Operation(
         summary = "Execute Execution Request and Download as JSON (MongoDB only)",
-        description = "Run the query and download results as JSON after the Execution Request has been approved (MongoDB Only)",
+        description = "Download results as JSON after the Execution Request has been approved (MongoDB Only)",
     )
     @GetMapping("/{executionRequestId}/download-json")
     fun downloadJson(

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
@@ -680,7 +680,7 @@ class ExecutionRequestController(
 
     @Operation(
         summary = "Execute Execution Request and Download as JSON (MongoDB only)",
-        description = "Run the query and download results as JSON after the Execution Request has been approved. Only supported for MongoDB connections.",
+        description = "Run the query and download results as JSON after the Execution Request has been approved (MongoDB Only)",
     )
     @GetMapping("/{executionRequestId}/download-json")
     fun downloadJson(
@@ -690,7 +690,7 @@ class ExecutionRequestController(
         @RequestParam(required = false) query: String?,
     ) {
         response.contentType = MediaType.APPLICATION_JSON_VALUE
-        val fileName = "${executionRequestId}.json"
+        val fileName = "$executionRequestId.json"
         response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"$fileName\"")
         val outputStream = response.outputStream
         executionRequestService.streamResultsAsJson(executionRequestId, userDetails.id, outputStream, query)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -634,7 +634,7 @@ class ExecutionRequestService(
 
         val mapper = com.fasterxml.jackson.module.kotlin.jacksonObjectMapper()
         val jsonGenerator = mapper.factory.createGenerator(outputStream)
-            .useDefaultPrettyPrinter() 
+            .useDefaultPrettyPrinter()
         jsonGenerator.writeStartArray()
 
         // streaming tanpa limit

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -606,7 +606,6 @@ class ExecutionRequestService(
         if (connection.type != DatasourceType.MONGODB) {
             throw RuntimeException("Only MongoDB requests can be downloaded as JSON")
         }
-        
         val (allowed, reason) = executionRequest.jsonDownloadAllowed(query)
         if (!allowed) {
             throw RuntimeException(reason)
@@ -636,7 +635,6 @@ class ExecutionRequestService(
         val mapper = com.fasterxml.jackson.module.kotlin.jacksonObjectMapper()
         val jsonGenerator = mapper.factory.createGenerator(outputStream)
             .useDefaultPrettyPrinter() 
-
         jsonGenerator.writeStartArray()
 
         // streaming tanpa limit
@@ -651,7 +649,6 @@ class ExecutionRequestService(
         jsonGenerator.writeEndArray()
         jsonGenerator.flush()
     }
-
 
     @Policy(Permission.EXECUTION_REQUEST_GET)
     fun explain(id: ExecutionRequestId, query: String?, userId: String): DBExecutionResult {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -591,6 +591,68 @@ class ExecutionRequestService(
         return field
     }
 
+    @Policy(Permission.EXECUTION_REQUEST_EXECUTE)
+    fun streamResultsAsJson(
+        id: ExecutionRequestId,
+        userId: String,
+        outputStream: OutputStream,
+        query: String? = null,
+    ) {
+        val executionRequest = executionRequestAdapter.getExecutionRequestDetails(id)
+        val connection = executionRequest.request.connection
+        if (connection !is DatasourceConnection || executionRequest.request !is DatasourceExecutionRequest) {
+            throw RuntimeException("Only Datasource requests can be downloaded as JSON")
+        }
+        if (connection.type != DatasourceType.MONGODB) {
+            throw RuntimeException("Only MongoDB requests can be downloaded as JSON")
+        }
+        
+        val (allowed, reason) = executionRequest.jsonDownloadAllowed(query)
+        if (!allowed) {
+            throw RuntimeException(reason)
+        }
+
+        val queryToExecute = when (executionRequest.request.type) {
+            RequestType.SingleExecution ->
+                executionRequest.request.statement!!
+                    .trim()
+                    .removeSuffix(";")
+            RequestType.TemporaryAccess ->
+                query?.trim()?.removeSuffix(";")
+                    ?: throw MissingQueryException("For temporary access requests a query to execute is required")
+            RequestType.Dump -> throw RuntimeException("Dump requests can't be downloaded as JSON")
+        }
+
+        // simpan event eksekusi (download)
+        eventService.saveEvent(
+            id,
+            userId,
+            ExecutePayload(
+                query = queryToExecute,
+                isDownload = true,
+            ),
+        )
+
+        val mapper = com.fasterxml.jackson.module.kotlin.jacksonObjectMapper()
+        val jsonGenerator = mapper.factory.createGenerator(outputStream)
+            .useDefaultPrettyPrinter() 
+
+        jsonGenerator.writeStartArray()
+
+        // streaming tanpa limit
+        mongoDBExecutor.executeAndStreamAll(
+            connectionString = connection.getConnectionString(),
+            databaseName = connection.databaseName ?: "db",
+            query = queryToExecute,
+        ) { doc ->
+            jsonGenerator.writeObject(doc)
+        }
+
+        jsonGenerator.writeEndArray()
+        jsonGenerator.flush()
+    }
+
+
     @Policy(Permission.EXECUTION_REQUEST_GET)
     fun explain(id: ExecutionRequestId, query: String?, userId: String): DBExecutionResult {
         val executionRequest = executionRequestAdapter.getExecutionRequestDetails(id)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/MongoDBExecutor.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/MongoDBExecutor.kt
@@ -70,4 +70,44 @@ class MongoDBExecutor {
     } catch (e: MongoException) {
         emptyList()
     }
+
+    fun executeAndStreamAll(
+        connectionString: String,
+        databaseName: String,
+        query: String,
+        onDocument: (Document) -> Unit
+    ) {
+        try {
+            val settings = MongoClientSettings.builder()
+                .applyConnectionString(ConnectionString(connectionString))
+                .applyToClusterSettings { builder ->
+                    builder.serverSelectionTimeout(3, TimeUnit.SECONDS)
+                }
+                .applyToSocketSettings { builder ->
+                    builder.connectTimeout(3, TimeUnit.SECONDS)
+                }
+                .build()
+
+            MongoClients.create(settings).use { client ->
+                val database = client.getDatabase(databaseName)
+                val command = Document.parse(query)
+
+                // Pastikan query adalah find command
+                val collectionName = command.getString("find")
+                    ?: throw RuntimeException("JSON export only supports 'find' queries")
+
+                val filter = command.get("filter", Document::class.java) ?: Document()
+                val collection = database.getCollection(collectionName)
+
+                val cursor = collection.find(filter).iterator()
+                cursor.use {
+                    while (cursor.hasNext()) {
+                        onDocument(cursor.next())
+                    }
+                }
+            }
+        } catch (e: MongoException) {
+            throw RuntimeException("Error while streaming MongoDB query results: ${e.message}", e)
+        }
+    }
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/MongoDBExecutor.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/MongoDBExecutor.kt
@@ -75,7 +75,7 @@ class MongoDBExecutor {
         connectionString: String,
         databaseName: String,
         query: String,
-        onDocument: (Document) -> Unit
+        onDocument: (Document) -> Unit,
     ) {
         try {
             val settings = MongoClientSettings.builder()

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
@@ -323,6 +323,43 @@ data class ExecutionRequestDetails(val request: ExecutionRequest, val events: Mu
             return Pair(false, "Error parsing query: ${e.message}")
         }
     }
+
+    fun jsonDownloadAllowed(query: String? = null): Pair<Boolean, String> {
+        if (request.type === RequestType.Dump) {
+            return false to "JSON download is not available for SQLDump"
+        }
+
+        if (request.connection !is DatasourceConnection || request !is DatasourceExecutionRequest) {
+            return false to "Only Datasource Requests can be downloaded as JSON"
+        }
+
+        if (request.connection.type != DatasourceType.MONGODB) {
+            return false to "Only MongoDB requests can be downloaded as JSON"
+        }
+
+        if (resolveReviewStatus() != ReviewStatus.APPROVED) {
+            return false to "This request has not been approved yet!"
+        }
+
+        if (resolveExecutionStatus() == ExecutionStatus.EXECUTED) {
+            return false to "This request has already been executed the maximum amount of times!"
+        }
+
+        val queryToExecute = when (request.type) {
+            RequestType.SingleExecution -> request.statement?.trim()?.removeSuffix(";")
+                ?: return false to "Statement can't be empty"
+            RequestType.TemporaryAccess -> query?.trim()?.removeSuffix(";")
+                ?: return false to "Query can't be empty"
+            else -> return false to "Can't download results for this request type"
+        }
+
+        if (queryToExecute.isBlank()) {
+            return false to "Query can't be empty"
+        }
+
+        // Untuk MongoDB kita tidak pakai JSQLParser, cukup lolos validasi di atas
+        return true to ""
+    }
 }
 
 data class ExecutionProxy(

--- a/frontend/src/api/ExecutionRequestApi.ts
+++ b/frontend/src/api/ExecutionRequestApi.ts
@@ -94,6 +94,11 @@ const CSVDownloadSchema = z.object({
   reason: z.string(),
 });
 
+const JSONDownloadSchema = z.object({
+  allowed: z.boolean(),
+  reason: z.string(),
+});
+
 const RawDatasourceRequestSchema = z.object({
   id: z.string(),
   type: z.enum(["TemporaryAccess", "SingleExecution", "Dump"]),
@@ -107,6 +112,7 @@ const RawDatasourceRequestSchema = z.object({
   createdAt: z.coerce.date(),
   connectionName: z.string().optional(),
   csvDownload: CSVDownloadSchema.optional(),
+  jsonDownload: JSONDownloadSchema.optional(),
   temporaryAccessDuration: z.number().nullable(),
   liveSessionEnabled: z.boolean().optional(),
 });

--- a/frontend/src/api/ExecutionRequestApi.ts
+++ b/frontend/src/api/ExecutionRequestApi.ts
@@ -479,6 +479,12 @@ const executeCommand = async (
   );
 };
 
+export enum ConnectionType {
+  MYSQL = "MYSQL",
+  POSTGRESQL = "POSTGRESQL",
+  MONGODB = "MONGODB",
+}
+
 export {
   addRequest,
   getRequests,

--- a/frontend/src/api/ExecutionRequestApi.ts
+++ b/frontend/src/api/ExecutionRequestApi.ts
@@ -89,15 +89,13 @@ const ExecuteEvent = withType(
   "EXECUTE",
 );
 
-const CSVDownloadSchema = z.object({
+const DownloadSchema = z.object({
   allowed: z.boolean(),
   reason: z.string(),
 });
 
-const JSONDownloadSchema = z.object({
-  allowed: z.boolean(),
-  reason: z.string(),
-});
+const CSVDownloadSchema = DownloadSchema;
+const JSONDownloadSchema = DownloadSchema;
 
 const RawDatasourceRequestSchema = z.object({
   id: z.string(),

--- a/frontend/src/api/ExecutionRequestApi.ts
+++ b/frontend/src/api/ExecutionRequestApi.ts
@@ -479,8 +479,6 @@ const executeCommand = async (
   );
 };
 
-export type ConnectionType = "MYSQL" | "POSTGRESQL" | "MONGODB";
-
 export {
   addRequest,
   getRequests,

--- a/frontend/src/api/ExecutionRequestApi.ts
+++ b/frontend/src/api/ExecutionRequestApi.ts
@@ -479,11 +479,7 @@ const executeCommand = async (
   );
 };
 
-export enum ConnectionType {
-  MYSQL = "MYSQL",
-  POSTGRESQL = "POSTGRESQL",
-  MONGODB = "MONGODB",
-}
+export type ConnectionType = "MYSQL" | "POSTGRESQL" | "MONGODB";
 
 export {
   addRequest,

--- a/frontend/src/routes/LiveSession.tsx
+++ b/frontend/src/routes/LiveSession.tsx
@@ -103,6 +103,21 @@ const Editor = ({
     }/download?query=${encodeURIComponent(query || "")}`;
   };
 
+  const handleJsonClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+
+    const selection = editor?.getSelection();
+    const query =
+      (selection && editor?.getModel()?.getValueInRange(selection)) ||
+      editor?.getValue();
+
+    const downloadUrl = `${baseUrl}/execution-requests/${
+      request.id
+    }/download-json?query=${encodeURIComponent(query || "")}`;
+
+    window.location.href = downloadUrl;
+  };
+
   const executeQuery = async () => {
     const selection = editor?.getSelection();
     const text =
@@ -136,6 +151,11 @@ const Editor = ({
           {request?._type === "DATASOURCE" && isRelationalDatabase(request) && (
             <a className="ml-auto mr-2" href="#" onClick={handleClick}>
               <Button>Download as CSV</Button>
+            </a>
+          )}
+          {request?._type === "DATASOURCE" && request.connection.type === "MONGODB" && (
+            <a className="ml-auto mr-2" href="#" onClick={handleJsonClick}>
+              <Button>Download as JSON</Button>
             </a>
           )}
           {request?._type === "DATASOURCE" && isRelationalDatabase(request) ? (

--- a/frontend/src/routes/LiveSession.tsx
+++ b/frontend/src/routes/LiveSession.tsx
@@ -154,7 +154,7 @@ const Editor = ({
               <Button>Download as CSV</Button>
             </a>
           )}
-          {request?._type === "DATASOURCE" && request.connection.type === ConnectionType.MONGODB && (
+          {request?._type === "DATASOURCE" && request.connection.type === "MONGODB" && (
             <a className="ml-auto mr-2" href="#" onClick={handleJsonClick}>
               <Button>Download as JSON</Button>
             </a>

--- a/frontend/src/routes/LiveSession.tsx
+++ b/frontend/src/routes/LiveSession.tsx
@@ -98,8 +98,9 @@ const Editor = ({
       (selection && editor?.getModel()?.getValueInRange(selection)) ||
       editor?.getValue();
 
-    window.location.href = `${baseUrl}/execution-requests/${request.id
-      }/download?query=${encodeURIComponent(query || "")}`;
+    window.location.href = `${baseUrl}/execution-requests/${
+      request.id
+    }/download?query=${encodeURIComponent(query || "")}`;
   };
 
   const handleJsonClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
@@ -110,8 +111,9 @@ const Editor = ({
       (selection && editor?.getModel()?.getValueInRange(selection)) ||
       editor?.getValue();
 
-    const downloadUrl = `${baseUrl}/execution-requests/${request.id
-      }/download-json?query=${encodeURIComponent(query || "")}`;
+    const downloadUrl = `${baseUrl}/execution-requests/${
+      request.id
+    }/download-json?query=${encodeURIComponent(query || "")}`;
 
     window.location.href = downloadUrl;
   };
@@ -147,15 +149,16 @@ const Editor = ({
         </div>
         <div className="flex flex-row">
           {request?._type === "DATASOURCE" && isRelationalDatabase(request) && (
-            <a className="ml-auto mr-2" href="#" onClick={handleClick}>
+            <a className="mr-2 ml-auto" href="#" onClick={handleClick}>
               <Button>Download as CSV</Button>
             </a>
           )}
-          {request?._type === "DATASOURCE" && (request.connection.type as string) === "MONGODB" && (
-            <a className="ml-auto mr-2" href="#" onClick={handleJsonClick}>
-              <Button>Download as JSON</Button>
-            </a>
-          )}
+          {request?._type === "DATASOURCE" &&
+            (request.connection.type as string) === "MONGODB" && (
+              <a className="mr-2 ml-auto" href="#" onClick={handleJsonClick}>
+                <Button>Download as JSON</Button>
+              </a>
+            )}
           {request?._type === "DATASOURCE" && isRelationalDatabase(request) ? (
             <LoadingCancelButton
               className=""

--- a/frontend/src/routes/LiveSession.tsx
+++ b/frontend/src/routes/LiveSession.tsx
@@ -17,7 +17,6 @@ import { isApiErrorResponse } from "../api/Errors";
 import baseUrl from "../api/base";
 import useRequest, { isRelationalDatabase } from "../hooks/request";
 import LoadingCancelButton from "../components/LoadingCancelButton";
-import { ConnectionType } from "../api/ExecutionRequestApi"; 
 
 interface SessionParams {
   requestId: string;
@@ -154,7 +153,7 @@ const Editor = ({
               <Button>Download as CSV</Button>
             </a>
           )}
-          {request?._type === "DATASOURCE" && request.connection.type === ConnectionType.MONGODB && (
+          {request?._type === "DATASOURCE" && (request.connection.type as string) === "MONGODB" && (
             <a className="ml-auto mr-2" href="#" onClick={handleJsonClick}>
               <Button>Download as JSON</Button>
             </a>

--- a/frontend/src/routes/LiveSession.tsx
+++ b/frontend/src/routes/LiveSession.tsx
@@ -17,6 +17,7 @@ import { isApiErrorResponse } from "../api/Errors";
 import baseUrl from "../api/base";
 import useRequest, { isRelationalDatabase } from "../hooks/request";
 import LoadingCancelButton from "../components/LoadingCancelButton";
+import { ConnectionType } from "../api/ExecutionRequestApi"; 
 
 interface SessionParams {
   requestId: string;
@@ -153,7 +154,7 @@ const Editor = ({
               <Button>Download as CSV</Button>
             </a>
           )}
-          {request?._type === "DATASOURCE" && request.connection.type === "MONGODB" && (
+          {request?._type === "DATASOURCE" && request.connection.type === ConnectionType.MONGODB && (
             <a className="ml-auto mr-2" href="#" onClick={handleJsonClick}>
               <Button>Download as JSON</Button>
             </a>

--- a/frontend/src/routes/LiveSession.tsx
+++ b/frontend/src/routes/LiveSession.tsx
@@ -149,13 +149,13 @@ const Editor = ({
         </div>
         <div className="flex flex-row">
           {request?._type === "DATASOURCE" && isRelationalDatabase(request) && (
-            <a className="mr-2 ml-auto" href="#" onClick={handleClick}>
+            <a className="ml-auto mr-2" href="#" onClick={handleClick}>
               <Button>Download as CSV</Button>
             </a>
           )}
           {request?._type === "DATASOURCE" &&
             (request.connection.type as string) === "MONGODB" && (
-              <a className="mr-2 ml-auto" href="#" onClick={handleJsonClick}>
+              <a className="ml-auto mr-2" href="#" onClick={handleJsonClick}>
                 <Button>Download as JSON</Button>
               </a>
             )}

--- a/frontend/src/routes/LiveSession.tsx
+++ b/frontend/src/routes/LiveSession.tsx
@@ -98,9 +98,8 @@ const Editor = ({
       (selection && editor?.getModel()?.getValueInRange(selection)) ||
       editor?.getValue();
 
-    window.location.href = `${baseUrl}/execution-requests/${
-      request.id
-    }/download?query=${encodeURIComponent(query || "")}`;
+    window.location.href = `${baseUrl}/execution-requests/${request.id
+      }/download?query=${encodeURIComponent(query || "")}`;
   };
 
   const handleJsonClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
@@ -111,9 +110,8 @@ const Editor = ({
       (selection && editor?.getModel()?.getValueInRange(selection)) ||
       editor?.getValue();
 
-    const downloadUrl = `${baseUrl}/execution-requests/${
-      request.id
-    }/download-json?query=${encodeURIComponent(query || "")}`;
+    const downloadUrl = `${baseUrl}/execution-requests/${request.id
+      }/download-json?query=${encodeURIComponent(query || "")}`;
 
     window.location.href = downloadUrl;
   };

--- a/frontend/src/routes/LiveSession.tsx
+++ b/frontend/src/routes/LiveSession.tsx
@@ -154,7 +154,7 @@ const Editor = ({
               <Button>Download as CSV</Button>
             </a>
           )}
-          {request?._type === "DATASOURCE" && request.connection.type === "MONGODB" && (
+          {request?._type === "DATASOURCE" && request.connection.type === ConnectionType.MONGODB && (
             <a className="ml-auto mr-2" href="#" onClick={handleJsonClick}>
               <Button>Download as JSON</Button>
             </a>

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -34,11 +34,13 @@ function DatasourceRequestBox({
   const [showSQLDumpModal, setShowSQLDumpModal] = useState(false);
   const navigate = useNavigate();
   const [statement, setStatement] = useState(request?.statement || "");
+
   const changeStatement = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     await updateRequest({ statement });
     setEditMode(false);
   };
+
   useEffect(() => {
     setStatement(request?.statement || "");
   }, [request?.statement]);
@@ -134,7 +136,6 @@ function DatasourceRequestBox({
 
   const fileHandler = async (connectionId: string) => {
     try {
-      // Create a handle for the file the user wants to save
       const fileHandle: FileSystemFileHandle = await window.showSaveFilePicker({
         suggestedName: `${connectionId}.sql`,
         types: [
@@ -153,7 +154,6 @@ function DatasourceRequestBox({
     }
   };
 
-  // Function to handle streaming the SQL dump and saving it to a file
   const handleStreamSQLDump = async (
     executionRequestId: string,
     connectionId: string,
@@ -165,7 +165,6 @@ function DatasourceRequestBox({
       const reader = responseStream.getReader();
       const writableStream = await fileHandle.createWritable();
 
-      // Handle reading from the readable stream and writing to the writable stream
       const pump = async () => {
         let done = false;
         while (!done) {

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -47,8 +47,8 @@ function DatasourceRequestBox({
     request?.type == "SingleExecution"
       ? " wants to execute a statement on "
       : request?.type == "TemporaryAccess"
-      ? " wants to have access to "
-      : " wants to get a SQL dump from ";
+        ? " wants to have access to "
+        : " wants to get a SQL dump from ";
 
   const navigateCopy = () => {
     navigate(`/new`, {
@@ -65,7 +65,7 @@ function DatasourceRequestBox({
 
   const menuDropDownItems = [
     {
-      onClick: () => {},
+      onClick: () => { },
       enabled: request?.csvDownload?.allowed || false,
       tooltip:
         (!request?.csvDownload?.allowed && request?.csvDownload?.reason) ||
@@ -80,18 +80,18 @@ function DatasourceRequestBox({
     },
     ...((request?.connection?.type as string) === "MONGODB"
       ? [
-          {
-            onClick: () => {},
-            enabled: request?.jsonDownload?.allowed || false,
-            tooltip:
-              (!request?.jsonDownload?.allowed && request?.jsonDownload?.reason) || undefined,
-            content: (
-              <a href={`${baseUrl}/execution-requests/${request?.id}/download-json`}>
-                Download as JSON
-              </a>
-            ),
-          },
-        ]
+        {
+          onClick: () => { },
+          enabled: request?.jsonDownload?.allowed || false,
+          tooltip:
+            (!request?.jsonDownload?.allowed && request?.jsonDownload?.reason) || undefined,
+          content: (
+            <a href={`${baseUrl}/execution-requests/${request?.id}/download-json`}>
+              Download as JSON
+            </a>
+          ),
+        },
+      ]
       : []),
     {
       onClick: () => {
@@ -102,29 +102,29 @@ function DatasourceRequestBox({
     },
     ...(request?.type == "SingleExecution"
       ? [
-          {
-            onClick: () => {
-              void runQuery(true);
-            },
-            enabled:
-              isRelationalDatabase(request) &&
-              request?.connection?.explainEnabled &&
-              (request?.reviewStatus === "APPROVED" ||
-                request?.reviewStatus === "AWAITING_APPROVAL"),
-            content: "Explain",
+        {
+          onClick: () => {
+            void runQuery(true);
           },
-        ]
+          enabled:
+            isRelationalDatabase(request) &&
+            request?.connection?.explainEnabled &&
+            (request?.reviewStatus === "APPROVED" ||
+              request?.reviewStatus === "AWAITING_APPROVAL"),
+          content: "Explain",
+        },
+      ]
       : []),
     ...(request?.type == "TemporaryAccess"
       ? [
-          {
-            onClick: () => {
-              void startServer();
-            },
-            enabled: request?.reviewStatus === "APPROVED",
-            content: "Start Proxy",
+        {
+          onClick: () => {
+            void startServer();
           },
-        ]
+          enabled: request?.reviewStatus === "APPROVED",
+          content: "Start Proxy",
+        },
+      ]
       : []),
   ];
 
@@ -307,16 +307,15 @@ function DatasourceRequestBox({
               title={getDisabledReason()}
             >
               <div
-                className={`play-triangle mr-2 inline-block h-3 w-2 ${
-                  (request?.reviewStatus == "APPROVED" && "bg-slate-50") ||
+                className={`play-triangle mr-2 inline-block h-3 w-2 ${(request?.reviewStatus == "APPROVED" && "bg-slate-50") ||
                   "bg-slate-500"
-                }`}
+                  }`}
               ></div>
               {request?.type === "SingleExecution"
                 ? "Run Query"
                 : request?.type === "TemporaryAccess"
-                ? "Start Session"
-                : "Get SQL Dump"}
+                  ? "Start Session"
+                  : "Get SQL Dump"}
             </LoadingCancelButton>
           ) : (
             <Button
@@ -333,10 +332,9 @@ function DatasourceRequestBox({
               title={getDisabledReason()}
             >
               <div
-                className={`play-triangle mr-2 inline-block h-3 w-2 ${
-                  (request?.reviewStatus == "APPROVED" && "bg-slate-50") ||
+                className={`play-triangle mr-2 inline-block h-3 w-2 ${(request?.reviewStatus == "APPROVED" && "bg-slate-50") ||
                   "bg-slate-500"
-                }`}
+                  }`}
               ></div>
               {request?.type == "SingleExecution"
                 ? "Run Query"

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -65,7 +65,7 @@ function DatasourceRequestBox({
 
   const menuDropDownItems = [
     {
-      onClick: () => { },
+      onClick: () => {},
       enabled: request?.csvDownload?.allowed || false,
       tooltip:
         (!request?.csvDownload?.allowed && request?.csvDownload?.reason) ||
@@ -80,18 +80,22 @@ function DatasourceRequestBox({
     },
     ...((request?.connection?.type as string) === "MONGODB"
       ? [
-        {
-          onClick: () => { },
-          enabled: request?.jsonDownload?.allowed || false,
-          tooltip:
-            (!request?.jsonDownload?.allowed && request?.jsonDownload?.reason) || undefined,
-          content: (
-            <a href={`${baseUrl}/execution-requests/${request?.id}/download-json`}>
-              Download as JSON
-            </a>
-          ),
-        },
-      ]
+          {
+            onClick: () => {},
+            enabled: request?.jsonDownload?.allowed || false,
+            tooltip:
+              (!request?.jsonDownload?.allowed &&
+                request?.jsonDownload?.reason) ||
+              undefined,
+            content: (
+              <a
+                href={`${baseUrl}/execution-requests/${request?.id}/download-json`}
+              >
+                Download as JSON
+              </a>
+            ),
+          },
+        ]
       : []),
     {
       onClick: () => {
@@ -102,29 +106,29 @@ function DatasourceRequestBox({
     },
     ...(request?.type == "SingleExecution"
       ? [
-        {
-          onClick: () => {
-            void runQuery(true);
+          {
+            onClick: () => {
+              void runQuery(true);
+            },
+            enabled:
+              isRelationalDatabase(request) &&
+              request?.connection?.explainEnabled &&
+              (request?.reviewStatus === "APPROVED" ||
+                request?.reviewStatus === "AWAITING_APPROVAL"),
+            content: "Explain",
           },
-          enabled:
-            isRelationalDatabase(request) &&
-            request?.connection?.explainEnabled &&
-            (request?.reviewStatus === "APPROVED" ||
-              request?.reviewStatus === "AWAITING_APPROVAL"),
-          content: "Explain",
-        },
-      ]
+        ]
       : []),
     ...(request?.type == "TemporaryAccess"
       ? [
-        {
-          onClick: () => {
-            void startServer();
+          {
+            onClick: () => {
+              void startServer();
+            },
+            enabled: request?.reviewStatus === "APPROVED",
+            content: "Start Proxy",
           },
-          enabled: request?.reviewStatus === "APPROVED",
-          content: "Start Proxy",
-        },
-      ]
+        ]
       : []),
   ];
 
@@ -246,7 +250,7 @@ function DatasourceRequestBox({
             editMode ? (
               <div>
                 <textarea
-                  className="mb-2 block w-full appearance-none rounded-md border border-gray-200 bg-slate-100 p-1 leading-normal text-gray-700 transition-colors focus:border-gray-500 focus:bg-white focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:focus:border-slate-500 dark:hover:border-slate-600 dark:focus:hover:border-slate-500"
+                  className="mb-2 block w-full appearance-none rounded-md border border-gray-200 bg-slate-100 p-1 leading-normal text-gray-700 transition-colors focus:border-gray-500 focus:bg-white focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:hover:border-slate-600 dark:focus:border-slate-500 dark:focus:hover:border-slate-500"
                   id="statement"
                   name="statement"
                   rows={4}
@@ -307,9 +311,10 @@ function DatasourceRequestBox({
               title={getDisabledReason()}
             >
               <div
-                className={`play-triangle mr-2 inline-block h-3 w-2 ${(request?.reviewStatus == "APPROVED" && "bg-slate-50") ||
+                className={`play-triangle mr-2 inline-block h-3 w-2 ${
+                  (request?.reviewStatus == "APPROVED" && "bg-slate-50") ||
                   "bg-slate-500"
-                  }`}
+                }`}
               ></div>
               {request?.type === "SingleExecution"
                 ? "Run Query"
@@ -332,9 +337,10 @@ function DatasourceRequestBox({
               title={getDisabledReason()}
             >
               <div
-                className={`play-triangle mr-2 inline-block h-3 w-2 ${(request?.reviewStatus == "APPROVED" && "bg-slate-50") ||
+                className={`play-triangle mr-2 inline-block h-3 w-2 ${
+                  (request?.reviewStatus == "APPROVED" && "bg-slate-50") ||
                   "bg-slate-500"
-                  }`}
+                }`}
               ></div>
               {request?.type == "SingleExecution"
                 ? "Run Query"

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -49,8 +49,8 @@ function DatasourceRequestBox({
     request?.type == "SingleExecution"
       ? " wants to execute a statement on "
       : request?.type == "TemporaryAccess"
-      ? " wants to have access to "
-      : " wants to get a SQL dump from ";
+        ? " wants to have access to "
+        : " wants to get a SQL dump from ";
 
   const navigateCopy = () => {
     navigate(`/new`, {
@@ -86,10 +86,13 @@ function DatasourceRequestBox({
             onClick: () => {},
             enabled: request?.jsonDownload?.allowed || false,
             tooltip:
-              (!request?.jsonDownload?.allowed && request?.jsonDownload?.reason) ||
+              (!request?.jsonDownload?.allowed &&
+                request?.jsonDownload?.reason) ||
               undefined,
             content: (
-              <a href={`${baseUrl}/execution-requests/${request?.id}/download-json`}>
+              <a
+                href={`${baseUrl}/execution-requests/${request?.id}/download-json`}
+              >
                 Download as JSON
               </a>
             ),
@@ -201,7 +204,9 @@ function DatasourceRequestBox({
         <SQLDumpConfirm
           title="Get SQL Dump"
           message={`Are you sure you want to get sql dump from database ${request?.connection?.displayName}?`}
-          onConfirm={() => handleStreamSQLDump(request.id, request.connection.id)}
+          onConfirm={() =>
+            handleStreamSQLDump(request.id, request.connection.id)
+          }
           onCancel={() => setShowSQLDumpModal(false)}
         />
       </Modal>
@@ -313,8 +318,8 @@ function DatasourceRequestBox({
               {request?.type === "SingleExecution"
                 ? "Run Query"
                 : request?.type === "TemporaryAccess"
-                ? "Start Session"
-                : "Get SQL Dump"}
+                  ? "Start Session"
+                  : "Get SQL Dump"}
             </LoadingCancelButton>
           ) : (
             <Button

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -250,7 +250,7 @@ function DatasourceRequestBox({
             editMode ? (
               <div>
                 <textarea
-                  className="mb-2 block w-full appearance-none rounded-md border border-gray-200 bg-slate-100 p-1 leading-normal text-gray-700 transition-colors focus:border-gray-500 focus:bg-white focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:hover:border-slate-600 dark:focus:border-slate-500 dark:focus:hover:border-slate-500"
+                  className="mb-2 block w-full appearance-none rounded-md border border-gray-200 bg-slate-100 p-1 leading-normal text-gray-700 transition-colors focus:border-gray-500 focus:bg-white focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:focus:border-slate-500 dark:hover:border-slate-600 dark:focus:hover:border-slate-500"
                   id="statement"
                   name="statement"
                   rows={4}

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -34,13 +34,11 @@ function DatasourceRequestBox({
   const [showSQLDumpModal, setShowSQLDumpModal] = useState(false);
   const navigate = useNavigate();
   const [statement, setStatement] = useState(request?.statement || "");
-
   const changeStatement = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     await updateRequest({ statement });
     setEditMode(false);
   };
-
   useEffect(() => {
     setStatement(request?.statement || "");
   }, [request?.statement]);
@@ -49,8 +47,8 @@ function DatasourceRequestBox({
     request?.type == "SingleExecution"
       ? " wants to execute a statement on "
       : request?.type == "TemporaryAccess"
-        ? " wants to have access to "
-        : " wants to get a SQL dump from ";
+      ? " wants to have access to "
+      : " wants to get a SQL dump from ";
 
   const navigateCopy = () => {
     navigate(`/new`, {
@@ -80,25 +78,6 @@ function DatasourceRequestBox({
         <span>Download as CSV</span>
       ),
     },
-    ...((request?.connection?.type as string) === "MONGODB"
-      ? [
-          {
-            onClick: () => {},
-            enabled: request?.jsonDownload?.allowed || false,
-            tooltip:
-              (!request?.jsonDownload?.allowed &&
-                request?.jsonDownload?.reason) ||
-              undefined,
-            content: (
-              <a
-                href={`${baseUrl}/execution-requests/${request?.id}/download-json`}
-              >
-                Download as JSON
-              </a>
-            ),
-          },
-        ]
-      : []),
     {
       onClick: () => {
         void navigateCopy();
@@ -136,6 +115,7 @@ function DatasourceRequestBox({
 
   const fileHandler = async (connectionId: string) => {
     try {
+      // Create a handle for the file the user wants to save
       const fileHandle: FileSystemFileHandle = await window.showSaveFilePicker({
         suggestedName: `${connectionId}.sql`,
         types: [
@@ -154,6 +134,7 @@ function DatasourceRequestBox({
     }
   };
 
+  // Function to handle streaming the SQL dump and saving it to a file
   const handleStreamSQLDump = async (
     executionRequestId: string,
     connectionId: string,
@@ -165,6 +146,7 @@ function DatasourceRequestBox({
       const reader = responseStream.getReader();
       const writableStream = await fileHandle.createWritable();
 
+      // Handle reading from the readable stream and writing to the writable stream
       const pump = async () => {
         let done = false;
         while (!done) {
@@ -172,7 +154,7 @@ function DatasourceRequestBox({
           done = result.done;
           const value = result.value;
           if (value !== undefined) {
-            await writableStream.write(new Uint8Array(value));
+            await writableStream.write(value);
           }
         }
         await writableStream.close();
@@ -318,8 +300,8 @@ function DatasourceRequestBox({
               {request?.type === "SingleExecution"
                 ? "Run Query"
                 : request?.type === "TemporaryAccess"
-                  ? "Start Session"
-                  : "Get SQL Dump"}
+                ? "Start Session"
+                : "Get SQL Dump"}
             </LoadingCancelButton>
           ) : (
             <Button

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -78,7 +78,7 @@ function DatasourceRequestBox({
         <span>Download as CSV</span>
       ),
     },
-    ...(request?.connection?.type === (request.connection.type as string) === "MONGODB"
+    ...((request?.connection?.type as string) === "MONGODB"
       ? [
           {
             onClick: () => {},

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -78,7 +78,7 @@ function DatasourceRequestBox({
         <span>Download as CSV</span>
       ),
     },
-    ...(request?.connection?.type === (request.connection.type as string) === "MONGODB" &&
+    ...(request?.connection?.type === (request.connection.type as string) === "MONGODB"
       ? [
           {
             onClick: () => {},

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -173,7 +173,7 @@ function DatasourceRequestBox({
           done = result.done;
           const value = result.value;
           if (value !== undefined) {
-            await writableStream.write(value);
+            await writableStream.write(new Uint8Array(value));
           }
         }
         await writableStream.close();

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -49,8 +49,8 @@ function DatasourceRequestBox({
     request?.type == "SingleExecution"
       ? " wants to execute a statement on "
       : request?.type == "TemporaryAccess"
-        ? " wants to have access to "
-        : " wants to get a SQL dump from ";
+      ? " wants to have access to "
+      : " wants to get a SQL dump from ";
 
   const navigateCopy = () => {
     navigate(`/new`, {
@@ -86,13 +86,10 @@ function DatasourceRequestBox({
             onClick: () => {},
             enabled: request?.jsonDownload?.allowed || false,
             tooltip:
-              (!request?.jsonDownload?.allowed &&
-                request?.jsonDownload?.reason) ||
+              (!request?.jsonDownload?.allowed && request?.jsonDownload?.reason) ||
               undefined,
             content: (
-              <a
-                href={`${baseUrl}/execution-requests/${request?.id}/download-json`}
-              >
+              <a href={`${baseUrl}/execution-requests/${request?.id}/download-json`}>
                 Download as JSON
               </a>
             ),
@@ -204,9 +201,7 @@ function DatasourceRequestBox({
         <SQLDumpConfirm
           title="Get SQL Dump"
           message={`Are you sure you want to get sql dump from database ${request?.connection?.displayName}?`}
-          onConfirm={() =>
-            handleStreamSQLDump(request.id, request.connection.id)
-          }
+          onConfirm={() => handleStreamSQLDump(request.id, request.connection.id)}
           onCancel={() => setShowSQLDumpModal(false)}
         />
       </Modal>
@@ -318,8 +313,8 @@ function DatasourceRequestBox({
               {request?.type === "SingleExecution"
                 ? "Run Query"
                 : request?.type === "TemporaryAccess"
-                  ? "Start Session"
-                  : "Get SQL Dump"}
+                ? "Start Session"
+                : "Get SQL Dump"}
             </LoadingCancelButton>
           ) : (
             <Button

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -34,11 +34,13 @@ function DatasourceRequestBox({
   const [showSQLDumpModal, setShowSQLDumpModal] = useState(false);
   const navigate = useNavigate();
   const [statement, setStatement] = useState(request?.statement || "");
+
   const changeStatement = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     await updateRequest({ statement });
     setEditMode(false);
   };
+
   useEffect(() => {
     setStatement(request?.statement || "");
   }, [request?.statement]);
@@ -47,8 +49,8 @@ function DatasourceRequestBox({
     request?.type == "SingleExecution"
       ? " wants to execute a statement on "
       : request?.type == "TemporaryAccess"
-      ? " wants to have access to "
-      : " wants to get a SQL dump from ";
+        ? " wants to have access to "
+        : " wants to get a SQL dump from ";
 
   const navigateCopy = () => {
     navigate(`/new`, {
@@ -78,6 +80,24 @@ function DatasourceRequestBox({
         <span>Download as CSV</span>
       ),
     },
+    ...((request?.connection?.type as string) === "MONGODB"
+      ? [
+          {
+            onClick: () => {},
+            enabled: request?.jsonDownload?.allowed || false,
+            tooltip:
+              (!request?.jsonDownload?.allowed && request?.jsonDownload?.reason) ||
+              undefined,
+            content: request?.jsonDownload?.allowed ? (
+              <a href={`${baseUrl}/execution-requests/${request?.id}/download-json`}>
+                Download as JSON
+              </a>
+            ) : (
+              <span>Download as CSV</span>
+            ),
+          },
+        ]
+      : []),
     {
       onClick: () => {
         void navigateCopy();
@@ -115,7 +135,6 @@ function DatasourceRequestBox({
 
   const fileHandler = async (connectionId: string) => {
     try {
-      // Create a handle for the file the user wants to save
       const fileHandle: FileSystemFileHandle = await window.showSaveFilePicker({
         suggestedName: `${connectionId}.sql`,
         types: [
@@ -134,7 +153,6 @@ function DatasourceRequestBox({
     }
   };
 
-  // Function to handle streaming the SQL dump and saving it to a file
   const handleStreamSQLDump = async (
     executionRequestId: string,
     connectionId: string,
@@ -146,7 +164,6 @@ function DatasourceRequestBox({
       const reader = responseStream.getReader();
       const writableStream = await fileHandle.createWritable();
 
-      // Handle reading from the readable stream and writing to the writable stream
       const pump = async () => {
         let done = false;
         while (!done) {
@@ -154,7 +171,7 @@ function DatasourceRequestBox({
           done = result.done;
           const value = result.value;
           if (value !== undefined) {
-            await writableStream.write(value);
+            await writableStream.write(new Uint8Array(value));
           }
         }
         await writableStream.close();
@@ -300,8 +317,8 @@ function DatasourceRequestBox({
               {request?.type === "SingleExecution"
                 ? "Run Query"
                 : request?.type === "TemporaryAccess"
-                ? "Start Session"
-                : "Get SQL Dump"}
+                  ? "Start Session"
+                  : "Get SQL Dump"}
             </LoadingCancelButton>
           ) : (
             <Button

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -78,6 +78,21 @@ function DatasourceRequestBox({
         <span>Download as CSV</span>
       ),
     },
+    ...(request?.connection?.type === "MONGODB"
+      ? [
+          {
+            onClick: () => {},
+            enabled: request?.jsonDownload?.allowed || false,
+            tooltip:
+              (!request?.jsonDownload?.allowed && request?.jsonDownload?.reason) || undefined,
+            content: (
+              <a href={`${baseUrl}/execution-requests/${request?.id}/download-json`}>
+                Download as JSON
+              </a>
+            ),
+          },
+        ]
+      : []),
     {
       onClick: () => {
         void navigateCopy();

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -78,7 +78,7 @@ function DatasourceRequestBox({
         <span>Download as CSV</span>
       ),
     },
-    ...(request?.connection?.type === ConnectionType.MONGODB
+    ...(request?.connection?.type === "MONGODB"
       ? [
           {
             onClick: () => {},

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -78,7 +78,7 @@ function DatasourceRequestBox({
         <span>Download as CSV</span>
       ),
     },
-    ...(request?.connection?.type === "MONGODB"
+    ...(request?.connection?.type === ConnectionType.MONGODB &&
       ? [
           {
             onClick: () => {},

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -78,7 +78,7 @@ function DatasourceRequestBox({
         <span>Download as CSV</span>
       ),
     },
-    ...(request?.connection?.type === "MONGODB"
+    ...(request?.connection?.type === ConnectionType.MONGODB
       ? [
           {
             onClick: () => {},

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -49,8 +49,8 @@ function DatasourceRequestBox({
     request?.type == "SingleExecution"
       ? " wants to execute a statement on "
       : request?.type == "TemporaryAccess"
-        ? " wants to have access to "
-        : " wants to get a SQL dump from ";
+      ? " wants to have access to "
+      : " wants to get a SQL dump from ";
 
   const navigateCopy = () => {
     navigate(`/new`, {
@@ -86,14 +86,17 @@ function DatasourceRequestBox({
             onClick: () => {},
             enabled: request?.jsonDownload?.allowed || false,
             tooltip:
-              (!request?.jsonDownload?.allowed && request?.jsonDownload?.reason) ||
+              (!request?.jsonDownload?.allowed &&
+                request?.jsonDownload?.reason) ||
               undefined,
             content: request?.jsonDownload?.allowed ? (
-              <a href={`${baseUrl}/execution-requests/${request?.id}/download-json`}>
+              <a
+                href={`${baseUrl}/execution-requests/${request?.id}/download-json`}
+              >
                 Download as JSON
               </a>
             ) : (
-              <span>Download as CSV</span>
+              <span>Download as JSON</span>
             ),
           },
         ]
@@ -317,8 +320,8 @@ function DatasourceRequestBox({
               {request?.type === "SingleExecution"
                 ? "Run Query"
                 : request?.type === "TemporaryAccess"
-                  ? "Start Session"
-                  : "Get SQL Dump"}
+                ? "Start Session"
+                : "Get SQL Dump"}
             </LoadingCancelButton>
           ) : (
             <Button

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -78,7 +78,7 @@ function DatasourceRequestBox({
         <span>Download as CSV</span>
       ),
     },
-    ...(request?.connection?.type === ConnectionType.MONGODB &&
+    ...(request?.connection?.type === (request.connection.type as string) === "MONGODB" &&
       ? [
           {
             onClick: () => {},


### PR DESCRIPTION
Changes : 

- Add capability to Download as JSON in Request Query specified MongoDB connection only
- Download as JSON also support in Live access but only for MongoDB connection
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add JSON download feature for MongoDB queries, including backend handling and frontend UI updates.
> 
>   - **Backend**:
>     - Add `downloadJson()` in `ExecutionRequestController.kt` to handle JSON downloads for MongoDB connections.
>     - Implement `streamResultsAsJson()` in `ExecutionRequestService.kt` to stream MongoDB query results as JSON.
>     - Add `executeAndStreamAll()` in `MongoDBExecutor.kt` to execute and stream MongoDB queries.
>     - Add `jsonDownloadAllowed()` in `ExecutionRequest.kt` to check JSON download permissions.
>   - **Frontend**:
>     - Add `JSONDownloadSchema` in `ExecutionRequestApi.ts` to handle JSON download permissions.
>     - Update `LiveSession.tsx` to include a "Download as JSON" button for MongoDB connections.
>     - Update `DatasourceRequestBox.tsx` to include a menu item for JSON download for MongoDB connections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 53f0c1e85c248205b98850eb5645fc62d76fe4d9. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->