### PR TITLE
Provide a default pw for userdetails of non pw users in ApiKey flow

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/ApiKeyAuthFilter.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/ApiKeyAuthFilter.kt
@@ -49,8 +49,17 @@ class ApiKeyAuthFilter(private val apiKeyService: ApiKeyService, private val pas
 
             // Create authentication token
             val policies = user.roles.flatMap(Role::policies).map(::PolicyGrantedAuthority)
-            val userDetails = UserDetailsWithId(userId, user.email, user.password, policies)
-            val authentication = UsernamePasswordAuthenticationToken(userDetails, user.password, policies)
+            val userDetails = UserDetailsWithId(
+                userId,
+                user.email,
+                user.password ?: "default password",
+                policies,
+            )
+            val authentication = UsernamePasswordAuthenticationToken(
+                userDetails,
+                user.password ?: "default password",
+                policies,
+            )
 
             // Set authentication in context
             SecurityContextHolder.getContext().authentication = authentication


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set default password for users without a password in `ApiKeyAuthFilter` to prevent authentication errors.
> 
>   - **Behavior**:
>     - In `ApiKeyAuthFilter`, set default password "default password" for `userDetails` and `authentication` if `user.password` is null.
>   - **Error Handling**:
>     - Handles cases where users do not have a password set, preventing potential null pointer exceptions during authentication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 3fff3073cfce4eb979a9150c0c719b09cbfcac63. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->