### PR TITLE
Fix testing connections without temp access

### DIFF
--- a/frontend/src/routes/settings/connection/DatabaseConnectionForm.tsx
+++ b/frontend/src/routes/settings/connection/DatabaseConnectionForm.tsx
@@ -579,6 +579,12 @@ const TestingConnectionFragment = (props: {
 
   const handleSubmitTest = props.handleSubmit(async (data: ConnectionForm) => {
     setIsTestingConnection(true);
+    if (data.connectionType === "DATASOURCE") {
+      const duration = data.maxTemporaryAccessDuration;
+      if (!duration || duration === 0) {
+        data.maxTemporaryAccessDuration = null;
+      }
+    }
     const response = await testConnection(data);
     if (isApiErrorResponse(response)) {
       addNotification({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `handleSubmitTest` in `TestingConnectionFragment` to set `maxTemporaryAccessDuration` to null for `DATASOURCE` connections if not set or zero.
> 
>   - **Behavior**:
>     - In `TestingConnectionFragment`, `handleSubmitTest` now sets `maxTemporaryAccessDuration` to null if not set or zero for `DATASOURCE` connections.
>   - **Misc**:
>     - No other files or functions are affected by this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 251637e5dede37906826fa084ac5dead194b27e6. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->