### PR TITLE
Fix pending requests toggle filtering

### DIFF
--- a/frontend/src/routes/Requests.tsx
+++ b/frontend/src/routes/Requests.tsx
@@ -95,6 +95,7 @@ const useRequests = (onlyPending: boolean, searchTerm: string) => {
 
       const response = await getRequestsPaginated({
         reviewStatuses: onlyPending ? ["AWAITING_APPROVAL"] : undefined,
+        executionStatuses: onlyPending ? ["EXECUTABLE", "ACTIVE"] : undefined,
         after: reset ? undefined : cursor ?? undefined,
         limit: 20,
       });


### PR DESCRIPTION
## Summary
- add execution status filter to pending toggle query so executed rows are excluded

## Testing
- not run (UI-only change)

Fixes #387
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds execution status filter to exclude executed requests when pending toggle is active in `Requests.tsx`.
> 
>   - **Behavior**:
>     - Adds `executionStatuses` filter to `getRequestsPaginated` call in `useRequests` in `Requests.tsx` to exclude executed requests when `onlyPending` is true.
>   - **Testing**:
>     - No tests run; UI-only change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for af94f4b77ff3517f8550e4cb2336f79548ff169a. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->