### PR TITLE
Overhaul spinner with indigo color and context-aware sizes

### DIFF
--- a/frontend/src/components/Spinner.tsx
+++ b/frontend/src/components/Spinner.tsx
@@ -1,9 +1,17 @@
 import React from "react";
 
-const Spinner: React.FC = () => {
+const sizeClasses = {
+  sm: "h-5 w-5 border-2",
+  md: "h-8 w-8 border-[3px]",
+  lg: "h-12 w-12 border-4",
+};
+
+const Spinner: React.FC<{ size?: "sm" | "md" | "lg" }> = ({ size = "md" }) => {
   return (
     <div className="flex items-center justify-center">
-      <div className="h-32 w-32 animate-spin rounded-full border-b-2 border-t-2 border-purple-500"></div>
+      <div
+        className={`${sizeClasses[size]} animate-spin rounded-full border-indigo-500 border-r-transparent`}
+      ></div>
     </div>
   );
 };

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -112,7 +112,7 @@ const Login = () => {
 
   return (
     <div>
-      {(loading && <Spinner></Spinner>) || (
+      {(loading && <Spinner size="lg" />) || (
         <div className="mx-auto my-2 mt-6 max-w-sm dark:bg-slate-950">
           <div className="text-center">
             <img

--- a/frontend/src/routes/NewRequest.tsx
+++ b/frontend/src/routes/NewRequest.tsx
@@ -235,7 +235,7 @@ export default function ConnectionChooser() {
       </div>
       <div className="mx-auto mt-5 flex max-w-5xl">
         {loading ? (
-          <Spinner></Spinner>
+          <Spinner size="lg" />
         ) : (
           <div className="w-full">
             <Disclosure defaultOpen={true}>
@@ -715,7 +715,7 @@ const KubernetesExecutionRequestForm = ({
 
   return (
     <div className="mx-auto w-full">
-      {(loading && <Spinner></Spinner>) || (
+      {(loading && <Spinner size="lg" />) || (
         <form
           className="mx-auto w-full"
           onSubmit={(event) => void handleSubmit(onSubmit)(event)}

--- a/frontend/src/routes/Requests.tsx
+++ b/frontend/src/routes/Requests.tsx
@@ -257,7 +257,7 @@ function Requests() {
           </div>
         </div>
       </div>
-      {(loading && <Spinner></Spinner>) || (
+      {(loading && <Spinner size="lg" />) || (
         <div
           className="h-full bg-slate-50 dark:bg-slate-950"
           data-testid="requests-list"
@@ -353,7 +353,7 @@ function Requests() {
             {/* Loading more indicator */}
             {loadingMore && (
               <div className="my-4 flex justify-center">
-                <Spinner />
+                <Spinner size="sm" />
               </div>
             )}
           </div>

--- a/frontend/src/routes/Review/index.tsx
+++ b/frontend/src/routes/Review/index.tsx
@@ -40,7 +40,7 @@ function RequestReview() {
 
   return (
     <div>
-      {(loading && <Spinner />) ||
+      {(loading && <Spinner size="lg" />) ||
         (request && (
           <div className="m-auto mt-10 max-w-3xl">
             <h1 className="my-2 flex w-full items-start text-3xl">

--- a/frontend/src/routes/settings/GeneralSettings.tsx
+++ b/frontend/src/routes/settings/GeneralSettings.tsx
@@ -27,7 +27,7 @@ export default function GeneralSettings() {
     <div>
       <h1 className="mb-2 text-lg">General Settings</h1>
       {loading ? (
-        <Spinner />
+        <Spinner size="lg" />
       ) : (
         config && (
           <div>

--- a/frontend/src/routes/settings/LicenseSettings.tsx
+++ b/frontend/src/routes/settings/LicenseSettings.tsx
@@ -16,7 +16,7 @@ export default function LicenseSettings() {
     <div>
       <div className="mx-auto max-w-7xl">
         {!config ? (
-          <Spinner />
+          <Spinner size="lg" />
         ) : (
           <div className="flex flex-col gap-y-2">
             <LicenseInfo license={config} userCount={users.length.toString()} />

--- a/frontend/src/routes/settings/RoleDetailsView.tsx
+++ b/frontend/src/routes/settings/RoleDetailsView.tsx
@@ -29,7 +29,7 @@ export default function RoleDetailsView() {
       <div className="mb-3 border-b border-slate-300 dark:border-slate-700">
         <h1 className="text-xl">{role && role.name}</h1>
       </div>
-      {loading && <Spinner></Spinner>}
+      {loading && <Spinner size="lg" />}
       {role && (
         <RoleForm role={transformRole(role)} onSubmit={submit}></RoleForm>
       )}

--- a/frontend/src/routes/settings/RoleSyncSettings.tsx
+++ b/frontend/src/routes/settings/RoleSyncSettings.tsx
@@ -69,7 +69,7 @@ export default function RoleSyncSettings() {
     : false;
 
   if (loading || rolesLoading) {
-    return <Spinner />;
+    return <Spinner size="lg" />;
   }
 
   if (!config) {

--- a/frontend/src/routes/settings/connection/DatabaseConnectionForm.tsx
+++ b/frontend/src/routes/settings/connection/DatabaseConnectionForm.tsx
@@ -725,7 +725,7 @@ const TestingConnectionFragment = (props: {
 
   return (
     <div className="flex-col">
-      {isTestingConnection && <Spinner />}
+      {isTestingConnection && <Spinner size="sm" />}
       {!isTestingConnection && testConnectionResponse && (
         <div className="flex flex-col space-y-2">
           <div>

--- a/frontend/src/routes/settings/connection/details/ConnectionDetails.tsx
+++ b/frontend/src/routes/settings/connection/details/ConnectionDetails.tsx
@@ -30,7 +30,7 @@ export default function ConnectionDetails() {
   };
 
   if (loading) {
-    return <Spinner />;
+    return <Spinner size="lg" />;
   }
 
   if (!connection) {


### PR DESCRIPTION
## Summary
- Redesign Spinner component: modern 3/4 arc in indigo (was oversized 128px purple top/bottom border ring)
- Add size variants (`sm`/`md`/`lg`) with contextual sizing across all 15 usages:
  - `lg` (48px): full-page loading states (login, settings, request pages)
  - `md` (32px): section-level loading like query results (default)
  - `sm` (20px): compact indicators (pagination load-more, connection testing)