### PR TITLE
Restart kubernetes pod after applying deployment change

### DIFF
--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -62,3 +62,6 @@ jobs:
             --namespace kviklet \
             --create-namespace \
             --wait
+
+      - name: Restart deployment to pull latest image
+        run: kubectl rollout restart deployment/kviklet-demo -n kviklet


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a step to restart the `kviklet-demo` deployment in `.github/workflows/deploy-demo.yaml` to ensure the latest image is used.
> 
>   - **Behavior**:
>     - Adds a step in `.github/workflows/deploy-demo.yaml` to restart the `kviklet-demo` deployment using `kubectl rollout restart` after applying deployment changes.
>   - **Purpose**:
>     - Ensures the Kubernetes pod uses the latest image by restarting the deployment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 970689bf0bb17ee8ea01057ffc55eb84e403fe5e. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->