### PR TITLE
Fix new optional fields  breaking temporary access requests

### DIFF
--- a/frontend/src/api/ExecutionRequestApi.ts
+++ b/frontend/src/api/ExecutionRequestApi.ts
@@ -75,9 +75,10 @@ const QueryResultLog = z.object({
         typeClass: z.string(),
       }),
     )
-    .optional(),
-  storedRows: z.array(z.record(z.coerce.string())).optional(),
-  storedRowCount: z.number().optional(),
+    .optional()
+    .nullable(),
+  storedRows: z.array(z.record(z.coerce.string())).optional().nullable(),
+  storedRowCount: z.number().optional().nullable(),
 });
 
 const KubernetesOutputResultLog = z.object({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes issue with optional fields in `QueryResultLog` by making them nullable to prevent errors in temporary access requests.
> 
>   - **Behavior**:
>     - Fixes issue with optional fields in `QueryResultLog` in `ExecutionRequestApi.ts` by making `columns`, `storedRows`, and `storedRowCount` nullable.
>     - Ensures temporary access requests do not break when these fields are absent.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kviklet%2Fkviklet&utm_source=github&utm_medium=referral)<sup> for 1c1b5c906b350b93f70b2cbc66d34ce8cbb3b60a. You can [customize](https://app.ellipsis.dev/kviklet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->