### PR TITLE
Fix license file loading to prefer newest valid

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConfigController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConfigController.kt
@@ -53,7 +53,7 @@ data class ConfigResponse(
             samlEnabled: Boolean,
             licenses: List<License>,
         ): ConfigResponse {
-            val licensesSorted = licenses.sortedByDescending { it.validUntil }
+            val licensesSorted = licenses.sortedByDescending { it.file.createdAt }
             return ConfigResponse(
                 oAuthProvider = oAuthProvider,
                 ldapEnabled = ldapEnabled,
@@ -87,7 +87,7 @@ class ConfigController(
     @GetMapping("/")
     fun getConfig(): PublicConfigResponse {
         val licenses = licenseService.getLicenses()
-        val licensesSorted = licenses.sortedByDescending { it.validUntil }
+        val licensesSorted = licenses.sortedByDescending { it.file.createdAt }
         try {
             val config = configService.getConfiguration()
             return ConfigResponse.fromConfiguration(

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/LicenseService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/LicenseService.kt
@@ -78,7 +78,7 @@ class LicenseService(private val licenseAdapter: LicenseAdapter) {
     }
 
     @NoPolicy
-    fun getActiveLicense(): License? = getLicenses().filter { it.isValid() }.maxByOrNull { it.validUntil }
+    fun getActiveLicense(): License? = getLicenses().filter { it.isValid() }.maxByOrNull { it.file.createdAt }
 }
 
 class InvalidLicenseException(message: String, e: Exception? = null) : IllegalArgumentException(message, e)


### PR DESCRIPTION
Change license selection logic to use file.createdAt instead of validUntil, so the most recently uploaded license is always preferred.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change license selection logic to prefer the most recently uploaded license using `file.createdAt`.
> 
>   - **Behavior**:
>     - Change license selection logic in `ConfigController` and `LicenseService` to use `file.createdAt` instead of `validUntil`.
>     - Ensures the most recently uploaded license is preferred.
>   - **Functions**:
>     - Update `getConfig()` in `ConfigController` to sort licenses by `file.createdAt`.
>     - Update `getActiveLicense()` in `LicenseService` to use `file.createdAt` for determining the active license.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 7f0d41cc62211a6cba53dda5888aa9b764a7ed61. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->