### PR TITLE
Serialize LocalDateTime as UTC and add local-time tooltips

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/JacksonConfig.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/JacksonConfig.kt
@@ -1,0 +1,30 @@
+package dev.kviklet.kviklet
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.Module
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.module.SimpleModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+/**
+ * All `LocalDateTime` values in Kviklet represent UTC instants (see `utcTimeNow()`).
+ * This module makes that explicit on the wire by appending `Z`, so the frontend
+ * `new Date(...)` parses them as UTC instead of misinterpreting them as local time.
+ */
+@Configuration
+class JacksonConfig {
+    @Bean
+    fun localDateTimeUtcModule(): Module = SimpleModule().apply {
+        addSerializer(LocalDateTime::class.java, UtcLocalDateTimeSerializer())
+    }
+}
+
+private class UtcLocalDateTimeSerializer : JsonSerializer<LocalDateTime>() {
+    override fun serialize(value: LocalDateTime, gen: JsonGenerator, serializers: SerializerProvider) {
+        gen.writeString(value.toInstant(ZoneOffset.UTC).toString())
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionRequestPaginationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionRequestPaginationTest.kt
@@ -270,14 +270,10 @@ class ExecutionRequestPaginationTest {
                 .andExpect(jsonPath("$.cursor").exists())
                 .andReturn()
 
-            val cursorRaw = com.jayway.jsonpath.JsonPath.read<String>(
+            val cursor = com.jayway.jsonpath.JsonPath.read<String>(
                 firstPage.response.contentAsString,
                 "$.cursor",
             )
-            // Add 'Z' timezone to cursor for use in next request
-            val cursor = java.time.LocalDateTime.parse(cursorRaw)
-                .atZone(java.time.ZoneOffset.UTC)
-                .format(DateTimeFormatter.ISO_INSTANT)
 
             // Second page: use cursor
             mockMvc.perform(
@@ -297,14 +293,10 @@ class ExecutionRequestPaginationTest {
                     .cookie(cookie),
             ).andReturn()
 
-            val cursor2Raw = com.jayway.jsonpath.JsonPath.read<String>(
+            val cursor2 = com.jayway.jsonpath.JsonPath.read<String>(
                 secondPage.response.contentAsString,
                 "$.cursor",
             )
-            // Add 'Z' timezone to cursor for use in next request
-            val cursor2 = java.time.LocalDateTime.parse(cursor2Raw)
-                .atZone(java.time.ZoneOffset.UTC)
-                .format(DateTimeFormatter.ISO_INSTANT)
 
             mockMvc.perform(
                 get("/execution-requests/")

--- a/frontend/src/routes/Auditlog.tsx
+++ b/frontend/src/routes/Auditlog.tsx
@@ -186,6 +186,7 @@ function Item({ execution }: { execution: ExecutionLogResponse }) {
     <Link to={`/requests/${execution.requestId}`}>
       <li
         key={execution.statement}
+        title={execution.executionTime.toLocaleString()}
         className="relative flex justify-between gap-x-6 border-b px-2 py-5 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
       >
         <div className="flex min-w-0 items-center gap-x-4">
@@ -205,7 +206,10 @@ function Item({ execution }: { execution: ExecutionLogResponse }) {
             <span className="inline-flex flex-shrink-0 items-center rounded-full bg-green-50 px-1.5 py-0.5 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20 dark:bg-green-400/10 dark:text-green-400">
               {execution.connectionId}
             </span>
-            <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">
+            <p
+              className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400"
+              title={execution.executionTime.toLocaleString()}
+            >
               Executed{" "}
               <time dateTime={execution.executionTime.toISOString()}>
                 {timeSince(execution.executionTime)}

--- a/frontend/src/routes/Requests.tsx
+++ b/frontend/src/routes/Requests.tsx
@@ -18,9 +18,7 @@ import SearchInput from "../components/SearchInput";
 import Tooltip from "../components/Tooltip";
 
 function timeSince(date: Date) {
-  const seconds =
-    Math.floor((new Date().getTime() - date.getTime()) / 1000) +
-    new Date().getTimezoneOffset() * 60;
+  const seconds = Math.floor((new Date().getTime() - date.getTime()) / 1000);
 
   const units: [number, string][] = [
     [31536000, "year"],
@@ -296,10 +294,7 @@ function Requests() {
                           </h2>
                           <span
                             className="shrink-0 text-xs text-slate-400 dark:text-slate-500"
-                            title={
-                              new Date(request.createdAt).toLocaleString() +
-                              " UTC"
-                            }
+                            title={new Date(request.createdAt).toLocaleString()}
                           >
                             {timeSince(new Date(request.createdAt))}
                           </span>

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -242,7 +242,14 @@ function DatasourceRequestBox({
               {request?.author?.fullName + questionText}
               <span className="italic">{request?.connection.displayName}</span>
             </div>
-            <div className="ml-auto dark:text-slate-500">
+            <div
+              className="ml-auto dark:text-slate-500"
+              title={
+                request?.createdAt
+                  ? new Date(request.createdAt).toLocaleString()
+                  : undefined
+              }
+            >
               {timeSince(new Date(request?.createdAt ?? ""))}
             </div>
           </div>

--- a/frontend/src/routes/Review/KubernetesRequestBox.tsx
+++ b/frontend/src/routes/Review/KubernetesRequestBox.tsx
@@ -72,7 +72,14 @@ const KubernetesRequestBox: FC<KubernetesRequestBoxProps> = ({
               in:
               <span className="italic"> {request?.connection.displayName}</span>
             </div>
-            <div className="ml-auto dark:text-slate-500">
+            <div
+              className="ml-auto dark:text-slate-500"
+              title={
+                request?.createdAt
+                  ? new Date(request.createdAt).toLocaleString()
+                  : undefined
+              }
+            >
               {timeSince(new Date(request?.createdAt ?? ""))}
             </div>
           </div>

--- a/frontend/src/routes/Review/events/Comment.tsx
+++ b/frontend/src/routes/Review/events/Comment.tsx
@@ -50,7 +50,7 @@ function Comment({
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <div>
+          <div title={event?.createdAt?.toLocaleString()}>
             {((event?.createdAt && timeSince(event.createdAt)) as
               | string
               | undefined) || ""}

--- a/frontend/src/routes/Review/events/EditEvent.tsx
+++ b/frontend/src/routes/Review/events/EditEvent.tsx
@@ -30,7 +30,7 @@ function EditEvent({ event, index }: { event: Edit; index: number }) {
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <div className="mr-4">
+          <div className="mr-4" title={event?.createdAt?.toLocaleString()}>
             {((event?.createdAt && timeSince(event.createdAt)) as
               | string
               | undefined) || ""}

--- a/frontend/src/routes/Review/events/ExecuteEvent.tsx
+++ b/frontend/src/routes/Review/events/ExecuteEvent.tsx
@@ -65,7 +65,7 @@ function ExecuteEvent({
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:bg-slate-900 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <div className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <div className="mr-4">
+          <div className="mr-4" title={event?.createdAt?.toLocaleString()}>
             {((event?.createdAt && timeSince(event.createdAt)) as
               | string
               | undefined) || ""}

--- a/frontend/src/routes/Review/events/ReviewEvent.tsx
+++ b/frontend/src/routes/Review/events/ReviewEvent.tsx
@@ -79,7 +79,7 @@ function ReviewEvent({ event, index }: { event: Review; index: number }) {
       <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
         <InitialBubble name={event?.author?.fullName} />
         <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <div>
+          <div title={event?.createdAt?.toLocaleString()}>
             {((event?.createdAt && timeSince(event.createdAt)) as
               | string
               | undefined) || ""}


### PR DESCRIPTION
## Summary
Backend `LocalDateTime` fields were serialized without a timezone marker, so the frontend parsed them as local time and silently shifted timestamps by the user's UTC offset. `timeSince()` compensated with `getTimezoneOffset()` and tooltips were mislabeled "UTC" while actually showing local time.

- Register a Jackson module that serializes `LocalDateTime` as an ISO instant with `Z` suffix (one config bean, no DTO changes — affects every `createdAt` / `executionTime` / `expiresAt` / `cursor` etc. field).
- Drop the `getTimezoneOffset()` compensation in `timeSince()` and the misleading `" UTC"` suffix on the request list tooltip.
- Add local-time tooltips to all other relative-time displays: audit log row, request review headers (datasource & kubernetes), and the four event types (comment, review, edit, execute).

Paritally fixes #452 