### PR TITLE
Fix WebSocket sessions in Docker container

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/Config.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/Config.kt
@@ -39,11 +39,9 @@ class WebSocketConfig : WebSocketConfigurer {
     lateinit var corsSettings: CorsSettings
 
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
-        val handlerRegistry = registry.addHandler(sessionWebsocketHandler, "/sql/{requestId}")
+        registry.addHandler(sessionWebsocketHandler, "/sql/{requestId}")
             .addInterceptors(AuthHandshakeInterceptor())
-        if (corsSettings.allowedOrigins.isNotEmpty()) {
-            handlerRegistry.setAllowedOrigins(*corsSettings.allowedOrigins.toTypedArray())
-        }
+            .setAllowedOriginPatterns("*")
     }
 }
 

--- a/frontend/docker/nginx/conf.d/default.conf
+++ b/frontend/docker/nginx/conf.d/default.conf
@@ -1,4 +1,3 @@
-# Map to handle WebSocket upgrades conditionally
 map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix WebSocket session handling in Docker by updating CORS settings in `Config.kt` and adding WebSocket support in `default.conf`.
> 
>   - **Backend**:
>     - In `Config.kt`, simplified CORS settings for WebSocket handlers by replacing `setAllowedOrigins` with `setAllowedOriginPatterns("*")`.
>   - **Frontend**:
>     - In `default.conf`, added WebSocket support by setting `proxy_http_version 1.1` and configuring `Upgrade` and `Connection` headers.
>     - Added `proxy_read_timeout 86400` to keep WebSocket connections alive.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 6b94f06fcb0010c90aa4a258602a17883ed11e3d. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->