### PR TITLE
Improve timestamp visibility and add date-range filtering

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
@@ -689,8 +689,12 @@ class ExecutionRequestController(val executionRequestService: ExecutionRequestSe
         @RequestParam(required = false) connectionId: ConnectionId?,
         @RequestParam(required = false) after: Instant?,
         @RequestParam(required = false, defaultValue = "${Int.MAX_VALUE}") limit: Int,
+        @RequestParam(required = false) createdBefore: Instant?,
+        @RequestParam(required = false) createdAfter: Instant?,
     ): ExecutionRequestListResponse {
         val afterLocalDateTime = after?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
+        val createdBeforeLocalDateTime = createdBefore?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
+        val createdAfterLocalDateTime = createdAfter?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
 
         return ExecutionRequestListResponse.fromDto(
             executionRequestService.list(
@@ -699,6 +703,8 @@ class ExecutionRequestController(val executionRequestService: ExecutionRequestSe
                 connectionId = connectionId,
                 after = afterLocalDateTime,
                 limit = limit,
+                createdBefore = createdBeforeLocalDateTime,
+                createdAfter = createdAfterLocalDateTime,
             ),
         )
     }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/ExecutionRequest.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/ExecutionRequest.kt
@@ -146,6 +146,8 @@ interface CustomExecutionRequestRepository {
         connectionId: ConnectionId?,
         after: LocalDateTime?,
         limit: Int,
+        createdBefore: LocalDateTime? = null,
+        createdAfter: LocalDateTime? = null,
     ): List<ExecutionRequestEntity>
 }
 
@@ -177,6 +179,8 @@ class CustomExecutionRequestRepositoryImpl(private val entityManager: EntityMana
         connectionId: ConnectionId?,
         after: LocalDateTime?,
         limit: Int,
+        createdBefore: LocalDateTime?,
+        createdAfter: LocalDateTime?,
     ): List<ExecutionRequestEntity> {
         val query = JPAQuery<ExecutionRequestEntity>(entityManager)
             .from(qExecutionRequestEntity)
@@ -204,6 +208,14 @@ class CustomExecutionRequestRepositoryImpl(private val entityManager: EntityMana
         // Apply cursor-based pagination
         after?.let {
             query.where(qExecutionRequestEntity.createdAt.lt(it))
+        }
+
+        // Apply date-range filters
+        createdAfter?.let {
+            query.where(qExecutionRequestEntity.createdAt.goe(it))
+        }
+        createdBefore?.let {
+            query.where(qExecutionRequestEntity.createdAt.loe(it))
         }
 
         // Order and limit
@@ -380,12 +392,16 @@ class ExecutionRequestAdapter(
         connectionId: ConnectionId? = null,
         after: LocalDateTime? = null,
         limit: Int = Int.MAX_VALUE,
+        createdBefore: LocalDateTime? = null,
+        createdAfter: LocalDateTime? = null,
     ): List<ExecutionRequestDetails> = executionRequestRepository.findAllWithDetailsFiltered(
         reviewStatuses = reviewStatuses,
         executionStatuses = executionStatuses,
         connectionId = connectionId,
         after = after,
         limit = limit,
+        createdBefore = createdBefore,
+        createdAfter = createdAfter,
     ).map {
         it.toDetailDto(connectionAdapter.toDto(it.connection))
     }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -361,6 +361,8 @@ class ExecutionRequestService(
         connectionId: ConnectionId?,
         after: LocalDateTime?,
         limit: Int = 20,
+        createdBefore: LocalDateTime? = null,
+        createdAfter: LocalDateTime? = null,
     ): ExecutionRequestList {
         // Fetch limit + 1 to determine if there are more results, but avoid Int overflow
         val fetchLimit = if (limit == Int.MAX_VALUE) {
@@ -375,6 +377,8 @@ class ExecutionRequestService(
             connectionId = connectionId,
             after = after,
             limit = fetchLimit,
+            createdBefore = createdBefore,
+            createdAfter = createdAfter,
         ).map { ensureMaterializedStatuses(it) }
 
         val hasMore = requests.size > limit

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionRequestPaginationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionRequestPaginationTest.kt
@@ -318,6 +318,171 @@ class ExecutionRequestPaginationTest {
     }
 
     @Nested
+    inner class DateRangeFilterTests {
+
+        @Test
+        fun `createdAfter parameter returns only requests created on or after the given timestamp`() {
+            val cookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+            val req1 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            Thread.sleep(10)
+            val req2 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            Thread.sleep(10)
+            val req3 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+
+            val createdAfterTimestamp = req2.request.createdAt.atZone(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT)
+
+            // Should return req2 and req3 (created on or after req2's timestamp)
+            mockMvc.perform(
+                get("/execution-requests/")
+                    .param("createdAfter", createdAfterTimestamp)
+                    .cookie(cookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(2)))
+                .andExpect(jsonPath("$.requests[0].id").value(req3.getId()))
+                .andExpect(jsonPath("$.requests[1].id").value(req2.getId()))
+        }
+
+        @Test
+        fun `createdBefore parameter returns only requests created on or before the given timestamp`() {
+            val cookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+            val req1 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            Thread.sleep(10)
+            val req2 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            Thread.sleep(10)
+            val req3 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+
+            val createdBeforeTimestamp = req2.request.createdAt.atZone(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT)
+
+            // Should return req1 and req2 (created on or before req2's timestamp)
+            mockMvc.perform(
+                get("/execution-requests/")
+                    .param("createdBefore", createdBeforeTimestamp)
+                    .cookie(cookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(2)))
+                .andExpect(jsonPath("$.requests[0].id").value(req2.getId()))
+                .andExpect(jsonPath("$.requests[1].id").value(req1.getId()))
+        }
+
+        @Test
+        fun `createdAfter and createdBefore together define a date range window`() {
+            val cookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+            val req1 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            Thread.sleep(10)
+            val req2 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            Thread.sleep(10)
+            val req3 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            Thread.sleep(10)
+            val req4 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            Thread.sleep(10)
+            val req5 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+
+            val createdAfterTimestamp = req2.request.createdAt.atZone(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT)
+            val createdBeforeTimestamp = req4.request.createdAt.atZone(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT)
+
+            // Should return req2, req3, req4 (within the date range)
+            mockMvc.perform(
+                get("/execution-requests/")
+                    .param("createdAfter", createdAfterTimestamp)
+                    .param("createdBefore", createdBeforeTimestamp)
+                    .cookie(cookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(3)))
+                .andExpect(jsonPath("$.requests[0].id").value(req4.getId()))
+                .andExpect(jsonPath("$.requests[1].id").value(req3.getId()))
+                .andExpect(jsonPath("$.requests[2].id").value(req2.getId()))
+        }
+
+        @Test
+        fun `date range filter works with cursor pagination`() {
+            val cookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+            val requests = mutableListOf<ExecutionRequestDetails>()
+            repeat(5) {
+                requests.add(executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection))
+                Thread.sleep(10)
+            }
+
+            val createdAfterTimestamp = requests[0].request.createdAt.atZone(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT)
+            val createdBeforeTimestamp = requests[4].request.createdAt.atZone(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT)
+
+            // First page with limit=2 and date range covering all 5
+            val firstPage = mockMvc.perform(
+                get("/execution-requests/")
+                    .param("createdAfter", createdAfterTimestamp)
+                    .param("createdBefore", createdBeforeTimestamp)
+                    .param("limit", "2")
+                    .cookie(cookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(2)))
+                .andExpect(jsonPath("$.hasMore").value(true))
+                .andReturn()
+
+            val cursorRaw = com.jayway.jsonpath.JsonPath.read<String>(
+                firstPage.response.contentAsString,
+                "$.cursor",
+            )
+            val cursor = java.time.LocalDateTime.parse(cursorRaw)
+                .atZone(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT)
+
+            // Second page with cursor + date range
+            mockMvc.perform(
+                get("/execution-requests/")
+                    .param("createdAfter", createdAfterTimestamp)
+                    .param("createdBefore", createdBeforeTimestamp)
+                    .param("after", cursor)
+                    .param("limit", "2")
+                    .cookie(cookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(2)))
+                .andExpect(jsonPath("$.hasMore").value(true))
+        }
+
+        @Test
+        fun `date range filter works with status filters`() {
+            val cookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+            val reviewer = userHelper.createUser(permissions = listOf("*"))
+            val reviewerCookie = userHelper.login(email = reviewer.email, mockMvc = mockMvc)
+
+            val req1 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            Thread.sleep(10)
+            val req2 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            Thread.sleep(10)
+            val req3 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+
+            // Approve req2
+            approveRequest(req2.getId(), "Approved", reviewerCookie)
+
+            val createdAfterTimestamp = req1.request.createdAt.atZone(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT)
+            val createdBeforeTimestamp = req3.request.createdAt.atZone(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT)
+
+            // Filter for AWAITING_APPROVAL within date range (should be req1 and req3)
+            mockMvc.perform(
+                get("/execution-requests/")
+                    .param("createdAfter", createdAfterTimestamp)
+                    .param("createdBefore", createdBeforeTimestamp)
+                    .param("reviewStatuses", "AWAITING_APPROVAL")
+                    .cookie(cookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(2)))
+                .andExpect(jsonPath("$.requests[0].id").value(req3.getId()))
+                .andExpect(jsonPath("$.requests[1].id").value(req1.getId()))
+        }
+    }
+
+    @Nested
     inner class AuthorizationFilteringTests {
 
         @Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
   #    - ./mssql-data:/var/opt/mssql
 
   ldap:
-    image: osixia/openldap:1.1.8
+    image: osixia/openldap:1.5.0
     ports:
       - "389:389"
     environment:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5620,17 +5620,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9547,20 +9536,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {
   UserStatusProvider,
 } from "./components/UserStatusProvider";
 import { ThemeStatusProvider } from "./components/ThemeStatusProvider";
+import { TimezoneProvider } from "./components/TimezoneProvider";
 import ConnectionChooser from "./routes/NewRequest";
 import Auditlog from "./routes/Auditlog";
 import { NotificationContextProvider } from "./components/NotifcationStatusProvider";
@@ -38,8 +39,9 @@ function App() {
     <div className="min-h-screen bg-slate-50 text-slate-900 transition-colors dark:bg-slate-950 dark:text-slate-50">
       <UserStatusProvider>
         <ThemeStatusProvider>
-          <NotificationContextProvider>
-            <ConfigProvider>
+          <TimezoneProvider>
+            <NotificationContextProvider>
+              <ConfigProvider>
               <Routes>
                 <Route path="/" element={<DefaultLayout />}>
                   <Route
@@ -101,8 +103,9 @@ function App() {
                   <Route path="login" element={<Login />} />
                 </Route>
               </Routes>
-            </ConfigProvider>
-          </NotificationContextProvider>
+              </ConfigProvider>
+            </NotificationContextProvider>
+          </TimezoneProvider>
         </ThemeStatusProvider>
       </UserStatusProvider>
     </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,67 +42,67 @@ function App() {
           <TimezoneProvider>
             <NotificationContextProvider>
               <ConfigProvider>
-              <Routes>
-                <Route path="/" element={<DefaultLayout />}>
-                  <Route
-                    index
-                    element={
-                      <ProtectedRoute>
-                        <Requests />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="settings/*"
-                    element={
-                      <ProtectedRoute>
-                        <Settings />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="new"
-                    element={
-                      <ProtectedRoute>
-                        <ConnectionChooser></ConnectionChooser>
-                      </ProtectedRoute>
-                    }
-                  ></Route>
-                  <Route
-                    path="requests"
-                    element={
-                      <ProtectedRoute>
-                        <Requests />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="auditlog"
-                    element={
-                      <ProtectedRoute>
-                        <Auditlog />
-                      </ProtectedRoute>
-                    }
-                  ></Route>
-                  <Route
-                    path="requests/:requestId"
-                    element={
-                      <ProtectedRoute>
-                        <RequestReview />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="requests/:requestId/session"
-                    element={
-                      <ProtectedRoute>
-                        <LiveSessionWebsockets />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route path="login" element={<Login />} />
-                </Route>
-              </Routes>
+                <Routes>
+                  <Route path="/" element={<DefaultLayout />}>
+                    <Route
+                      index
+                      element={
+                        <ProtectedRoute>
+                          <Requests />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="settings/*"
+                      element={
+                        <ProtectedRoute>
+                          <Settings />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="new"
+                      element={
+                        <ProtectedRoute>
+                          <ConnectionChooser></ConnectionChooser>
+                        </ProtectedRoute>
+                      }
+                    ></Route>
+                    <Route
+                      path="requests"
+                      element={
+                        <ProtectedRoute>
+                          <Requests />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="auditlog"
+                      element={
+                        <ProtectedRoute>
+                          <Auditlog />
+                        </ProtectedRoute>
+                      }
+                    ></Route>
+                    <Route
+                      path="requests/:requestId"
+                      element={
+                        <ProtectedRoute>
+                          <RequestReview />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="requests/:requestId/session"
+                      element={
+                        <ProtectedRoute>
+                          <LiveSessionWebsockets />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route path="login" element={<Login />} />
+                  </Route>
+                </Routes>
               </ConfigProvider>
             </NotificationContextProvider>
           </TimezoneProvider>

--- a/frontend/src/api/ExecutionRequestApi.ts
+++ b/frontend/src/api/ExecutionRequestApi.ts
@@ -312,6 +312,8 @@ interface GetRequestsParams {
   connectionId?: string;
   after?: Date;
   limit?: number;
+  createdBefore?: Date;
+  createdAfter?: Date;
 }
 
 const getRequestsPaginated = async (
@@ -341,6 +343,14 @@ const getRequestsPaginated = async (
 
   if (params?.limit) {
     searchParams.append("limit", params.limit.toString());
+  }
+
+  if (params?.createdBefore) {
+    searchParams.append("createdBefore", params.createdBefore.toISOString());
+  }
+
+  if (params?.createdAfter) {
+    searchParams.append("createdAfter", params.createdAfter.toISOString());
   }
 
   const url = searchParams.toString()

--- a/frontend/src/components/TimezoneProvider.tsx
+++ b/frontend/src/components/TimezoneProvider.tsx
@@ -1,0 +1,37 @@
+import React, { useCallback, useState } from "react";
+
+type TimezoneMode = "local" | "utc";
+
+type TimezoneContext = {
+  timezone: TimezoneMode;
+  setTimezone(tz: TimezoneMode): void;
+};
+
+const TimezoneStatusContext = React.createContext<TimezoneContext>({
+  timezone: "local",
+  setTimezone: () => {},
+});
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const TimezoneProvider: React.FC<Props> = ({ children }) => {
+  const stored =
+    (localStorage.getItem("timezone") as TimezoneMode) || "local";
+  const [timezone, setTimezoneState] = useState<TimezoneMode>(stored);
+
+  const setTimezone = useCallback((tz: TimezoneMode) => {
+    localStorage.setItem("timezone", tz);
+    setTimezoneState(tz);
+  }, []);
+
+  return (
+    <TimezoneStatusContext.Provider value={{ timezone, setTimezone }}>
+      {children}
+    </TimezoneStatusContext.Provider>
+  );
+};
+
+export { TimezoneStatusContext };
+export type { TimezoneMode, TimezoneContext };

--- a/frontend/src/components/TimezoneProvider.tsx
+++ b/frontend/src/components/TimezoneProvider.tsx
@@ -17,8 +17,7 @@ type Props = {
 };
 
 export const TimezoneProvider: React.FC<Props> = ({ children }) => {
-  const stored =
-    (localStorage.getItem("timezone") as TimezoneMode) || "local";
+  const stored = (localStorage.getItem("timezone") as TimezoneMode) || "local";
   const [timezone, setTimezoneState] = useState<TimezoneMode>(stored);
 
   const setTimezone = useCallback((tz: TimezoneMode) => {

--- a/frontend/src/hooks/useTimezone.ts
+++ b/frontend/src/hooks/useTimezone.ts
@@ -1,0 +1,15 @@
+import { useContext } from "react";
+import { TimezoneStatusContext } from "../components/TimezoneProvider";
+import { formatAbsoluteTime } from "../utils/timeFormat";
+
+function useTimezone() {
+  const { timezone, setTimezone } = useContext(TimezoneStatusContext);
+
+  const formatTime = (date: Date): string => {
+    return formatAbsoluteTime(date, timezone);
+  };
+
+  return { timezone, setTimezone, formatTime };
+}
+
+export default useTimezone;

--- a/frontend/src/hooks/useTimezone.ts
+++ b/frontend/src/hooks/useTimezone.ts
@@ -1,15 +1,22 @@
-import { useContext } from "react";
+import { useContext, useCallback } from "react";
 import { TimezoneStatusContext } from "../components/TimezoneProvider";
+import type { TimezoneMode } from "../components/TimezoneProvider";
 import { formatAbsoluteTime } from "../utils/timeFormat";
 
 function useTimezone() {
-  const { timezone, setTimezone } = useContext(TimezoneStatusContext);
+  const ctx = useContext(TimezoneStatusContext);
 
-  const formatTime = (date: Date): string => {
-    return formatAbsoluteTime(date, timezone);
-  };
+  const formatTime = useCallback(
+    (date: Date): string => formatAbsoluteTime(date, ctx.timezone),
+    [ctx.timezone],
+  );
 
-  return { timezone, setTimezone, formatTime };
+  const setTimezone = useCallback(
+    (tz: TimezoneMode) => ctx.setTimezone(tz),
+    [ctx],
+  );
+
+  return { timezone: ctx.timezone, setTimezone, formatTime };
 }
 
 export default useTimezone;

--- a/frontend/src/routes/Auditlog.tsx
+++ b/frontend/src/routes/Auditlog.tsx
@@ -24,7 +24,7 @@ import {
   exportExecutions,
 } from "../api/ExecutionsApi";
 import { ChangeEvent, useEffect, useState } from "react";
-import { timeSince } from "./Requests";
+import { formatAbsoluteTime } from "../utils/timeFormat";
 import { isApiErrorResponse } from "../api/Errors";
 import SearchInput from "../components/SearchInput";
 import Button from "../components/Button";
@@ -208,7 +208,7 @@ function Item({ execution }: { execution: ExecutionLogResponse }) {
             <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">
               Executed{" "}
               <time dateTime={execution.executionTime.toISOString()}>
-                {timeSince(execution.executionTime)}
+                {formatAbsoluteTime(execution.executionTime)}
               </time>
             </p>
           </div>

--- a/frontend/src/routes/Auditlog.tsx
+++ b/frontend/src/routes/Auditlog.tsx
@@ -206,7 +206,7 @@ function Item({ execution }: { execution: ExecutionLogResponse }) {
             <span className="inline-flex flex-shrink-0 items-center rounded-full bg-green-50 px-1.5 py-0.5 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20 dark:bg-green-400/10 dark:text-green-400">
               {execution.connectionId}
             </span>
-            <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">
+            <p className="mt-1 text-xs leading-5">
               Executed{" "}
               <time dateTime={execution.executionTime.toISOString()}>
                 {formatTime(execution.executionTime)}

--- a/frontend/src/routes/Auditlog.tsx
+++ b/frontend/src/routes/Auditlog.tsx
@@ -24,7 +24,7 @@ import {
   exportExecutions,
 } from "../api/ExecutionsApi";
 import { ChangeEvent, useEffect, useState } from "react";
-import { formatAbsoluteTime } from "../utils/timeFormat";
+import useTimezone from "../hooks/useTimezone";
 import { isApiErrorResponse } from "../api/Errors";
 import SearchInput from "../components/SearchInput";
 import Button from "../components/Button";
@@ -182,6 +182,7 @@ function ItemSkeleton() {
 }
 
 function Item({ execution }: { execution: ExecutionLogResponse }) {
+  const { formatTime } = useTimezone();
   return (
     <Link to={`/requests/${execution.requestId}`}>
       <li
@@ -208,7 +209,7 @@ function Item({ execution }: { execution: ExecutionLogResponse }) {
             <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">
               Executed{" "}
               <time dateTime={execution.executionTime.toISOString()}>
-                {formatAbsoluteTime(execution.executionTime)}
+                {formatTime(execution.executionTime)}
               </time>
             </p>
           </div>

--- a/frontend/src/routes/Requests.tsx
+++ b/frontend/src/routes/Requests.tsx
@@ -17,7 +17,7 @@ import useNotification from "../hooks/useNotification";
 import Toggle from "../components/Toggle";
 import SearchInput from "../components/SearchInput";
 import Tooltip from "../components/Tooltip";
-import { formatAbsoluteTime, timeSince } from "../utils/timeFormat";
+import useTimezone from "../hooks/useTimezone";
 
 function mapStatus(reviewStatus: string, executionStatus: string) {
   if (reviewStatus === "AWAITING_APPROVAL" && executionStatus !== "EXECUTED")
@@ -200,6 +200,7 @@ function Requests() {
   const [searchTerm, setSearchTerm] = useState("");
   const [dateFrom, setDateFrom] = useState<Date | null>(null);
   const [dateTo, setDateTo] = useState<Date | null>(null);
+  const { timezone, formatTime } = useTimezone();
   const { requests, loading, loadingMore, hasMore, loadMore } = useRequests(
     onlyPending,
     searchTerm,
@@ -267,7 +268,10 @@ function Requests() {
               onChange={(e) =>
                 setDateFrom(
                   e.target.value
-                    ? new Date(e.target.value + "T00:00:00")
+                    ? new Date(
+                        e.target.value +
+                          (timezone === "utc" ? "T00:00:00Z" : "T00:00:00"),
+                      )
                     : null,
                 )
               }
@@ -282,7 +286,10 @@ function Requests() {
               onChange={(e) =>
                 setDateTo(
                   e.target.value
-                    ? new Date(e.target.value + "T23:59:59")
+                    ? new Date(
+                        e.target.value +
+                          (timezone === "utc" ? "T23:59:59Z" : "T23:59:59"),
+                      )
                     : null,
                 )
               }
@@ -340,14 +347,9 @@ function Requests() {
                           <h2 className="truncate text-sm font-medium">
                             {request.title}
                           </h2>
-                          <Tooltip
-                            position="bottom"
-                            content={timeSince(new Date(request.createdAt))}
-                          >
-                            <span className="shrink-0 text-xs text-slate-400 dark:text-slate-500">
-                              {formatAbsoluteTime(new Date(request.createdAt))}
-                            </span>
-                          </Tooltip>
+                          <span className="shrink-0 text-xs text-slate-400 dark:text-slate-500">
+                            {formatTime(new Date(request.createdAt))}
+                          </span>
                         </div>
                         <p className="mt-0.5 flex flex-wrap items-center gap-1 text-sm text-slate-500 dark:text-slate-400">
                           <span className="truncate font-medium text-slate-600 dark:text-slate-300">

--- a/frontend/src/routes/Requests.tsx
+++ b/frontend/src/routes/Requests.tsx
@@ -10,34 +10,14 @@ import {
   CircleStackIcon,
   ClockIcon,
   CloudIcon,
+  XMarkIcon,
 } from "@heroicons/react/20/solid";
 import { isApiErrorResponse } from "../api/Errors";
 import useNotification from "../hooks/useNotification";
 import Toggle from "../components/Toggle";
 import SearchInput from "../components/SearchInput";
 import Tooltip from "../components/Tooltip";
-
-function timeSince(date: Date) {
-  const seconds =
-    Math.floor((new Date().getTime() - date.getTime()) / 1000) +
-    new Date().getTimezoneOffset() * 60;
-
-  const units: [number, string][] = [
-    [31536000, "year"],
-    [2592000, "month"],
-    [86400, "day"],
-    [3600, "hour"],
-    [60, "minute"],
-  ];
-
-  for (const [divisor, unit] of units) {
-    const value = Math.floor(seconds / divisor);
-    if (value > 0) {
-      return `${value} ${unit}${value !== 1 ? "s" : ""} ago`;
-    }
-  }
-  return Math.floor(seconds) + " seconds ago";
-}
+import { formatAbsoluteTime, timeSince } from "../utils/timeFormat";
 
 function mapStatus(reviewStatus: string, executionStatus: string) {
   if (reviewStatus === "AWAITING_APPROVAL" && executionStatus !== "EXECUTED")
@@ -115,7 +95,12 @@ function shortTypeLabel(type: string) {
   }
 }
 
-const useRequests = (onlyPending: boolean, searchTerm: string) => {
+const useRequests = (
+  onlyPending: boolean,
+  searchTerm: string,
+  dateFrom: Date | null,
+  dateTo: Date | null,
+) => {
   const [requests, setRequests] = useState<ExecutionRequestResponse[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [loadingMore, setLoadingMore] = useState<boolean>(false);
@@ -139,6 +124,8 @@ const useRequests = (onlyPending: boolean, searchTerm: string) => {
         executionStatuses: onlyPending ? ["EXECUTABLE", "ACTIVE"] : undefined,
         after: reset ? undefined : cursor ?? undefined,
         limit: 20,
+        createdAfter: dateFrom ?? undefined,
+        createdBefore: dateTo ?? undefined,
       });
 
       if (isApiErrorResponse(response)) {
@@ -165,7 +152,7 @@ const useRequests = (onlyPending: boolean, searchTerm: string) => {
 
   useEffect(() => {
     void loadRequests(true);
-  }, [onlyPending]);
+  }, [onlyPending, dateFrom, dateTo]);
 
   const loadMore = useCallback(() => {
     if (!loadingMore && hasMore) {
@@ -200,14 +187,27 @@ const useRequests = (onlyPending: boolean, searchTerm: string) => {
   };
 };
 
+function toDateInputValue(date: Date | null): string {
+  if (!date) return "";
+  const y = date.getFullYear();
+  const m = (date.getMonth() + 1).toString().padStart(2, "0");
+  const d = date.getDate().toString().padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
 function Requests() {
   const [onlyPending, setOnlyPending] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
+  const [dateFrom, setDateFrom] = useState<Date | null>(null);
+  const [dateTo, setDateTo] = useState<Date | null>(null);
   const { requests, loading, loadingMore, hasMore, loadMore } = useRequests(
     onlyPending,
     searchTerm,
+    dateFrom,
+    dateTo,
   );
   const observerTarget = useRef<HTMLDivElement>(null);
+  const hasDateFilter = dateFrom !== null || dateTo !== null;
 
   // Infinite scroll observer
   useEffect(() => {
@@ -234,26 +234,72 @@ function Requests() {
   return (
     <div className="h-full">
       <div className="border-b border-slate-300 bg-slate-50 dark:border-slate-700 dark:bg-slate-950">
-        <div className="mx-auto flex max-w-3xl flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <h1 className="text-xl font-medium">Open Requests</h1>
-          <div className="flex items-center gap-3">
-            <SearchInput
-              value={searchTerm}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                setSearchTerm(e.target.value)
+        <div className="mx-auto flex max-w-3xl flex-col gap-3 px-4 py-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h1 className="text-xl font-medium">Open Requests</h1>
+            <div className="flex items-center gap-3">
+              <SearchInput
+                value={searchTerm}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setSearchTerm(e.target.value)
+                }
+                placeholder="Search requests..."
+                className="w-full sm:w-64"
+              />
+              <Tooltip position="bottom" content="Show only pending requests">
+                <div className="flex shrink-0 items-center">
+                  <ClockIcon className="mr-2 h-5 w-5 text-slate-400" />
+                  <Toggle
+                    active={onlyPending}
+                    onClick={() => setOnlyPending(!onlyPending)}
+                  />
+                </div>
+              </Tooltip>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <label className="text-xs text-slate-500 dark:text-slate-400">
+              From
+            </label>
+            <input
+              type="date"
+              value={toDateInputValue(dateFrom)}
+              onChange={(e) =>
+                setDateFrom(
+                  e.target.value
+                    ? new Date(e.target.value + "T00:00:00")
+                    : null,
+                )
               }
-              placeholder="Search requests..."
-              className="w-full sm:w-64"
+              className="rounded-md border border-slate-300 bg-white px-2 py-1 text-sm text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300"
             />
-            <Tooltip position="bottom" content="Show only pending requests">
-              <div className="flex shrink-0 items-center">
-                <ClockIcon className="mr-2 h-5 w-5 text-slate-400" />
-                <Toggle
-                  active={onlyPending}
-                  onClick={() => setOnlyPending(!onlyPending)}
-                />
-              </div>
-            </Tooltip>
+            <label className="text-xs text-slate-500 dark:text-slate-400">
+              To
+            </label>
+            <input
+              type="date"
+              value={toDateInputValue(dateTo)}
+              onChange={(e) =>
+                setDateTo(
+                  e.target.value
+                    ? new Date(e.target.value + "T23:59:59")
+                    : null,
+                )
+              }
+              className="rounded-md border border-slate-300 bg-white px-2 py-1 text-sm text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300"
+            />
+            {hasDateFilter && (
+              <button
+                onClick={() => {
+                  setDateFrom(null);
+                  setDateTo(null);
+                }}
+                className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-xs text-slate-500 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700"
+              >
+                <XMarkIcon className="h-3.5 w-3.5" />
+                Clear
+              </button>
+            )}
           </div>
         </div>
       </div>
@@ -294,15 +340,14 @@ function Requests() {
                           <h2 className="truncate text-sm font-medium">
                             {request.title}
                           </h2>
-                          <span
-                            className="shrink-0 text-xs text-slate-400 dark:text-slate-500"
-                            title={
-                              new Date(request.createdAt).toLocaleString() +
-                              " UTC"
-                            }
+                          <Tooltip
+                            position="bottom"
+                            content={timeSince(new Date(request.createdAt))}
                           >
-                            {timeSince(new Date(request.createdAt))}
-                          </span>
+                            <span className="shrink-0 text-xs text-slate-400 dark:text-slate-500">
+                              {formatAbsoluteTime(new Date(request.createdAt))}
+                            </span>
+                          </Tooltip>
                         </div>
                         <p className="mt-0.5 flex flex-wrap items-center gap-1 text-sm text-slate-500 dark:text-slate-400">
                           <span className="truncate font-medium text-slate-600 dark:text-slate-300">
@@ -363,4 +408,4 @@ function Requests() {
   );
 }
 
-export { Requests, mapStatusToLabelColor, mapStatus, timeSince };
+export { Requests, mapStatusToLabelColor, mapStatus };

--- a/frontend/src/routes/Requests.tsx
+++ b/frontend/src/routes/Requests.tsx
@@ -39,7 +39,7 @@ function mapStatusToLabelColor(status?: string) {
     case "Active":
       return "dark:ring-sky-400/10 dark:text-sky-500 ring-sky-500/10 text-sky-600 bg-sky-50 dark:bg-sky-400/10";
     case "Executed":
-      return "dark:ring-lime-400/10 dark:text-lime-500 ring-lime-500/10 text-lime-600 bg-lime-50 dark:bg-lime-400/10";
+      return "dark:ring-slate-400/10 dark:text-slate-400 ring-slate-500/10 text-slate-500 bg-slate-50 dark:bg-slate-400/10";
     case "Change Requested":
       return "dark:ring-red-400/10 dark:text-red-500 ring-red-500/10 text-red-600 bg-red-50 dark:bg-red-400/10";
     case "Rejected":
@@ -51,8 +51,9 @@ function mapStatusToLabelColor(status?: string) {
 function mapStatusToBorderColor(status?: string) {
   switch (status) {
     case "Ready":
-    case "Executed":
       return "border-l-lime-500 dark:border-l-lime-500";
+    case "Executed":
+      return "border-l-slate-400 dark:border-l-slate-500";
     case "Pending":
       return "border-l-yellow-500 dark:border-l-yellow-500";
     case "Active":
@@ -68,8 +69,9 @@ function mapStatusToBorderColor(status?: string) {
 function mapStatusToTextColor(status?: string) {
   switch (status) {
     case "Ready":
-    case "Executed":
       return "text-lime-600 dark:text-lime-500";
+    case "Executed":
+      return "text-slate-500 dark:text-slate-400";
     case "Pending":
       return "text-yellow-600 dark:text-yellow-500";
     case "Active":
@@ -347,7 +349,7 @@ function Requests() {
                           <h2 className="truncate text-sm font-medium">
                             {request.title}
                           </h2>
-                          <span className="shrink-0 text-xs text-slate-400 dark:text-slate-500">
+                          <span className="shrink-0 text-xs">
                             {formatTime(new Date(request.createdAt))}
                           </span>
                         </div>

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -5,7 +5,8 @@ import {
   streamDump,
 } from "../../api/ExecutionRequestApi";
 import Button from "../../components/Button";
-import { timeSince } from "../Requests";
+import { formatAbsoluteTime, timeSince } from "../../utils/timeFormat";
+import Tooltip from "../../components/Tooltip";
 import { AbsoluteInitialBubble as InitialBubble } from "../../components/InitialBubble";
 import MenuDropDown from "../../components/MenuDropdown";
 import baseUrl from "../../api/base";
@@ -242,9 +243,14 @@ function DatasourceRequestBox({
               {request?.author?.fullName + questionText}
               <span className="italic">{request?.connection.displayName}</span>
             </div>
-            <div className="ml-auto dark:text-slate-500">
-              {timeSince(new Date(request?.createdAt ?? ""))}
-            </div>
+            <Tooltip
+              position="bottom"
+              content={timeSince(new Date(request?.createdAt ?? ""))}
+            >
+              <span className="ml-auto dark:text-slate-500">
+                {formatAbsoluteTime(new Date(request?.createdAt ?? ""))}
+              </span>
+            </Tooltip>
           </div>
           <div className="py-3">
             <p className="pb-6 text-slate-500">{request?.description}</p>

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -5,8 +5,7 @@ import {
   streamDump,
 } from "../../api/ExecutionRequestApi";
 import Button from "../../components/Button";
-import { formatAbsoluteTime, timeSince } from "../../utils/timeFormat";
-import Tooltip from "../../components/Tooltip";
+import useTimezone from "../../hooks/useTimezone";
 import { AbsoluteInitialBubble as InitialBubble } from "../../components/InitialBubble";
 import MenuDropDown from "../../components/MenuDropdown";
 import baseUrl from "../../api/base";
@@ -33,6 +32,7 @@ function DatasourceRequestBox({
 }) {
   const [editMode, setEditMode] = useState(false);
   const { addNotification } = useNotification();
+  const { formatTime } = useTimezone();
   const [showSQLDumpModal, setShowSQLDumpModal] = useState(false);
   const navigate = useNavigate();
   const [statement, setStatement] = useState(request?.statement || "");
@@ -243,14 +243,9 @@ function DatasourceRequestBox({
               {request?.author?.fullName + questionText}
               <span className="italic">{request?.connection.displayName}</span>
             </div>
-            <Tooltip
-              position="bottom"
-              content={timeSince(new Date(request?.createdAt ?? ""))}
-            >
-              <span className="ml-auto dark:text-slate-500">
-                {formatAbsoluteTime(new Date(request?.createdAt ?? ""))}
-              </span>
-            </Tooltip>
+            <span className="ml-auto dark:text-slate-500">
+              {formatTime(new Date(request?.createdAt ?? ""))}
+            </span>
           </div>
           <div className="py-3">
             <p className="pb-6 text-slate-500">{request?.description}</p>

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -243,7 +243,7 @@ function DatasourceRequestBox({
               {request?.author?.fullName + questionText}
               <span className="italic">{request?.connection.displayName}</span>
             </div>
-            <span className="ml-auto dark:text-slate-500">
+            <span className="ml-auto">
               {formatTime(new Date(request?.createdAt ?? ""))}
             </span>
           </div>

--- a/frontend/src/routes/Review/KubernetesRequestBox.tsx
+++ b/frontend/src/routes/Review/KubernetesRequestBox.tsx
@@ -73,7 +73,7 @@ const KubernetesRequestBox: FC<KubernetesRequestBoxProps> = ({
               in:
               <span className="italic"> {request?.connection.displayName}</span>
             </div>
-            <span className="ml-auto dark:text-slate-500">
+            <span className="ml-auto">
               {formatTime(new Date(request?.createdAt ?? ""))}
             </span>
           </div>

--- a/frontend/src/routes/Review/KubernetesRequestBox.tsx
+++ b/frontend/src/routes/Review/KubernetesRequestBox.tsx
@@ -2,7 +2,8 @@ import { useNavigate } from "react-router-dom";
 
 import { KubernetesExecutionRequestResponseWithComments } from "../../api/ExecutionRequestApi";
 import Button from "../../components/Button";
-import { timeSince } from "../Requests";
+import { formatAbsoluteTime, timeSince } from "../../utils/timeFormat";
+import Tooltip from "../../components/Tooltip";
 import MenuDropDown from "../../components/MenuDropdown";
 import { Highlighter } from "./components/Highlighter";
 import { FC, useEffect, useState, MouseEvent } from "react";
@@ -72,9 +73,14 @@ const KubernetesRequestBox: FC<KubernetesRequestBoxProps> = ({
               in:
               <span className="italic"> {request?.connection.displayName}</span>
             </div>
-            <div className="ml-auto dark:text-slate-500">
-              {timeSince(new Date(request?.createdAt ?? ""))}
-            </div>
+            <Tooltip
+              position="bottom"
+              content={timeSince(new Date(request?.createdAt ?? ""))}
+            >
+              <span className="ml-auto dark:text-slate-500">
+                {formatAbsoluteTime(new Date(request?.createdAt ?? ""))}
+              </span>
+            </Tooltip>
           </div>
           <div className="px-4 py-3">
             <p className="pb-6 text-slate-500">{request?.description}</p>

--- a/frontend/src/routes/Review/KubernetesRequestBox.tsx
+++ b/frontend/src/routes/Review/KubernetesRequestBox.tsx
@@ -2,8 +2,7 @@ import { useNavigate } from "react-router-dom";
 
 import { KubernetesExecutionRequestResponseWithComments } from "../../api/ExecutionRequestApi";
 import Button from "../../components/Button";
-import { formatAbsoluteTime, timeSince } from "../../utils/timeFormat";
-import Tooltip from "../../components/Tooltip";
+import useTimezone from "../../hooks/useTimezone";
 import MenuDropDown from "../../components/MenuDropdown";
 import { Highlighter } from "./components/Highlighter";
 import { FC, useEffect, useState, MouseEvent } from "react";
@@ -23,6 +22,7 @@ const KubernetesRequestBox: FC<KubernetesRequestBoxProps> = ({
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [command, setCommand] = useState(request?.command || "");
+  const { formatTime } = useTimezone();
 
   const navigate = useNavigate();
 
@@ -73,14 +73,9 @@ const KubernetesRequestBox: FC<KubernetesRequestBoxProps> = ({
               in:
               <span className="italic"> {request?.connection.displayName}</span>
             </div>
-            <Tooltip
-              position="bottom"
-              content={timeSince(new Date(request?.createdAt ?? ""))}
-            >
-              <span className="ml-auto dark:text-slate-500">
-                {formatAbsoluteTime(new Date(request?.createdAt ?? ""))}
-              </span>
-            </Tooltip>
+            <span className="ml-auto dark:text-slate-500">
+              {formatTime(new Date(request?.createdAt ?? ""))}
+            </span>
           </div>
           <div className="px-4 py-3">
             <p className="pb-6 text-slate-500">{request?.description}</p>

--- a/frontend/src/routes/Review/events/Comment.tsx
+++ b/frontend/src/routes/Review/events/Comment.tsx
@@ -3,7 +3,8 @@ import {
   Review,
   Comment as CommentEvent,
 } from "../../../api/ExecutionRequestApi";
-import { timeSince } from "../../Requests";
+import { formatAbsoluteTime, timeSince } from "../../../utils/timeFormat";
+import Tooltip from "../../../components/Tooltip";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { solid } from "@fortawesome/fontawesome-svg-core/import.macro";
 import { AbsoluteInitialBubble as InitialBubble } from "../../../components/InitialBubble";
@@ -50,11 +51,18 @@ function Comment({
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <div>
-            {((event?.createdAt && timeSince(event.createdAt)) as
-              | string
-              | undefined) || ""}
-          </div>
+          <Tooltip
+            position="bottom"
+            content={
+              event?.createdAt ? timeSince(event.createdAt) : ""
+            }
+          >
+            <span>
+              {event?.createdAt
+                ? formatAbsoluteTime(event.createdAt)
+                : ""}
+            </span>
+          </Tooltip>
         </p>
         <div className="rounded-b-md px-4 py-3 dark:bg-slate-900">
           <ReactMarkdown components={componentMap}>

--- a/frontend/src/routes/Review/events/Comment.tsx
+++ b/frontend/src/routes/Review/events/Comment.tsx
@@ -50,7 +50,7 @@ function Comment({
       </div>
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
-        <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
+        <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-900 dark:bg-slate-900 dark:text-slate-50">
           <span>
             {event?.createdAt
               ? formatTime(event.createdAt)

--- a/frontend/src/routes/Review/events/Comment.tsx
+++ b/frontend/src/routes/Review/events/Comment.tsx
@@ -3,8 +3,7 @@ import {
   Review,
   Comment as CommentEvent,
 } from "../../../api/ExecutionRequestApi";
-import { formatAbsoluteTime, timeSince } from "../../../utils/timeFormat";
-import Tooltip from "../../../components/Tooltip";
+import useTimezone from "../../../hooks/useTimezone";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { solid } from "@fortawesome/fontawesome-svg-core/import.macro";
 import { AbsoluteInitialBubble as InitialBubble } from "../../../components/InitialBubble";
@@ -17,6 +16,7 @@ function Comment({
   event: Review | CommentEvent;
   index: number;
 }) {
+  const { formatTime } = useTimezone();
   return (
     <div>
       <div className="relative ml-4 flex py-4">
@@ -51,18 +51,11 @@ function Comment({
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <Tooltip
-            position="bottom"
-            content={
-              event?.createdAt ? timeSince(event.createdAt) : ""
-            }
-          >
-            <span>
-              {event?.createdAt
-                ? formatAbsoluteTime(event.createdAt)
-                : ""}
-            </span>
-          </Tooltip>
+          <span>
+            {event?.createdAt
+              ? formatTime(event.createdAt)
+              : ""}
+          </span>
         </p>
         <div className="rounded-b-md px-4 py-3 dark:bg-slate-900">
           <ReactMarkdown components={componentMap}>

--- a/frontend/src/routes/Review/events/Comment.tsx
+++ b/frontend/src/routes/Review/events/Comment.tsx
@@ -51,11 +51,7 @@ function Comment({
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-900 dark:bg-slate-900 dark:text-slate-50">
-          <span>
-            {event?.createdAt
-              ? formatTime(event.createdAt)
-              : ""}
-          </span>
+          <span>{event?.createdAt ? formatTime(event.createdAt) : ""}</span>
         </p>
         <div className="rounded-b-md px-4 py-3 dark:bg-slate-900">
           <ReactMarkdown components={componentMap}>

--- a/frontend/src/routes/Review/events/EditEvent.tsx
+++ b/frontend/src/routes/Review/events/EditEvent.tsx
@@ -1,5 +1,6 @@
 import { Edit } from "../../../api/ExecutionRequestApi";
-import { timeSince } from "../../Requests";
+import { formatAbsoluteTime, timeSince } from "../../../utils/timeFormat";
+import Tooltip from "../../../components/Tooltip";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { solid } from "@fortawesome/fontawesome-svg-core/import.macro";
 import { AbsoluteInitialBubble as InitialBubble } from "../../../components/InitialBubble";
@@ -30,11 +31,18 @@ function EditEvent({ event, index }: { event: Edit; index: number }) {
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <div className="mr-4">
-            {((event?.createdAt && timeSince(event.createdAt)) as
-              | string
-              | undefined) || ""}
-          </div>
+          <Tooltip
+            position="bottom"
+            content={
+              event?.createdAt ? timeSince(event.createdAt) : ""
+            }
+          >
+            <span className="mr-4">
+              {event?.createdAt
+                ? formatAbsoluteTime(event.createdAt)
+                : ""}
+            </span>
+          </Tooltip>
           {event?.previousQuery && (
             <div>
               <p>Previous Statement</p>

--- a/frontend/src/routes/Review/events/EditEvent.tsx
+++ b/frontend/src/routes/Review/events/EditEvent.tsx
@@ -1,12 +1,12 @@
 import { Edit } from "../../../api/ExecutionRequestApi";
-import { formatAbsoluteTime, timeSince } from "../../../utils/timeFormat";
-import Tooltip from "../../../components/Tooltip";
+import useTimezone from "../../../hooks/useTimezone";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { solid } from "@fortawesome/fontawesome-svg-core/import.macro";
 import { AbsoluteInitialBubble as InitialBubble } from "../../../components/InitialBubble";
 import { Highlighter } from "../components/Highlighter";
 
 function EditEvent({ event, index }: { event: Edit; index: number }) {
+  const { formatTime } = useTimezone();
   return (
     <div>
       <div className="relative ml-4 flex py-4">
@@ -31,18 +31,11 @@ function EditEvent({ event, index }: { event: Edit; index: number }) {
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <Tooltip
-            position="bottom"
-            content={
-              event?.createdAt ? timeSince(event.createdAt) : ""
-            }
-          >
-            <span className="mr-4">
-              {event?.createdAt
-                ? formatAbsoluteTime(event.createdAt)
-                : ""}
-            </span>
-          </Tooltip>
+          <span className="mr-4">
+            {event?.createdAt
+              ? formatTime(event.createdAt)
+              : ""}
+          </span>
           {event?.previousQuery && (
             <div>
               <p>Previous Statement</p>

--- a/frontend/src/routes/Review/events/EditEvent.tsx
+++ b/frontend/src/routes/Review/events/EditEvent.tsx
@@ -32,9 +32,7 @@ function EditEvent({ event, index }: { event: Edit; index: number }) {
         <InitialBubble name={event?.author?.fullName} />
         <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-900 dark:bg-slate-900 dark:text-slate-50">
           <span className="mr-4">
-            {event?.createdAt
-              ? formatTime(event.createdAt)
-              : ""}
+            {event?.createdAt ? formatTime(event.createdAt) : ""}
           </span>
           {event?.previousQuery && (
             <div>

--- a/frontend/src/routes/Review/events/EditEvent.tsx
+++ b/frontend/src/routes/Review/events/EditEvent.tsx
@@ -30,7 +30,7 @@ function EditEvent({ event, index }: { event: Edit; index: number }) {
       </div>
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
-        <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
+        <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-900 dark:bg-slate-900 dark:text-slate-50">
           <span className="mr-4">
             {event?.createdAt
               ? formatTime(event.createdAt)

--- a/frontend/src/routes/Review/events/ExecuteEvent.tsx
+++ b/frontend/src/routes/Review/events/ExecuteEvent.tsx
@@ -67,9 +67,7 @@ function ExecuteEvent({
         <InitialBubble name={event?.author?.fullName} />
         <div className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-900 dark:bg-slate-900 dark:text-slate-50">
           <span className="mr-4">
-            {event?.createdAt
-              ? formatTime(event.createdAt)
-              : ""}
+            {event?.createdAt ? formatTime(event.createdAt) : ""}
           </span>
         </div>
         {event?.query && (

--- a/frontend/src/routes/Review/events/ExecuteEvent.tsx
+++ b/frontend/src/routes/Review/events/ExecuteEvent.tsx
@@ -65,7 +65,7 @@ function ExecuteEvent({
       </div>
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:bg-slate-900 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
-        <div className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
+        <div className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-900 dark:bg-slate-900 dark:text-slate-50">
           <span className="mr-4">
             {event?.createdAt
               ? formatTime(event.createdAt)

--- a/frontend/src/routes/Review/events/ExecuteEvent.tsx
+++ b/frontend/src/routes/Review/events/ExecuteEvent.tsx
@@ -1,6 +1,7 @@
 import { Execute } from "../../../api/ExecutionRequestApi";
 import { DatabaseType } from "../../../api/DatasourceApi";
-import { timeSince } from "../../Requests";
+import { formatAbsoluteTime, timeSince } from "../../../utils/timeFormat";
+import Tooltip from "../../../components/Tooltip";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { solid } from "@fortawesome/fontawesome-svg-core/import.macro";
 import { AbsoluteInitialBubble as InitialBubble } from "../../../components/InitialBubble";
@@ -65,11 +66,18 @@ function ExecuteEvent({
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:bg-slate-900 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <div className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <div className="mr-4">
-            {((event?.createdAt && timeSince(event.createdAt)) as
-              | string
-              | undefined) || ""}
-          </div>
+          <Tooltip
+            position="bottom"
+            content={
+              event?.createdAt ? timeSince(event.createdAt) : ""
+            }
+          >
+            <span className="mr-4">
+              {event?.createdAt
+                ? formatAbsoluteTime(event.createdAt)
+                : ""}
+            </span>
+          </Tooltip>
         </div>
         {event?.query && (
           <div className="rounded-b-md px-4 py-3 dark:bg-slate-900">

--- a/frontend/src/routes/Review/events/ExecuteEvent.tsx
+++ b/frontend/src/routes/Review/events/ExecuteEvent.tsx
@@ -1,7 +1,6 @@
 import { Execute } from "../../../api/ExecutionRequestApi";
 import { DatabaseType } from "../../../api/DatasourceApi";
-import { formatAbsoluteTime, timeSince } from "../../../utils/timeFormat";
-import Tooltip from "../../../components/Tooltip";
+import useTimezone from "../../../hooks/useTimezone";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { solid } from "@fortawesome/fontawesome-svg-core/import.macro";
 import { AbsoluteInitialBubble as InitialBubble } from "../../../components/InitialBubble";
@@ -19,6 +18,7 @@ function ExecuteEvent({
   index: number;
   connectionType?: DatabaseType;
 }) {
+  const { formatTime } = useTimezone();
   const isDownload = event.isDownload || false;
   const sqlStatementText = isDownload
     ? "downloaded the results for the following statement:"
@@ -66,18 +66,11 @@ function ExecuteEvent({
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:bg-slate-900 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <div className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <Tooltip
-            position="bottom"
-            content={
-              event?.createdAt ? timeSince(event.createdAt) : ""
-            }
-          >
-            <span className="mr-4">
-              {event?.createdAt
-                ? formatAbsoluteTime(event.createdAt)
-                : ""}
-            </span>
-          </Tooltip>
+          <span className="mr-4">
+            {event?.createdAt
+              ? formatTime(event.createdAt)
+              : ""}
+          </span>
         </div>
         {event?.query && (
           <div className="rounded-b-md px-4 py-3 dark:bg-slate-900">

--- a/frontend/src/routes/Review/events/ReviewEvent.tsx
+++ b/frontend/src/routes/Review/events/ReviewEvent.tsx
@@ -1,6 +1,5 @@
 import ReactMarkdown from "react-markdown";
-import { formatAbsoluteTime, timeSince } from "../../../utils/timeFormat";
-import Tooltip from "../../../components/Tooltip";
+import useTimezone from "../../../hooks/useTimezone";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { solid } from "@fortawesome/fontawesome-svg-core/import.macro";
 import { AbsoluteInitialBubble as InitialBubble } from "../../../components/InitialBubble";
@@ -9,6 +8,7 @@ import { componentMap } from "../components/Highlighter";
 import { ReactElement } from "react";
 
 function ReviewEvent({ event, index }: { event: Review; index: number }) {
+  const { formatTime } = useTimezone();
   const notificationText = (): ReactElement => {
     switch (event.action) {
       case "APPROVE":
@@ -80,18 +80,11 @@ function ReviewEvent({ event, index }: { event: Review; index: number }) {
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <Tooltip
-            position="bottom"
-            content={
-              event?.createdAt ? timeSince(event.createdAt) : ""
-            }
-          >
-            <span>
-              {event?.createdAt
-                ? formatAbsoluteTime(event.createdAt)
-                : ""}
-            </span>
-          </Tooltip>
+          <span>
+            {event?.createdAt
+              ? formatTime(event.createdAt)
+              : ""}
+          </span>
         </p>
         <div className="rounded-b-md px-4 py-3 dark:bg-slate-900">
           <ReactMarkdown components={componentMap}>

--- a/frontend/src/routes/Review/events/ReviewEvent.tsx
+++ b/frontend/src/routes/Review/events/ReviewEvent.tsx
@@ -80,11 +80,7 @@ function ReviewEvent({ event, index }: { event: Review; index: number }) {
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-900 dark:bg-slate-900 dark:text-slate-50">
-          <span>
-            {event?.createdAt
-              ? formatTime(event.createdAt)
-              : ""}
-          </span>
+          <span>{event?.createdAt ? formatTime(event.createdAt) : ""}</span>
         </p>
         <div className="rounded-b-md px-4 py-3 dark:bg-slate-900">
           <ReactMarkdown components={componentMap}>

--- a/frontend/src/routes/Review/events/ReviewEvent.tsx
+++ b/frontend/src/routes/Review/events/ReviewEvent.tsx
@@ -1,5 +1,6 @@
 import ReactMarkdown from "react-markdown";
-import { timeSince } from "../../Requests";
+import { formatAbsoluteTime, timeSince } from "../../../utils/timeFormat";
+import Tooltip from "../../../components/Tooltip";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { solid } from "@fortawesome/fontawesome-svg-core/import.macro";
 import { AbsoluteInitialBubble as InitialBubble } from "../../../components/InitialBubble";
@@ -79,11 +80,18 @@ function ReviewEvent({ event, index }: { event: Review; index: number }) {
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <div>
-            {((event?.createdAt && timeSince(event.createdAt)) as
-              | string
-              | undefined) || ""}
-          </div>
+          <Tooltip
+            position="bottom"
+            content={
+              event?.createdAt ? timeSince(event.createdAt) : ""
+            }
+          >
+            <span>
+              {event?.createdAt
+                ? formatAbsoluteTime(event.createdAt)
+                : ""}
+            </span>
+          </Tooltip>
         </p>
         <div className="rounded-b-md px-4 py-3 dark:bg-slate-900">
           <ReactMarkdown components={componentMap}>

--- a/frontend/src/routes/Review/events/ReviewEvent.tsx
+++ b/frontend/src/routes/Review/events/ReviewEvent.tsx
@@ -79,7 +79,7 @@ function ReviewEvent({ event, index }: { event: Review; index: number }) {
       </div>
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
-        <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
+        <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-900 dark:bg-slate-900 dark:text-slate-50">
           <span>
             {event?.createdAt
               ? formatTime(event.createdAt)

--- a/frontend/src/routes/settings/ProfileSettings.tsx
+++ b/frontend/src/routes/settings/ProfileSettings.tsx
@@ -5,6 +5,8 @@ import { updateUser } from "../../api/UserApi";
 import { UserStatusContext } from "../../components/UserStatusProvider";
 import { isApiErrorResponse } from "../../api/Errors";
 import useNotification from "../../hooks/useNotification";
+import useTimezone from "../../hooks/useTimezone";
+import { localTimezoneLabel } from "../../utils/timeFormat";
 
 function ProfileSettings() {
   const [newPassword, setNewPassword] = useState<string>("");
@@ -32,8 +34,40 @@ function ProfileSettings() {
     }
   };
 
+  const { timezone, setTimezone } = useTimezone();
+
   return (
     <div>
+      <div className="mb-6">
+        <div className="mb-2 text-sm font-medium text-slate-900 dark:text-slate-50">
+          Timezone
+        </div>
+        <p className="mb-3 text-sm text-slate-500 dark:text-slate-400">
+          Choose how timestamps are displayed across the application.
+        </p>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setTimezone("local")}
+            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              timezone === "local"
+                ? "bg-indigo-800 text-white"
+                : "bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+            }`}
+          >
+            Local (UTC{localTimezoneLabel()})
+          </button>
+          <button
+            onClick={() => setTimezone("utc")}
+            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              timezone === "utc"
+                ? "bg-indigo-800 text-white"
+                : "bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+            }`}
+          >
+            UTC
+          </button>
+        </div>
+      </div>
       <div>
         <div>Change Password</div>
         <label

--- a/frontend/src/utils/timeFormat.ts
+++ b/frontend/src/utils/timeFormat.ts
@@ -1,0 +1,37 @@
+function pad(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
+function formatAbsoluteTime(date: Date): string {
+  const tz = -date.getTimezoneOffset();
+  const sign = tz >= 0 ? "+" : "-";
+  const absH = pad(Math.floor(Math.abs(tz) / 60));
+  const absM = pad(Math.abs(tz) % 60);
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}` +
+    `${sign}${absH}:${absM}`
+  );
+}
+
+function timeSince(date: Date): string {
+  const seconds = Math.floor((new Date().getTime() - date.getTime()) / 1000);
+
+  const units: [number, string][] = [
+    [31536000, "year"],
+    [2592000, "month"],
+    [86400, "day"],
+    [3600, "hour"],
+    [60, "minute"],
+  ];
+
+  for (const [divisor, unit] of units) {
+    const value = Math.floor(seconds / divisor);
+    if (value > 0) {
+      return `${value} ${unit}${value !== 1 ? "s" : ""} ago`;
+    }
+  }
+  return Math.floor(seconds) + " seconds ago";
+}
+
+export { formatAbsoluteTime, timeSince };

--- a/frontend/src/utils/timeFormat.ts
+++ b/frontend/src/utils/timeFormat.ts
@@ -10,8 +10,12 @@ function formatAbsoluteTime(
 ): string {
   if (timezone === "utc") {
     return (
-      `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}` +
-      `T${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}Z`
+      `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(
+        date.getUTCDate(),
+      )}` +
+      `T${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(
+        date.getUTCSeconds(),
+      )}Z`
     );
   }
   const tz = -date.getTimezoneOffset();
@@ -20,7 +24,9 @@ function formatAbsoluteTime(
   const absM = pad(Math.abs(tz) % 60);
   return (
     `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
-    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(
+      date.getSeconds(),
+    )}` +
     `${sign}${absH}:${absM}`
   );
 }

--- a/frontend/src/utils/timeFormat.ts
+++ b/frontend/src/utils/timeFormat.ts
@@ -1,8 +1,19 @@
+import type { TimezoneMode } from "../components/TimezoneProvider";
+
 function pad(n: number): string {
   return n.toString().padStart(2, "0");
 }
 
-function formatAbsoluteTime(date: Date): string {
+function formatAbsoluteTime(
+  date: Date,
+  timezone: TimezoneMode = "local",
+): string {
+  if (timezone === "utc") {
+    return (
+      `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}` +
+      `T${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}Z`
+    );
+  }
   const tz = -date.getTimezoneOffset();
   const sign = tz >= 0 ? "+" : "-";
   const absH = pad(Math.floor(Math.abs(tz) / 60));
@@ -14,24 +25,13 @@ function formatAbsoluteTime(date: Date): string {
   );
 }
 
-function timeSince(date: Date): string {
-  const seconds = Math.floor((new Date().getTime() - date.getTime()) / 1000);
-
-  const units: [number, string][] = [
-    [31536000, "year"],
-    [2592000, "month"],
-    [86400, "day"],
-    [3600, "hour"],
-    [60, "minute"],
-  ];
-
-  for (const [divisor, unit] of units) {
-    const value = Math.floor(seconds / divisor);
-    if (value > 0) {
-      return `${value} ${unit}${value !== 1 ? "s" : ""} ago`;
-    }
-  }
-  return Math.floor(seconds) + " seconds ago";
+/** Get the local timezone offset label, e.g. "+09:00" */
+function localTimezoneLabel(): string {
+  const tz = -new Date().getTimezoneOffset();
+  const sign = tz >= 0 ? "+" : "-";
+  const h = pad(Math.floor(Math.abs(tz) / 60));
+  const m = pad(Math.abs(tz) % 60);
+  return `${sign}${h}:${m}`;
 }
 
-export { formatAbsoluteTime, timeSince };
+export { formatAbsoluteTime, localTimezoneLabel };


### PR DESCRIPTION

## Motivation

Resolves #451

Currently Kviklet displayed timestamps as relative strings (e.g. "2 hours ago") which made precise lookup difficult. Also no way to filter requests by date range.


## Modification

- Make timestamp renders ISO 8601 format (e.g. `2026-04-11T14:32:05+09:00`)
  - User can choose UTC or Local Timezone, in setting page. It's stored in localStorage
- Add date range filter
- Updated request list page design little bit
- Update `osixia/openldap` image tag from 1.1.8 to 1.5.0 (Looks like 1.1.8 get removed lately?) in docker-compose.yml

## Screenshots

### List (Local Timezone)

<img width="759" height="733" alt="51964" src="https://github.com/user-attachments/assets/8b4155fc-8b00-4aa6-865a-b8f29a9bd200" />

### List (UTC)

<img width="753" height="130" alt="23211" src="https://github.com/user-attachments/assets/3cdc3b65-7336-4b0b-ab6a-9bb16dc202c6" />


### Setting page to choose timezone

<img width="876" height="463" alt="53296" src="https://github.com/user-attachments/assets/551ebef9-42cd-4a1b-ba5d-973ecd93d79f" />

