### PR TITLE
Fix live session layout issues and mobile responsiveness

### DIFF
--- a/frontend/src/components/MultiResult.tsx
+++ b/frontend/src/components/MultiResult.tsx
@@ -24,7 +24,7 @@ const MultiResult: FC<{ resultList: ExecuteResponseResult[] }> = ({
   const selectedContent = resultList[currentIndex];
   return (
     <div
-      className="flex w-screen flex-col justify-center"
+      className="flex w-full flex-col justify-center"
       data-testid="result-component"
     >
       {resultList.length > 1 && (

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -37,7 +37,7 @@ const Table: FC<{ data: SelectExecuteResponse }> = ({ data }) => {
   return (
     <div
       className={`block max-h-[calc(100vh-theme(spacing.32))] overflow-y-scroll px-2 font-thin ${
-        selected ? "w-screen" : "w-full"
+        selected ? "relative left-1/2 w-screen -translate-x-1/2" : "w-full"
       } my-4 shrink-0 rounded border border-slate-300 shadow-md transition-width dark:border-slate-700 dark:shadow-none`}
     >
       <table className="w-full text-left">

--- a/frontend/src/routes/LiveSessionWebsockets.tsx
+++ b/frontend/src/routes/LiveSessionWebsockets.tsx
@@ -133,8 +133,8 @@ const LiveSessionWebsockets: React.FC<LiveSessionWebsocketsProps> = ({
   };
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="mx-auto flex h-full w-2/3 flex-col">
+    <div className="flex h-full flex-col overflow-x-hidden">
+      <div className="mx-auto flex h-full w-full max-w-5xl flex-col px-4">
         <div className="relative my-5">
           {(isSyncing || showSynced) && (
             <div
@@ -150,15 +150,15 @@ const LiveSessionWebsockets: React.FC<LiveSessionWebsocketsProps> = ({
             </div>
           )}
           <div
-            className="h-64 resize-y overflow-auto"
+            className="h-40 resize-y overflow-auto sm:h-64"
             data-testid="monaco-editor-wrapper"
           >
             <div className="h-full w-full" ref={monacoEl}></div>
           </div>
         </div>
-        <div className="mb-4 flex flex-row">
+        <div className="mb-4 flex flex-row items-center justify-end gap-2">
           {request?._type === "DATASOURCE" && isRelationalDatabase(request) && (
-            <a className="ml-auto mr-2" href="#" onClick={handleCsvDownload}>
+            <a href="#" onClick={handleCsvDownload}>
               <Button>Download as CSV</Button>
             </a>
           )}


### PR DESCRIPTION
## Summary
- Fix Run Query button layout shift when Download CSV button loads asynchronously (use `justify-end` + `gap-2`)
- Contain result table within parent container instead of spanning full viewport (`w-screen` → `w-full` on MultiResult)
- Restore table expand/collapse functionality with CSS breakout technique (`relative left-1/2 -translate-x-1/2`)
- Make page responsive with `max-w-5xl` + `px-4` instead of fixed `w-2/3`
- Reduce editor height on mobile (`h-40` on small screens, `sm:h-64` on larger)