### PR TITLE
Add KVIKLET_BASE_URL documentation for notification links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -377,7 +377,7 @@ Currently there are notifications for:
 
 #### Base URL Configuration
 
-When running Kviklet behind a reverse proxy or Kubernetes Ingress, notification links may use the internal IP address instead of your public domain. Kviklet tries to track the correct URL by looking at incoming requests but some rverser proxies do not set the Forwarded headers correctly. To fix this, set the base URL explicitly:
+When running Kviklet behind a reverse proxy or Kubernetes Ingress, notification links may use the internal IP address instead of your public domain. Kviklet tries to track the correct URL by looking at incoming requests but some reverse proxies do not set the Forwarded headers correctly. To fix this, set the base URL explicitly:
 
 ```
 KVIKLET_BASE_URL=https://kviklet.example.com


### PR DESCRIPTION
## Summary
- Documents the existing `KVIKLET_BASE_URL` environment variable in the Notifications section of the README
- Helps users running Kviklet behind reverse proxies or Kubernetes Ingress configure the correct public URL for notification links

## Context
The functionality to set a custom base URL already exists (`kviklet.baseUrl` property / `KVIKLET_BASE_URL` env var) but was undocumented. Users behind reverse proxies may see notification links with internal Pod IPs instead of their public domain.

Fixes #398
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds documentation for `KVIKLET_BASE_URL` in `Readme.md` to guide users in setting the correct public URL for notification links.
> 
>   - **Documentation**:
>     - Adds documentation for `KVIKLET_BASE_URL` in `Readme.md` under Notifications section.
>     - Guides users to set the base URL for correct notification links when using reverse proxies or Kubernetes Ingress.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 21fe61cf7046e8c83c18f942a24ce2662bd0ff6d. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->