### PR TITLE
Fix null pointer exceptions in SQL parser validation

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
@@ -311,13 +311,13 @@ data class ExecutionRequestDetails(val request: ExecutionRequest, val events: Mu
             else -> return Pair(false, "Can't download results for this request type")
         }
         try {
-            val statementCount = CCJSqlParserUtil.parseStatements(queryToExecute).size
+            val statementCount = CCJSqlParserUtil.parseStatements(queryToExecute)?.size ?: 0
             if (statementCount > 1) {
                 return Pair(false, "This request contains more than one statement!")
             }
             if (CCJSqlParserUtil.parseStatements(
                     queryToExecute,
-                ).first() !is net.sf.jsqlparser.statement.select.Select
+                )?.first() !is net.sf.jsqlparser.statement.select.Select
             ) {
                 return Pair(false, "Can only download results for select queries!")
             }


### PR DESCRIPTION
## Summary
- Add null-safe operators (`?.`) to `CCJSqlParserUtil.parseStatements()` calls in `csvDownloadAllowed()` method
- Prevents `NullPointerException` when parser returns null for malformed SQL queries

## Changes
- `backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt:314`: Added `?.size ?: 0` for statement count
- `backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt:320`: Added `?.first()` for statement type check

## Test plan
- Verify CSV download validation handles invalid SQL without crashing
- Test with malformed queries that cause parser to return null
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add null-safe operators to prevent null pointer exceptions in SQL parser validation in `ExecutionRequest.kt`.
> 
>   - **Behavior**:
>     - Add null-safe operators (`?.`) to `CCJSqlParserUtil.parseStatements()` in `csvDownloadAllowed()` to prevent `NullPointerException` for malformed SQL.
>   - **Code Changes**:
>     - `ExecutionRequest.kt:314`: Use `?.size ?: 0` for statement count.
>     - `ExecutionRequest.kt:320`: Use `?.first()` for statement type check.
>   - **Test Plan**:
>     - Ensure CSV download validation handles invalid SQL without crashing.
>     - Test with malformed queries causing parser to return null.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for ed7f51dc236bd514a6b8fe97e4a635a672b18058. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->