### PR TITLE
Unify maxtemp access cleaning in hooks

### DIFF
--- a/frontend/src/hooks/connections.test.ts
+++ b/frontend/src/hooks/connections.test.ts
@@ -1,0 +1,254 @@
+import { renderHook, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, MockedFunction } from "vitest";
+import useConnections from "./connections";
+import {
+  ConnectionPayload,
+  DatabaseConnectionResponse,
+  TestConnectionResponse,
+  DatabaseType,
+  DatabaseProtocol,
+  AuthenticationType,
+  getConnections,
+  addConnection,
+  testConnection,
+} from "../api/DatasourceApi";
+
+// Mock the API module
+vi.mock("../api/DatasourceApi");
+
+// Mock the notification hook
+vi.mock("./useNotification", () => ({
+  default: () => ({
+    addNotification: vi.fn(),
+  }),
+}));
+
+// Get mocked functions with proper typing
+const mockGetConnections = getConnections as MockedFunction<
+  typeof getConnections
+>;
+const mockAddConnection = addConnection as MockedFunction<typeof addConnection>;
+const mockTestConnection = testConnection as MockedFunction<
+  typeof testConnection
+>;
+
+describe("useConnections hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConnections.mockResolvedValue([]);
+  });
+
+  describe("testConnection", () => {
+    it("should normalize maxTemporaryAccessDuration when value is 0", async () => {
+      const testResponse: TestConnectionResponse = {
+        success: true,
+        details: "Connection successful",
+        accessibleDatabases: ["db1", "db2"],
+      };
+      mockTestConnection.mockResolvedValue(testResponse);
+
+      const { result } = renderHook(() => useConnections());
+
+      const connectionPayload: ConnectionPayload = {
+        connectionType: "DATASOURCE",
+        id: "test-conn",
+        displayName: "Test Connection",
+        databaseName: "test_db",
+        maxTemporaryAccessDuration: 0,
+        username: "user",
+        password: "pass",
+        type: DatabaseType.POSTGRES,
+        protocol: DatabaseProtocol.POSTGRESQL,
+        hostname: "localhost",
+        port: 5432,
+        reviewConfig: { numTotalRequired: 1 },
+        authenticationType: AuthenticationType.USER_PASSWORD,
+        description: "",
+        additionalJDBCOptions: "",
+        dumpsEnabled: false,
+        temporaryAccessEnabled: true,
+        explainEnabled: false,
+        maxExecutions: null,
+      };
+
+      await act(async () => {
+        await result.current.testConnection(connectionPayload);
+      });
+
+      expect(mockTestConnection).toHaveBeenCalledWith({
+        ...connectionPayload,
+        maxTemporaryAccessDuration: null,
+      });
+    });
+
+    it("should normalize maxTemporaryAccessDuration when value is undefined", async () => {
+      const testResponse: TestConnectionResponse = {
+        success: true,
+        details: "Connection successful",
+        accessibleDatabases: ["db1"],
+      };
+      mockTestConnection.mockResolvedValue(testResponse);
+
+      const { result } = renderHook(() => useConnections());
+
+      const connectionPayload: ConnectionPayload = {
+        connectionType: "DATASOURCE",
+        id: "test-conn",
+        displayName: "Test Connection",
+        databaseName: "test_db",
+        maxTemporaryAccessDuration: undefined,
+        username: "user",
+        password: "pass",
+        type: DatabaseType.POSTGRES,
+        protocol: DatabaseProtocol.POSTGRESQL,
+        hostname: "localhost",
+        port: 5432,
+        reviewConfig: { numTotalRequired: 1 },
+        authenticationType: AuthenticationType.USER_PASSWORD,
+        description: "",
+        additionalJDBCOptions: "",
+        dumpsEnabled: false,
+        temporaryAccessEnabled: true,
+        explainEnabled: false,
+        maxExecutions: null,
+      };
+
+      await act(async () => {
+        await result.current.testConnection(connectionPayload);
+      });
+
+      expect(mockTestConnection).toHaveBeenCalledWith({
+        ...connectionPayload,
+        maxTemporaryAccessDuration: null,
+      });
+    });
+
+    it("should preserve maxTemporaryAccessDuration when value is positive", async () => {
+      const testResponse: TestConnectionResponse = {
+        success: true,
+        details: "Connection successful",
+        accessibleDatabases: ["db1"],
+      };
+      mockTestConnection.mockResolvedValue(testResponse);
+
+      const { result } = renderHook(() => useConnections());
+
+      const connectionPayload: ConnectionPayload = {
+        connectionType: "DATASOURCE",
+        id: "test-conn",
+        displayName: "Test Connection",
+        databaseName: "test_db",
+        maxTemporaryAccessDuration: 120,
+        username: "user",
+        password: "pass",
+        type: DatabaseType.POSTGRES,
+        protocol: DatabaseProtocol.POSTGRESQL,
+        hostname: "localhost",
+        port: 5432,
+        reviewConfig: { numTotalRequired: 1 },
+        authenticationType: AuthenticationType.USER_PASSWORD,
+        description: "",
+        additionalJDBCOptions: "",
+        dumpsEnabled: false,
+        temporaryAccessEnabled: true,
+        explainEnabled: false,
+        maxExecutions: null,
+      };
+
+      await act(async () => {
+        await result.current.testConnection(connectionPayload);
+      });
+
+      expect(mockTestConnection).toHaveBeenCalledWith({
+        ...connectionPayload,
+        maxTemporaryAccessDuration: 120,
+      });
+    });
+
+    it("should not modify Kubernetes connections", async () => {
+      const testResponse: TestConnectionResponse = {
+        success: true,
+        details: "Connection successful",
+        accessibleDatabases: [],
+      };
+      mockTestConnection.mockResolvedValue(testResponse);
+
+      const { result } = renderHook(() => useConnections());
+
+      const connectionPayload: ConnectionPayload = {
+        connectionType: "KUBERNETES",
+        id: "k8s-conn",
+        displayName: "K8s Connection",
+        description: "",
+        reviewConfig: { numTotalRequired: 1 },
+        maxExecutions: null,
+      };
+
+      await act(async () => {
+        await result.current.testConnection(connectionPayload);
+      });
+
+      expect(mockTestConnection).toHaveBeenCalledWith(connectionPayload);
+    });
+  });
+
+  describe("createConnection", () => {
+    it("should normalize maxTemporaryAccessDuration when creating datasource connection", async () => {
+      const connectionResponse: DatabaseConnectionResponse = {
+        id: "test-conn",
+        displayName: "Test Connection",
+        type: DatabaseType.POSTGRES,
+        protocol: DatabaseProtocol.POSTGRESQL,
+        maxExecutions: null,
+        authenticationType: AuthenticationType.USER_PASSWORD,
+        databaseName: "test_db",
+        username: "user",
+        hostname: "localhost",
+        port: 5432,
+        description: "",
+        reviewConfig: { numTotalRequired: 1 },
+        additionalJDBCOptions: "",
+        dumpsEnabled: false,
+        temporaryAccessEnabled: true,
+        explainEnabled: false,
+        roleArn: null,
+        maxTemporaryAccessDuration: null,
+        _type: "DATASOURCE",
+      };
+      mockAddConnection.mockResolvedValue(connectionResponse);
+
+      const { result } = renderHook(() => useConnections());
+
+      const connectionPayload: ConnectionPayload = {
+        connectionType: "DATASOURCE",
+        id: "test-conn",
+        displayName: "Test Connection",
+        databaseName: "test_db",
+        maxTemporaryAccessDuration: 0,
+        username: "user",
+        password: "pass",
+        type: DatabaseType.POSTGRES,
+        protocol: DatabaseProtocol.POSTGRESQL,
+        hostname: "localhost",
+        port: 5432,
+        reviewConfig: { numTotalRequired: 1 },
+        authenticationType: AuthenticationType.USER_PASSWORD,
+        description: "",
+        additionalJDBCOptions: "",
+        dumpsEnabled: false,
+        temporaryAccessEnabled: true,
+        explainEnabled: false,
+        maxExecutions: null,
+      };
+
+      await act(async () => {
+        await result.current.createConnection(connectionPayload);
+      });
+
+      expect(mockAddConnection).toHaveBeenCalledWith({
+        ...connectionPayload,
+        maxTemporaryAccessDuration: null,
+      });
+    });
+  });
+});

--- a/frontend/src/routes/settings/connection/ConnectionSettings.tsx
+++ b/frontend/src/routes/settings/connection/ConnectionSettings.tsx
@@ -37,7 +37,8 @@ const useIdNamePair = () => {
 };
 
 const ConnectionSettings = () => {
-  const { loading, connections, createConnection } = useConnections();
+  const { loading, connections, createConnection, testConnection } =
+    useConnections();
   const navigate = useNavigate();
 
   const [showAddConnectionModal, setShowAddConnectionModal] =
@@ -144,6 +145,7 @@ const ConnectionSettings = () => {
         >
           <DatabaseConnectionForm
             createConnection={handleCreateConnection}
+            testConnection={testConnection}
             closeModal={() => {
               setShowAddConnectionModal(false);
               setConnectionTypeChoice(null);

--- a/frontend/src/routes/settings/connection/DatabaseConnectionForm.test.tsx
+++ b/frontend/src/routes/settings/connection/DatabaseConnectionForm.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
 const mockCreateConnection = vi.fn();
+const mockTestConnection = vi.fn();
 const mockCloseModal = vi.fn();
 
 describe("DatabaseConnectionForm - Max Temporary Access Duration", () => {
@@ -16,6 +17,7 @@ describe("DatabaseConnectionForm - Max Temporary Access Duration", () => {
     render(
       <DatabaseConnectionForm
         createConnection={mockCreateConnection}
+        testConnection={mockTestConnection}
         closeModal={mockCloseModal}
       />,
     );
@@ -38,6 +40,7 @@ describe("DatabaseConnectionForm - Max Temporary Access Duration", () => {
     render(
       <DatabaseConnectionForm
         createConnection={mockCreateConnection}
+        testConnection={mockTestConnection}
         closeModal={mockCloseModal}
       />,
     );
@@ -77,6 +80,7 @@ describe("DatabaseConnectionForm - Max Temporary Access Duration", () => {
     render(
       <DatabaseConnectionForm
         createConnection={mockCreateConnection}
+        testConnection={mockTestConnection}
         closeModal={mockCloseModal}
       />,
     );
@@ -115,6 +119,7 @@ describe("DatabaseConnectionForm - Max Temporary Access Duration", () => {
     render(
       <DatabaseConnectionForm
         createConnection={mockCreateConnection}
+        testConnection={mockTestConnection}
         closeModal={mockCloseModal}
       />,
     );
@@ -132,6 +137,7 @@ describe("DatabaseConnectionForm - Max Temporary Access Duration", () => {
     render(
       <DatabaseConnectionForm
         createConnection={mockCreateConnection}
+        testConnection={mockTestConnection}
         closeModal={mockCloseModal}
       />,
     );

--- a/frontend/src/routes/settings/connection/DatabaseConnectionForm.tsx
+++ b/frontend/src/routes/settings/connection/DatabaseConnectionForm.tsx
@@ -3,9 +3,9 @@ import {
   ConnectionPayload,
   DatabaseProtocol,
   DatabaseType,
-  testConnection,
   TestConnectionResponse,
 } from "../../../api/DatasourceApi";
+import { ApiResponse } from "../../../api/Errors";
 import {
   FieldErrors,
   useForm,
@@ -107,6 +107,9 @@ function convertToAlphanumericDash(input: string): string {
 
 export default function DatabaseConnectionForm(props: {
   createConnection: (payload: ConnectionPayload) => Promise<void>;
+  testConnection: (
+    payload: ConnectionPayload,
+  ) => Promise<ApiResponse<TestConnectionResponse>>;
   closeModal: () => void;
 }) {
   const getProtocolOptions = (type: DatabaseType) => {
@@ -440,6 +443,7 @@ export default function DatabaseConnectionForm(props: {
                         handleSubmit={handleSubmit}
                         type={watchType}
                         createConnection={props.createConnection}
+                        testConnection={props.testConnection}
                         closeModal={props.closeModal}
                       />
                     </div>
@@ -565,6 +569,9 @@ const TestingConnectionFragment = (props: {
   handleSubmit: UseFormHandleSubmit<ConnectionForm>;
   type: DatabaseType;
   createConnection: (connection: ConnectionPayload) => Promise<void>;
+  testConnection: (
+    connection: ConnectionPayload,
+  ) => Promise<ApiResponse<TestConnectionResponse>>;
   closeModal: () => void;
 }) => {
   const [isTestingConnection, setIsTestingConnection] = useState(false);
@@ -579,13 +586,7 @@ const TestingConnectionFragment = (props: {
 
   const handleSubmitTest = props.handleSubmit(async (data: ConnectionForm) => {
     setIsTestingConnection(true);
-    if (data.connectionType === "DATASOURCE") {
-      const duration = data.maxTemporaryAccessDuration;
-      if (!duration || duration === 0) {
-        data.maxTemporaryAccessDuration = null;
-      }
-    }
-    const response = await testConnection(data);
+    const response = await props.testConnection(data);
     if (isApiErrorResponse(response)) {
       addNotification({
         title: "Failed to test connection",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Unifies `maxTemporaryAccessDuration` normalization in connection hooks and updates related tests and components.
> 
>   - **Normalization**:
>     - Introduces `normalizeMaxTemporaryAccessDuration` utility in `connections.ts` to convert `0` or falsy `maxTemporaryAccessDuration` to `null` for `DATASOURCE` connections.
>     - Updates `createConnection`, `testConnection`, and `editConnection` in `connections.ts` to use the normalization utility.
>   - **Testing**:
>     - Adds `connections.test.ts` to test normalization behavior in `testConnection` and `createConnection` functions.
>     - Updates `DatabaseConnectionForm.test.tsx` to test form behavior for `maxTemporaryAccessDuration` field.
>   - **Components**:
>     - Updates `DatabaseConnectionForm.tsx` to use `testConnection` prop and handle `maxTemporaryAccessDuration` field.
>     - Updates `ConnectionSettings.tsx` to pass `testConnection` to `DatabaseConnectionForm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 9642d263a266f4380ec6b11d97da4b50794dbf29. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->