### PR TITLE
Fix websocket debouncing to prevent state resets while typing

### DIFF
--- a/frontend/src/api/LiveSessionApi.ts
+++ b/frontend/src/api/LiveSessionApi.ts
@@ -32,6 +32,7 @@ const executeEventResponseSchema = withType(
 const updateContentMessage = z.object({
   type: z.literal("update_content"),
   content: z.string(),
+  ref: z.string(),
 });
 
 const executeStatementMessage = z.object({
@@ -48,6 +49,7 @@ const statusMessage = z.object({
   sessionId: z.string(),
   consoleContent: z.string(),
   observers: z.array(userResponseSchema),
+  ref: z.string(),
 });
 
 const resultMessage = z.object({

--- a/frontend/src/routes/LiveSessionWebsockets.tsx
+++ b/frontend/src/routes/LiveSessionWebsockets.tsx
@@ -62,7 +62,20 @@ const LiveSessionWebsockets: React.FC<LiveSessionWebsocketsProps> = ({
     updatedRows,
     results,
     websocketEvents,
+    isSyncing,
   } = useLiveSession(requestId, updateEditorContent);
+
+  const [showSynced, setShowSynced] = useState(false);
+
+  useEffect(() => {
+    if (!isSyncing && showSynced) {
+      // Just finished syncing, show green briefly then fade
+      const timer = setTimeout(() => setShowSynced(false), 1500);
+      return () => clearTimeout(timer);
+    } else if (isSyncing) {
+      setShowSynced(true);
+    }
+  }, [isSyncing]);
 
   const { request } = useRequest(requestId);
 
@@ -122,11 +135,26 @@ const LiveSessionWebsockets: React.FC<LiveSessionWebsocketsProps> = ({
   return (
     <div className="flex h-full flex-col">
       <div className="mx-auto flex h-full w-2/3 flex-col">
-        <div
-          className="my-5 h-64 resize-y overflow-auto"
-          data-testid="monaco-editor-wrapper"
-        >
-          <div className="h-full w-full" ref={monacoEl}></div>
+        <div className="relative my-5">
+          {(isSyncing || showSynced) && (
+            <div
+              className={`absolute -top-5 right-0 text-xs transition-opacity duration-500 ${
+                isSyncing
+                  ? "animate-pulse text-gray-500 dark:text-gray-400"
+                  : showSynced
+                  ? "text-green-500"
+                  : "opacity-0"
+              }`}
+            >
+              {isSyncing ? "..." : "✓"}
+            </div>
+          )}
+          <div
+            className="h-64 resize-y overflow-auto"
+            data-testid="monaco-editor-wrapper"
+          >
+            <div className="h-full w-full" ref={monacoEl}></div>
+          </div>
         </div>
         <div className="mb-4 flex flex-row">
           {request?._type === "DATASOURCE" && isRelationalDatabase(request) && (


### PR DESCRIPTION
## Summary

Fixed two bugs causing poor typing experience in live sessions:
- Debounce function was recreated on every render, breaking the 300ms delay
- Status messages from backend were resetting editor state while typing

## Test Plan

- [x] TypeScript type checking passing
- [x] All 22 frontend tests passing  
- [ ] Manual testing: Type slowly and quickly without interruptions
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix websocket debouncing and prevent editor state resets by tracking message origins with `ref` in backend and frontend.
> 
>   - **Behavior**:
>     - Fix debouncing in `useLiveSession.ts` by using `useMemo` to ensure debounce function is stable across renders.
>     - Add `ref` to `UpdateContentMessage` and `StatusMessage` in `SessionWebsocketHandler.kt` to track message origins and prevent state resets.
>     - Ignore echoed messages in `useLiveSession.ts` by checking `ref` in `handleWebSocketMessage()`.
>   - **Frontend**:
>     - Update `LiveSessionApi.ts` to include `ref` in `updateContentMessage` and `statusMessage` schemas.
>     - Add syncing indicator in `LiveSessionWebsockets.tsx` to show when content is syncing.
>   - **Backend**:
>     - Modify `broadcastUpdate()` in `SessionWebsocketHandler.kt` to include `ref` parameter.
>     - Update `handleTextMessage()` in `SessionWebsocketHandler.kt` to pass `ref` when broadcasting updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 80fa37da632ee9c182530d3a03e4ae184632946c. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->