### PR TITLE
feat: add configurable default roles for new user registration

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -24,7 +24,7 @@ kapt {
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
 val queryDslVersion = "5.0.0"
-val testcontainersVersion = "1.21.3"
+val testcontainersVersion = "1.21.4"
 java.sourceCompatibility = JavaVersion.VERSION_21
 
 configurations {
@@ -37,6 +37,12 @@ repositories {
     maven { url = uri("https://repo.spring.io/milestone") }
     mavenCentral()
     maven { url = uri("https://build.shibboleth.net/maven/releases/") }
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("org.testcontainers:testcontainers-bom:$testcontainersVersion")
+    }
 }
 
 dependencies {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConfigController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConfigController.kt
@@ -36,7 +36,7 @@ open class PublicConfigResponse(
     open val gitCommit: String,
 )
 
-data class ConfigRequest(val teamsUrl: String?, val slackUrl: String?)
+data class ConfigRequest(val teamsUrl: String?, val slackUrl: String?, val newUserRoleIds: List<String> = emptyList())
 
 data class ConfigResponse(
     override val oAuthProvider: String?,
@@ -51,6 +51,7 @@ data class ConfigResponse(
     override val gitCommit: String,
     val teamsUrl: String?,
     val slackUrl: String?,
+    val newUserRoleIds: List<String>,
 ) : PublicConfigResponse(
     oAuthProvider,
     ldapEnabled,
@@ -88,6 +89,7 @@ data class ConfigResponse(
                 gitCommit = gitCommit,
                 teamsUrl = configuration.teamsUrl,
                 slackUrl = configuration.slackUrl,
+                newUserRoleIds = configuration.newUserRoleIds,
             )
         }
     }
@@ -148,6 +150,7 @@ class ConfigController(
             Configuration(
                 teamsUrl = request.teamsUrl,
                 slackUrl = request.slackUrl,
+                newUserRoleIds = request.newUserRoleIds,
             ),
         )
         return ConfigResponse.fromConfiguration(

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConfigController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConfigController.kt
@@ -36,7 +36,7 @@ open class PublicConfigResponse(
     open val gitCommit: String,
 )
 
-data class ConfigRequest(val teamsUrl: String?, val slackUrl: String?, val newUserRoleIds: List<String> = emptyList())
+data class ConfigRequest(val teamsUrl: String?, val slackUrl: String?, val newUserRoleIds: List<String>? = null)
 
 data class ConfigResponse(
     override val oAuthProvider: String?,
@@ -146,11 +146,12 @@ class ConfigController(
     @PutMapping("/")
     fun createConfig(@RequestBody request: ConfigRequest): ConfigResponse {
         val licenses = licenseService.getLicenses()
+        val existing = configService.getConfiguration()
         val config = configService.setConfiguration(
             Configuration(
-                teamsUrl = request.teamsUrl,
-                slackUrl = request.slackUrl,
-                newUserRoleIds = request.newUserRoleIds,
+                teamsUrl = request.teamsUrl ?: existing.teamsUrl,
+                slackUrl = request.slackUrl ?: existing.slackUrl,
+                newUserRoleIds = request.newUserRoleIds ?: existing.newUserRoleIds,
             ),
         )
         return ConfigResponse.fromConfiguration(

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/Configuration.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/Configuration.kt
@@ -36,6 +36,8 @@ class ConfigurationAdapter(private val configurationRepository: ConfigurationRep
             listOfNotNull(
                 configuration.teamsUrl?.let { ConfigurationEntity("teamsUrl", it) },
                 configuration.slackUrl?.let { ConfigurationEntity("slackUrl", it) },
+                configuration.newUserRoleIds.takeIf { it.isNotEmpty() }
+                    ?.let { ConfigurationEntity("newUserRoleIds", it.joinToString(",")) },
             ),
         )
         return configurationEntities.toDto()
@@ -45,4 +47,6 @@ class ConfigurationAdapter(private val configurationRepository: ConfigurationRep
 fun List<ConfigurationEntity>.toDto(): Configuration = Configuration(
     teamsUrl = this.find { it.key == "teamsUrl" }?.value,
     slackUrl = this.find { it.key == "slackUrl" }?.value,
+    newUserRoleIds = this.find { it.key == "newUserRoleIds" }?.value
+        ?.split(",")?.filter { it.isNotBlank() } ?: emptyList(),
 )

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/Configuration.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/Configuration.kt
@@ -36,8 +36,7 @@ class ConfigurationAdapter(private val configurationRepository: ConfigurationRep
             listOfNotNull(
                 configuration.teamsUrl?.let { ConfigurationEntity("teamsUrl", it) },
                 configuration.slackUrl?.let { ConfigurationEntity("slackUrl", it) },
-                configuration.newUserRoleIds.takeIf { it.isNotEmpty() }
-                    ?.let { ConfigurationEntity("newUserRoleIds", it.joinToString(",")) },
+                ConfigurationEntity("newUserRoleIds", configuration.newUserRoleIds.joinToString(",")),
             ),
         )
         return configurationEntities.toDto()

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/UserAuthService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/UserAuthService.kt
@@ -1,5 +1,6 @@
 package dev.kviklet.kviklet.security
 
+import dev.kviklet.kviklet.db.ConfigurationAdapter
 import dev.kviklet.kviklet.db.RoleAdapter
 import dev.kviklet.kviklet.db.User
 import dev.kviklet.kviklet.db.UserAdapter
@@ -29,6 +30,7 @@ class UserAuthService(
     private val roleAdapter: RoleAdapter,
     private val licenseService: LicenseService,
     private val roleSyncService: RoleSyncService,
+    private val configurationAdapter: ConfigurationAdapter,
 ) {
     /**
      * Find existing user or create new one during authentication.
@@ -75,10 +77,13 @@ class UserAuthService(
                 }
 
                 val defaultRole = roleAdapter.findById(Role.DEFAULT_ROLE_ID)
+                val newUserRoleIds = (configurationAdapter.getConfiguration("newUserRoleIds") as String?)
+                    ?.split(",")?.filter { it.isNotBlank() } ?: emptyList()
+                val newUserRoles = roleAdapter.findByIds(newUserRoleIds).toSet()
                 user = User(
                     email = email,
                     fullName = fullName ?: email,
-                    roles = setOf(defaultRole),
+                    roles = setOf(defaultRole) + newUserRoles,
                 )
                 isNewUser = true
             }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/RoleService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/RoleService.kt
@@ -1,5 +1,6 @@
 package dev.kviklet.kviklet.service
 
+import dev.kviklet.kviklet.db.ConfigurationAdapter
 import dev.kviklet.kviklet.db.RoleAdapter
 import dev.kviklet.kviklet.security.Permission
 import dev.kviklet.kviklet.service.dto.Policy
@@ -9,7 +10,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-class RoleService(private val roleAdapter: RoleAdapter) {
+class RoleService(private val roleAdapter: RoleAdapter, private val configurationAdapter: ConfigurationAdapter) {
 
     @dev.kviklet.kviklet.security.Policy(Permission.ROLE_EDIT)
     @Transactional
@@ -61,6 +62,12 @@ class RoleService(private val roleAdapter: RoleAdapter) {
         val role = roleAdapter.findById(id)
         if (role.isDefault) {
             throw IllegalArgumentException("Cannot delete default role")
+        }
+        val config = configurationAdapter.getConfiguration()
+        if (config.newUserRoleIds.contains(id.toString())) {
+            configurationAdapter.setConfiguration(
+                config.copy(newUserRoleIds = config.newUserRoleIds.filter { it != id.toString() }),
+            )
         }
         roleAdapter.delete(id)
     }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/UserService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/UserService.kt
@@ -1,5 +1,6 @@
 package dev.kviklet.kviklet.service
 
+import dev.kviklet.kviklet.db.ConfigurationAdapter
 import dev.kviklet.kviklet.db.RoleAdapter
 import dev.kviklet.kviklet.db.User
 import dev.kviklet.kviklet.db.UserAdapter
@@ -17,6 +18,7 @@ class UserService(
     private val passwordEncoder: PasswordEncoder,
     private val roleAdapter: RoleAdapter,
     private val licenseService: LicenseService,
+    private val configurationAdapter: ConfigurationAdapter,
 ) {
 
     @Transactional
@@ -37,12 +39,15 @@ class UserService(
         }
 
         val defaultRole = roleAdapter.findById(Role.DEFAULT_ROLE_ID)
+        val newUserRoleIds = (configurationAdapter.getConfiguration("newUserRoleIds") as String?)
+            ?.split(",")?.filter { it.isNotBlank() } ?: emptyList()
+        val newUserRoles = roleAdapter.findByIds(newUserRoleIds).toSet()
 
         val user = User(
             email = email,
             fullName = fullName,
             password = passwordEncoder.encode(password),
-            roles = setOf(defaultRole),
+            roles = setOf(defaultRole) + newUserRoles,
         )
         return userAdapter.createUser(user)
     }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/Configuration.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/Configuration.kt
@@ -3,7 +3,7 @@ package dev.kviklet.kviklet.service.dto
 import dev.kviklet.kviklet.security.Resource
 import dev.kviklet.kviklet.security.SecuredDomainObject
 
-data class Configuration(val teamsUrl: String?, val slackUrl: String?) : SecuredDomainObject {
+data class Configuration(val teamsUrl: String?, val slackUrl: String?, val newUserRoleIds: List<String> = emptyList()) : SecuredDomainObject {
     override fun getSecuredObjectId(): String? = "configuration"
 
     override fun getDomainObjectType(): Resource = Resource.CONFIGURATION

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/NewUserDefaultRolesTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/NewUserDefaultRolesTest.kt
@@ -1,0 +1,461 @@
+package dev.kviklet.kviklet
+
+import com.ninjasquad.springmockk.MockkBean
+import dev.kviklet.kviklet.db.ConfigurationAdapter
+import dev.kviklet.kviklet.db.RoleSyncConfigAdapter
+import dev.kviklet.kviklet.db.UserAdapter
+import dev.kviklet.kviklet.helper.RoleHelper
+import dev.kviklet.kviklet.helper.UserHelper
+import dev.kviklet.kviklet.security.IdpIdentifier
+import dev.kviklet.kviklet.security.UserAuthService
+import dev.kviklet.kviklet.service.LicenseService
+import dev.kviklet.kviklet.service.RoleService
+import dev.kviklet.kviklet.service.UserService
+import dev.kviklet.kviklet.service.dto.Configuration
+import dev.kviklet.kviklet.service.dto.License
+import dev.kviklet.kviklet.service.dto.LicenseFile
+import dev.kviklet.kviklet.service.dto.RoleId
+import dev.kviklet.kviklet.service.dto.SyncMode
+import io.mockk.every
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.CoreMatchers.hasItem
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class NewUserDefaultRolesTest {
+
+    @MockkBean lateinit var licenseService: LicenseService
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var userHelper: UserHelper
+    @Autowired private lateinit var roleHelper: RoleHelper
+    @Autowired private lateinit var userAdapter: UserAdapter
+    @Autowired private lateinit var configurationAdapter: ConfigurationAdapter
+    @Autowired private lateinit var roleSyncConfigAdapter: RoleSyncConfigAdapter
+    @Autowired private lateinit var userAuthService: UserAuthService
+    @Autowired private lateinit var userService: UserService
+    @Autowired private lateinit var roleService: RoleService
+
+    @BeforeEach
+    fun setUp() {
+        every { licenseService.getActiveLicense() } returns null
+        every { licenseService.getLicenses() } returns emptyList()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        userHelper.deleteAll()
+        roleHelper.deleteAll()
+        configurationAdapter.setConfiguration("newUserRoleIds", "")
+        roleSyncConfigAdapter.updateConfig(enabled = false)
+        roleSyncConfigAdapter.deleteAllMappings()
+    }
+
+
+    @Nested
+    inner class PasswordRegistration {
+        @Test
+        fun `new user gets assigned configured default roles on registration`() {
+            val extraRole = roleHelper.createRole(
+                name = "Analyst",
+                permissions = listOf("datasource_connection:get"),
+            )
+
+            configurationAdapter.setConfiguration(
+                Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf(extraRole.getId()!!)),
+            )
+
+            userService.createUser(
+                email = "newuser@example.com",
+                password = "password123",
+                fullName = "New User",
+            )
+
+            val user = userAdapter.findByEmail("newuser@example.com")
+            assertThat(user).isNotNull
+            val roleNames = user!!.roles.map { it.name }
+            assertThat(roleNames).contains("Analyst")
+            assertThat(user.roles.any { it.isDefault }).isTrue()
+        }
+
+        @Test
+        fun `new user without configuration only has the default role`() {
+            userService.createUser(
+                email = "bareuser@example.com",
+                password = "password123",
+                fullName = "Bare User",
+            )
+
+            val user = userAdapter.findByEmail("bareuser@example.com")
+            assertThat(user).isNotNull
+            assertThat(user!!.roles).hasSize(1)
+            assertThat(user.roles.single().isDefault).isTrue()
+        }
+
+        @Test
+        fun `multiple configured default roles are all assigned to new users`() {
+            val roleA = roleHelper.createRole(name = "RoleA", permissions = listOf("datasource_connection:get"))
+            val roleB = roleHelper.createRole(name = "RoleB", permissions = listOf("execution_request:get"))
+            configurationAdapter.setConfiguration(
+                Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf(roleA.getId()!!, roleB.getId()!!)),
+            )
+
+            userService.createUser(
+                email = "multiuser@example.com",
+                password = "password123",
+                fullName = "Multi User",
+            )
+
+            val user = userAdapter.findByEmail("multiuser@example.com")
+            assertThat(user).isNotNull
+            val roleNames = user!!.roles.map { it.name }
+            assertThat(roleNames).containsAll(listOf("RoleA", "RoleB"))
+            assertThat(user.roles.any { it.isDefault }).isTrue()
+        }
+
+        @Test
+        fun `invalid role IDs in config are silently ignored and user still gets the default role`() {
+            configurationAdapter.setConfiguration(
+                Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf("non-existent-role-id")),
+            )
+
+            userService.createUser(
+                email = "robustuser@example.com",
+                password = "password123",
+                fullName = "Robust User",
+            )
+
+            val user = userAdapter.findByEmail("robustuser@example.com")
+            assertThat(user).isNotNull
+            assertThat(user!!.roles).hasSize(1)
+            assertThat(user.roles.single().isDefault).isTrue()
+        }
+
+        @Test
+        fun `new user created via HTTP POST users API receives configured default roles`() {
+            userHelper.createUser(permissions = listOf("*"))
+            val adminCookie = userHelper.login(mockMvc = mockMvc)
+
+            val extraRole = roleHelper.createRole(name = "Viewer", permissions = listOf("datasource_connection:get"))
+            configurationAdapter.setConfiguration(
+                Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf(extraRole.getId()!!)),
+            )
+
+            mockMvc.perform(
+                post("/users/")
+                    .cookie(adminCookie)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{"email": "newhttp@example.com", "password": "pass123", "fullName": "HTTP User"}""",
+                    ),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.roles.length()", `is`(2)))
+                .andExpect(jsonPath("$.roles[*].name", hasItem("Viewer")))
+        }
+    }
+
+    @Nested
+    inner class RoleDeletion {
+        @Test
+        fun `deleting a role that is in newUserRoleIds removes it from the configuration`() {
+            val role = roleHelper.createRole(name = "Removable", permissions = listOf("datasource_connection:get"))
+            val roleId = role.getId()!!
+            configurationAdapter.setConfiguration(Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf(roleId)))
+
+            assertThat(configurationAdapter.getConfiguration().newUserRoleIds).contains(roleId)
+            roleService.deleteRole(RoleId(roleId))
+            assertThat(configurationAdapter.getConfiguration().newUserRoleIds).doesNotContain(roleId)
+        }
+
+        @Test
+        fun `deleting a role not in newUserRoleIds leaves newUserRoleIds unchanged`() {
+            val keptRole = roleHelper.createRole(name = "Kept", permissions = listOf("datasource_connection:get"))
+            val unrelatedRole = roleHelper.createRole(name = "Unrelated", permissions = listOf("role:get"))
+            configurationAdapter.setConfiguration(Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf(keptRole.getId()!!)))
+
+            roleService.deleteRole(RoleId(unrelatedRole.getId()!!))
+
+            assertThat(configurationAdapter.getConfiguration().newUserRoleIds)
+                .containsExactly(keptRole.getId()!!)
+        }
+
+        @Test
+        fun `deleting a role via HTTP removes it from newUserRoleIds config`() {
+            userHelper.createUser(permissions = listOf("*"))
+            val adminCookie = userHelper.login(mockMvc = mockMvc)
+
+            val role = roleHelper.createRole(name = "TempRole", permissions = listOf("datasource_connection:get"))
+            val roleId = role.getId()!!
+            configurationAdapter.setConfiguration(Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf(roleId)))
+
+            mockMvc.perform(
+                delete("/roles/$roleId").cookie(adminCookie),
+            ).andExpect(status().isOk)
+
+            mockMvc.perform(
+                get("/config/").cookie(adminCookie),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.newUserRoleIds.length()", `is`(0)))
+        }
+
+        @Test
+        fun `deleting one of multiple newUserRoleIds keeps the remaining ones`() {
+            val roleA = roleHelper.createRole(name = "RoleA", permissions = listOf("datasource_connection:get"))
+            val roleB = roleHelper.createRole(name = "RoleB", permissions = listOf("execution_request:get"))
+            configurationAdapter.setConfiguration(
+                Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf(roleA.getId()!!, roleB.getId()!!)),
+            )
+
+            roleService.deleteRole(RoleId(roleA.getId()!!))
+
+            val config = configurationAdapter.getConfiguration()
+            assertThat(config.newUserRoleIds).doesNotContain(roleA.getId()!!)
+            assertThat(config.newUserRoleIds).contains(roleB.getId()!!)
+        }
+    }
+
+    @Nested
+    inner class ConfigApi {
+
+        @Test
+        fun `saved newUserRoleIds are returned by the config API`() {
+            userHelper.createUser(permissions = listOf("*"))
+            val adminCookie = userHelper.login(mockMvc = mockMvc)
+
+            val role = roleHelper.createRole(name = "Configured", permissions = listOf("datasource_connection:get"))
+
+            mockMvc.perform(
+                put("/config/")
+                    .cookie(adminCookie)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"newUserRoleIds": ["${role.getId()}"]}"""),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.newUserRoleIds.length()", `is`(1)))
+                .andExpect(jsonPath("$.newUserRoleIds[0]", `is`(role.getId())))
+
+            mockMvc.perform(get("/config/").cookie(adminCookie))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.newUserRoleIds.length()", `is`(1)))
+                .andExpect(jsonPath("$.newUserRoleIds[0]", `is`(role.getId())))
+        }
+
+        @Test
+        fun `saving config with empty newUserRoleIds clears previous configuration`() {
+            userHelper.createUser(permissions = listOf("*"))
+            val adminCookie = userHelper.login(mockMvc = mockMvc)
+
+            val role = roleHelper.createRole(name = "ToRemove", permissions = listOf("datasource_connection:get"))
+            configurationAdapter.setConfiguration(Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf(role.getId()!!)))
+
+            mockMvc.perform(
+                put("/config/")
+                    .cookie(adminCookie)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"newUserRoleIds": []}"""),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.newUserRoleIds.length()", `is`(0)))
+        }
+    }
+
+    @Nested
+    inner class RoleSyncInteraction {
+
+        @BeforeEach
+        fun setUpLicense() {
+            every { licenseService.getActiveLicense() } returns License(
+                file = LicenseFile(fileContent = "", fileName = "test.json", createdAt = LocalDateTime.now()),
+                validUntil = LocalDate.now().plusYears(1),
+                createdAt = LocalDateTime.now(),
+                allowedUsers = 100u,
+            )
+        }
+
+        /**
+         * Password-based registration goes through UserService which does NOT call RoleSyncService,
+         * so configured newUserRoleIds are always applied regardless of the sync settings.
+         *
+         * IdP-based logins (OIDC/SAML/LDAP) go through UserAuthService which calls RoleSyncService.resolveRoles
+         * after creating the user. The sync mode determines which roles survive:
+         *
+         *  - DISABLED    → resolveRoles returns only the default role (newUserRoleIds ignored)
+         *  - FULL_SYNC   → resolveRoles returns mapped roles + default (newUserRoleIds ignored)
+         *  - ADDITIVE    → resolveRoles returns existing + mapped + default (newUserRoleIds kept when groups match)
+         *  - FIRST_LOGIN_ONLY (new user)    → resolveRoles returns mapped roles + default
+         *  - FIRST_LOGIN_ONLY (existing user) → resolveRoles returns existingRoles unchanged
+         */
+
+        @Test
+        fun `password-based new user always gets configured default roles regardless of role sync settings`() {
+            val extraRole = roleHelper.createRole(name = "SyncRole", permissions = listOf("datasource_connection:get"))
+            configurationAdapter.setConfiguration(
+                Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf(extraRole.getId()!!)),
+            )
+            roleSyncConfigAdapter.updateConfig(enabled = true, syncMode = SyncMode.FULL_SYNC)
+
+            userService.createUser(
+                email = "passuser@example.com",
+                password = "pass123",
+                fullName = "Pass User",
+            )
+
+            val user = userAdapter.findByEmail("passuser@example.com")
+            assertThat(user!!.roles.map { it.name }).contains("SyncRole")
+        }
+
+        @Test
+        fun `new IdP user with role sync disabled receives only the default role`() {
+            val extraRole = roleHelper.createRole(name = "OidcDefault", permissions = listOf("datasource_connection:get"))
+            configurationAdapter.setConfiguration(
+                Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf(extraRole.getId()!!)),
+            )
+            // role sync remains disabled (setUp ensures this)
+
+            userAuthService.findOrCreateUser(
+                idpIdentifier = IdpIdentifier.Oidc("subject-sync-disabled"),
+                email = "oidc-disabled@example.com",
+                fullName = "OIDC Disabled",
+            )
+
+            val user = userAdapter.findByEmail("oidc-disabled@example.com")
+            assertThat(user).isNotNull
+            // With sync disabled, resolveRoles returns only the default role for new users
+            assertThat(user!!.roles).hasSize(1)
+            assertThat(user.roles.single().isDefault).isTrue()
+        }
+
+        @Test
+        fun `new IdP user with FULL_SYNC mode receives synced roles and the configured default roles are overridden`() {
+            val extraRole = roleHelper.createRole(name = "ExtraDefault", permissions = listOf("datasource_connection:get"))
+            val syncedRole = roleHelper.createRole(name = "SyncedGroup", permissions = listOf("execution_request:get"))
+            configurationAdapter.setConfiguration(
+                Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf(extraRole.getId()!!)),
+            )
+            roleSyncConfigAdapter.updateConfig(enabled = true, syncMode = SyncMode.FULL_SYNC, groupsAttribute = "groups")
+            roleSyncConfigAdapter.addMapping("dev-team", syncedRole.getId()!!)
+
+            userAuthService.findOrCreateUser(
+                idpIdentifier = IdpIdentifier.Oidc("subject-full-sync"),
+                email = "oidc-fullsync@example.com",
+                fullName = "OIDC Full Sync",
+                idpGroups = listOf("dev-team"),
+            )
+
+            val user = userAdapter.findByEmail("oidc-fullsync@example.com")
+            assertThat(user).isNotNull
+            val roleNames = user!!.roles.map { it.name }
+            // FULL_SYNC: resolved = mappedRoles + defaultRole (newUserRoleIds not preserved)
+            assertThat(roleNames).contains("SyncedGroup")
+            assertThat(roleNames).doesNotContain("ExtraDefault")
+            assertThat(user.roles.any { it.isDefault }).isTrue()
+        }
+
+        @Test
+        fun `new IdP user with ADDITIVE sync mode retains configured default roles alongside synced roles`() {
+            val extraRole = roleHelper.createRole(name = "AdditiveDefault", permissions = listOf("datasource_connection:get"))
+            val syncedRole = roleHelper.createRole(name = "AdditiveGroup", permissions = listOf("execution_request:get"))
+            configurationAdapter.setConfiguration(
+                Configuration(teamsUrl = null, slackUrl = null, newUserRoleIds = listOf(extraRole.getId()!!)),
+            )
+            roleSyncConfigAdapter.updateConfig(enabled = true, syncMode = SyncMode.ADDITIVE, groupsAttribute = "groups")
+            roleSyncConfigAdapter.addMapping("ops-team", syncedRole.getId()!!)
+
+            userAuthService.findOrCreateUser(
+                idpIdentifier = IdpIdentifier.Oidc("subject-additive"),
+                email = "oidc-additive@example.com",
+                fullName = "OIDC Additive",
+                idpGroups = listOf("ops-team"),
+            )
+
+            val user = userAdapter.findByEmail("oidc-additive@example.com")
+            assertThat(user).isNotNull
+            val roleNames = user!!.roles.map { it.name }
+            // ADDITIVE: resolved = existingRoles (includes extraRole) + mappedRoles + defaultRole
+            assertThat(roleNames).contains("AdditiveDefault")
+            assertThat(roleNames).contains("AdditiveGroup")
+            assertThat(user.roles.any { it.isDefault }).isTrue()
+        }
+
+        @Test
+        fun `new IdP user with FIRST_LOGIN_ONLY sync mode gets synced roles on first login`() {
+            val syncedRole = roleHelper.createRole(name = "FirstLoginGroup", permissions = listOf("execution_request:get"))
+            roleSyncConfigAdapter.updateConfig(
+                enabled = true,
+                syncMode = SyncMode.FIRST_LOGIN_ONLY,
+                groupsAttribute = "groups",
+            )
+            roleSyncConfigAdapter.addMapping("sre-team", syncedRole.getId()!!)
+
+            userAuthService.findOrCreateUser(
+                idpIdentifier = IdpIdentifier.Oidc("subject-first-login"),
+                email = "oidc-firstlogin@example.com",
+                fullName = "OIDC First Login",
+                idpGroups = listOf("sre-team"),
+            )
+
+            val user = userAdapter.findByEmail("oidc-firstlogin@example.com")
+            assertThat(user).isNotNull
+            val roleNames = user!!.roles.map { it.name }
+            assertThat(roleNames).contains("FirstLoginGroup")
+            assertThat(user.roles.any { it.isDefault }).isTrue()
+        }
+
+        @Test
+        fun `existing IdP user with FIRST_LOGIN_ONLY sync mode keeps their roles unchanged on subsequent logins`() {
+            val syncedRole = roleHelper.createRole(name = "FirstLoginSynced", permissions = listOf("execution_request:get"))
+            roleSyncConfigAdapter.updateConfig(
+                enabled = true,
+                syncMode = SyncMode.FIRST_LOGIN_ONLY,
+                groupsAttribute = "groups",
+            )
+            roleSyncConfigAdapter.addMapping("sre-team", syncedRole.getId()!!)
+
+            // First login: user is created and gets the "sre-team" mapped role
+            userAuthService.findOrCreateUser(
+                idpIdentifier = IdpIdentifier.Oidc("subject-first-login-existing"),
+                email = "oidc-existing@example.com",
+                fullName = "OIDC Existing",
+                idpGroups = listOf("sre-team"),
+            )
+            val rolesAfterFirstLogin = userAdapter.findByEmail("oidc-existing@example.com")!!.roles.map { it.name }
+            assertThat(rolesAfterFirstLogin).contains("FirstLoginSynced")
+
+            // Remove the group mapping to simulate the user leaving the IdP group
+            roleSyncConfigAdapter.deleteAllMappings()
+
+            // Second login: no groups match but FIRST_LOGIN_ONLY should keep existing roles
+            userAuthService.findOrCreateUser(
+                idpIdentifier = IdpIdentifier.Oidc("subject-first-login-existing"),
+                email = "oidc-existing@example.com",
+                fullName = "OIDC Existing",
+                idpGroups = listOf("sre-team"),
+            )
+
+            val rolesAfterSecondLogin = userAdapter.findByEmail("oidc-existing@example.com")!!.roles.map { it.name }
+            assertThat(rolesAfterSecondLogin).contains("FirstLoginSynced")
+        }
+    }
+}

--- a/frontend/src/api/ConfigApi.ts
+++ b/frontend/src/api/ConfigApi.ts
@@ -12,6 +12,7 @@ const ConfigResponseSchema = z.object({
   allowedUsers: z.number().nullable().optional(),
   teamsUrl: z.string().nullable().optional(),
   slackUrl: z.string().nullable().optional(),
+  newUserRoleIds: z.array(z.string()).nullable().optional(),
   version: z.string(),
   buildDate: z.string(),
   gitCommit: z.string(),

--- a/frontend/src/api/RoleApi.ts
+++ b/frontend/src/api/RoleApi.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import baseUrl from "./base";
-import { ApiResponse, fetchWithErrorHandling } from "./Errors";
+import {
+  ApiErrorResponse,
+  ApiResponse,
+  fetchEmptyWithErrorHandling,
+  fetchWithErrorHandling,
+} from "./Errors";
 
 const policyResponseSchema = z.object({
   id: z.string(),
@@ -83,15 +88,11 @@ const createRole = async (
   );
 };
 
-const removeRole = async (id: string): Promise<ApiResponse<void>> => {
-  return fetchWithErrorHandling(
-    `${baseUrl}/roles/${id}`,
-    {
-      method: "DELETE",
-      credentials: "include",
-    },
-    z.undefined(),
-  );
+const removeRole = async (id: string): Promise<ApiErrorResponse | null> => {
+  return fetchEmptyWithErrorHandling(`${baseUrl}/roles/${id}`, {
+    method: "DELETE",
+    credentials: "include",
+  });
 };
 
 const patchRole = async (

--- a/frontend/src/routes/settings/GeneralSettings.tsx
+++ b/frontend/src/routes/settings/GeneralSettings.tsx
@@ -1,10 +1,12 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
+import { useEffect, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 import {
   ConfigPayload,
   ConfigPayloadSchema,
   ConfigResponse,
 } from "../../api/ConfigApi";
+import { getRoles, RoleResponse } from "../../api/RoleApi";
 import InputField from "../../components/InputField";
 import Button from "../../components/Button";
 import useConfig from "../../components/ConfigProvider";
@@ -13,15 +15,20 @@ import {
   Disclosure,
   DisclosureButton,
   DisclosurePanel,
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
 } from "@headlessui/react";
-import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  ChevronUpDownIcon,
+} from "@heroicons/react/20/solid";
 
 export default function GeneralSettings() {
   const { config, loading, updateConfig } = useConfig();
-
-  const onSubmit = async (data: ConfigPayload) => {
-    await updateConfig(data);
-  };
 
   return (
     <div>
@@ -29,36 +36,7 @@ export default function GeneralSettings() {
       {loading ? (
         <Spinner size="lg" />
       ) : (
-        config && (
-          <div>
-            <Disclosure defaultOpen={true}>
-              {({ open }) => (
-                <>
-                  <DisclosureButton className="py-2">
-                    <div className="flex flex-row justify-between">
-                      <div className="flex flex-row">
-                        <h2>Notification Settings</h2>
-                      </div>
-                      <div className="flex flex-row">
-                        {open ? (
-                          <ChevronDownIcon className="h-6 w-6 text-slate-400 dark:text-slate-500"></ChevronDownIcon>
-                        ) : (
-                          <ChevronRightIcon className="h-6 w-6 text-slate-400 dark:text-slate-500"></ChevronRightIcon>
-                        )}
-                      </div>
-                    </div>
-                  </DisclosureButton>
-                  <DisclosurePanel unmount={false}>
-                    <ConfigForm
-                      config={config}
-                      onSubmit={onSubmit}
-                    ></ConfigForm>
-                  </DisclosurePanel>
-                </>
-              )}
-            </Disclosure>
-          </div>
-        )
+        config && <ConfigForm config={config} onSubmit={updateConfig} />
       )}
     </div>
   );
@@ -71,42 +49,167 @@ const ConfigForm = ({
   config: ConfigResponse;
   onSubmit: (data: ConfigPayload) => Promise<void>;
 }) => {
+  const [allRoles, setAllRoles] = useState<RoleResponse[]>([]);
+
+  useEffect(() => {
+    void getRoles().then((res) => {
+      if ("roles" in res) setAllRoles(res.roles);
+    });
+  }, []);
   const {
     register,
     handleSubmit,
+    control,
     formState: { errors },
   } = useForm<ConfigPayload>({
     resolver: zodResolver(ConfigPayloadSchema),
     defaultValues: {
-      teamsUrl: config?.teamsUrl,
-      slackUrl: config?.slackUrl,
+      teamsUrl: config.teamsUrl,
+      slackUrl: config.slackUrl,
+      newUserRoleIds: config.newUserRoleIds ?? [],
     },
   });
 
   return (
     <form
-      className="flex flex-col space-y-4"
+      className="divide-y divide-slate-200 dark:divide-slate-700"
       onSubmit={(event) => void handleSubmit(onSubmit)(event)}
     >
-      <span className="text-sm dark:text-slate-300">
-        See the Readme section on Notifications to see how to add webhooks, to
-        get notified in a channel when reviews are necessary.
-      </span>
-      <InputField
-        label="Teams Webhook URL"
-        type="text"
-        {...register("teamsUrl")}
-        placeholder="Teams URL"
-        error={errors.teamsUrl}
-      ></InputField>
-      <InputField
-        label="Slack Webhook URL"
-        type="text"
-        {...register("slackUrl")}
-        placeholder="Slack URL"
-        error={errors.slackUrl}
-      ></InputField>
-      <div className="flex flex-row-reverse">
+      <Disclosure defaultOpen={true}>
+        {({ open }) => (
+          <div className="py-4">
+            <DisclosureButton className="block w-full">
+              <div className="flex flex-row items-center justify-between">
+                <h2>Notification Settings</h2>
+                {open ? (
+                  <ChevronDownIcon className="h-6 w-6 text-slate-400 dark:text-slate-500" />
+                ) : (
+                  <ChevronRightIcon className="h-6 w-6 text-slate-400 dark:text-slate-500" />
+                )}
+              </div>
+            </DisclosureButton>
+            <DisclosurePanel unmount={false} className="mt-4">
+              <div className="flex flex-col space-y-4">
+                <span className="text-sm dark:text-slate-300">
+                  See the Readme section on Notifications to see how to add
+                  webhooks, to get notified in a channel when reviews are
+                  necessary.
+                </span>
+                <InputField
+                  label="Teams Webhook URL"
+                  type="text"
+                  {...register("teamsUrl")}
+                  placeholder="Teams URL"
+                  error={errors.teamsUrl}
+                />
+                <InputField
+                  label="Slack Webhook URL"
+                  type="text"
+                  {...register("slackUrl")}
+                  placeholder="Slack URL"
+                  error={errors.slackUrl}
+                />
+              </div>
+            </DisclosurePanel>
+          </div>
+        )}
+      </Disclosure>
+
+      <Disclosure defaultOpen={true}>
+        {({ open }) => (
+          <div className="py-4">
+            <DisclosureButton className="block w-full">
+              <div className="flex flex-row items-center justify-between">
+                <h2>New User Settings</h2>
+                {open ? (
+                  <ChevronDownIcon className="h-6 w-6 text-slate-400 dark:text-slate-500" />
+                ) : (
+                  <ChevronRightIcon className="h-6 w-6 text-slate-400 dark:text-slate-500" />
+                )}
+              </div>
+            </DisclosureButton>
+            <DisclosurePanel unmount={false} className="mt-4">
+              <div className="flex flex-col space-y-4">
+                <span className="text-sm dark:text-slate-300">
+                  Roles assigned to every new user upon registration, in
+                  addition to the Default role.
+                </span>
+                <Controller
+                  name="newUserRoleIds"
+                  control={control}
+                  render={({ field }) => {
+                    const selectedRoles = allRoles.filter((r) =>
+                      (field.value ?? []).includes(r.id),
+                    );
+                    return (
+                      <div>
+                        <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
+                          New User Roles
+                        </label>
+                        <Listbox
+                          value={selectedRoles}
+                          onChange={(roles) =>
+                            field.onChange(roles.map((r) => r.id))
+                          }
+                          multiple
+                        >
+                          <div className="relative">
+                            <ListboxButton className="relative w-64 cursor-default rounded-md bg-white py-1.5 pl-3 pr-10 text-left text-slate-900 ring-1 ring-slate-300 focus:outline-none focus:ring-slate-400 dark:bg-slate-900 dark:text-slate-50 dark:ring-slate-700 sm:text-sm sm:leading-6">
+                              <span className="block truncate">
+                                {selectedRoles.length === 0
+                                  ? "None"
+                                  : selectedRoles.map((r) => r.name).join(", ")}
+                              </span>
+                              <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                                <ChevronUpDownIcon className="h-5 w-5 text-slate-400" />
+                              </span>
+                            </ListboxButton>
+                            <ListboxOptions
+                              anchor="bottom"
+                              className="absolute z-10 mt-1 max-h-60 w-64 overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-slate-900 dark:text-slate-50 sm:text-sm"
+                            >
+                              {allRoles
+                                .filter((r) => !r.isDefault)
+                                .map((role) => (
+                                  <ListboxOption
+                                    key={role.id}
+                                    value={role}
+                                    className="relative cursor-default select-none py-2 pl-3 pr-9 data-[focus]:bg-blue-100 data-[focus]:dark:bg-slate-700"
+                                  >
+                                    {({ selected }) => (
+                                      <>
+                                        <span
+                                          className={
+                                            selected
+                                              ? "font-semibold"
+                                              : "font-normal"
+                                          }
+                                        >
+                                          {role.name}
+                                        </span>
+                                        {selected && (
+                                          <span className="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600">
+                                            <CheckIcon className="h-5 w-5" />
+                                          </span>
+                                        )}
+                                      </>
+                                    )}
+                                  </ListboxOption>
+                                ))}
+                            </ListboxOptions>
+                          </div>
+                        </Listbox>
+                      </div>
+                    );
+                  }}
+                />
+              </div>
+            </DisclosurePanel>
+          </div>
+        )}
+      </Disclosure>
+
+      <div className="flex flex-row-reverse pt-4">
         <Button htmlType="submit" variant="primary">
           Save
         </Button>

--- a/frontend/src/routes/settings/GeneralSettings.tsx
+++ b/frontend/src/routes/settings/GeneralSettings.tsx
@@ -1,12 +1,10 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import {
   ConfigPayload,
   ConfigPayloadSchema,
   ConfigResponse,
 } from "../../api/ConfigApi";
-import { getRoles, RoleResponse } from "../../api/RoleApi";
 import InputField from "../../components/InputField";
 import Button from "../../components/Button";
 import useConfig from "../../components/ConfigProvider";
@@ -15,20 +13,15 @@ import {
   Disclosure,
   DisclosureButton,
   DisclosurePanel,
-  Listbox,
-  ListboxButton,
-  ListboxOption,
-  ListboxOptions,
 } from "@headlessui/react";
-import {
-  CheckIcon,
-  ChevronDownIcon,
-  ChevronRightIcon,
-  ChevronUpDownIcon,
-} from "@heroicons/react/20/solid";
+import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
 
 export default function GeneralSettings() {
   const { config, loading, updateConfig } = useConfig();
+
+  const onSubmit = async (data: ConfigPayload) => {
+    await updateConfig(data);
+  };
 
   return (
     <div>
@@ -36,7 +29,36 @@ export default function GeneralSettings() {
       {loading ? (
         <Spinner size="lg" />
       ) : (
-        config && <ConfigForm config={config} onSubmit={updateConfig} />
+        config && (
+          <div>
+            <Disclosure defaultOpen={true}>
+              {({ open }) => (
+                <>
+                  <DisclosureButton className="py-2">
+                    <div className="flex flex-row justify-between">
+                      <div className="flex flex-row">
+                        <h2>Notification Settings</h2>
+                      </div>
+                      <div className="flex flex-row">
+                        {open ? (
+                          <ChevronDownIcon className="h-6 w-6 text-slate-400 dark:text-slate-500"></ChevronDownIcon>
+                        ) : (
+                          <ChevronRightIcon className="h-6 w-6 text-slate-400 dark:text-slate-500"></ChevronRightIcon>
+                        )}
+                      </div>
+                    </div>
+                  </DisclosureButton>
+                  <DisclosurePanel unmount={false}>
+                    <ConfigForm
+                      config={config}
+                      onSubmit={onSubmit}
+                    ></ConfigForm>
+                  </DisclosurePanel>
+                </>
+              )}
+            </Disclosure>
+          </div>
+        )
       )}
     </div>
   );
@@ -49,167 +71,42 @@ const ConfigForm = ({
   config: ConfigResponse;
   onSubmit: (data: ConfigPayload) => Promise<void>;
 }) => {
-  const [allRoles, setAllRoles] = useState<RoleResponse[]>([]);
-
-  useEffect(() => {
-    void getRoles().then((res) => {
-      if ("roles" in res) setAllRoles(res.roles);
-    });
-  }, []);
   const {
     register,
     handleSubmit,
-    control,
     formState: { errors },
   } = useForm<ConfigPayload>({
     resolver: zodResolver(ConfigPayloadSchema),
     defaultValues: {
-      teamsUrl: config.teamsUrl,
-      slackUrl: config.slackUrl,
-      newUserRoleIds: config.newUserRoleIds ?? [],
+      teamsUrl: config?.teamsUrl,
+      slackUrl: config?.slackUrl,
     },
   });
 
   return (
     <form
-      className="divide-y divide-slate-200 dark:divide-slate-700"
+      className="flex flex-col space-y-4"
       onSubmit={(event) => void handleSubmit(onSubmit)(event)}
     >
-      <Disclosure defaultOpen={true}>
-        {({ open }) => (
-          <div className="py-4">
-            <DisclosureButton className="block w-full">
-              <div className="flex flex-row items-center justify-between">
-                <h2>Notification Settings</h2>
-                {open ? (
-                  <ChevronDownIcon className="h-6 w-6 text-slate-400 dark:text-slate-500" />
-                ) : (
-                  <ChevronRightIcon className="h-6 w-6 text-slate-400 dark:text-slate-500" />
-                )}
-              </div>
-            </DisclosureButton>
-            <DisclosurePanel unmount={false} className="mt-4">
-              <div className="flex flex-col space-y-4">
-                <span className="text-sm dark:text-slate-300">
-                  See the Readme section on Notifications to see how to add
-                  webhooks, to get notified in a channel when reviews are
-                  necessary.
-                </span>
-                <InputField
-                  label="Teams Webhook URL"
-                  type="text"
-                  {...register("teamsUrl")}
-                  placeholder="Teams URL"
-                  error={errors.teamsUrl}
-                />
-                <InputField
-                  label="Slack Webhook URL"
-                  type="text"
-                  {...register("slackUrl")}
-                  placeholder="Slack URL"
-                  error={errors.slackUrl}
-                />
-              </div>
-            </DisclosurePanel>
-          </div>
-        )}
-      </Disclosure>
-
-      <Disclosure defaultOpen={true}>
-        {({ open }) => (
-          <div className="py-4">
-            <DisclosureButton className="block w-full">
-              <div className="flex flex-row items-center justify-between">
-                <h2>New User Settings</h2>
-                {open ? (
-                  <ChevronDownIcon className="h-6 w-6 text-slate-400 dark:text-slate-500" />
-                ) : (
-                  <ChevronRightIcon className="h-6 w-6 text-slate-400 dark:text-slate-500" />
-                )}
-              </div>
-            </DisclosureButton>
-            <DisclosurePanel unmount={false} className="mt-4">
-              <div className="flex flex-col space-y-4">
-                <span className="text-sm dark:text-slate-300">
-                  Roles assigned to every new user upon registration, in
-                  addition to the Default role.
-                </span>
-                <Controller
-                  name="newUserRoleIds"
-                  control={control}
-                  render={({ field }) => {
-                    const selectedRoles = allRoles.filter((r) =>
-                      (field.value ?? []).includes(r.id),
-                    );
-                    return (
-                      <div>
-                        <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
-                          New User Roles
-                        </label>
-                        <Listbox
-                          value={selectedRoles}
-                          onChange={(roles) =>
-                            field.onChange(roles.map((r) => r.id))
-                          }
-                          multiple
-                        >
-                          <div className="relative">
-                            <ListboxButton className="relative w-64 cursor-default rounded-md bg-white py-1.5 pl-3 pr-10 text-left text-slate-900 ring-1 ring-slate-300 focus:outline-none focus:ring-slate-400 dark:bg-slate-900 dark:text-slate-50 dark:ring-slate-700 sm:text-sm sm:leading-6">
-                              <span className="block truncate">
-                                {selectedRoles.length === 0
-                                  ? "None"
-                                  : selectedRoles.map((r) => r.name).join(", ")}
-                              </span>
-                              <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                                <ChevronUpDownIcon className="h-5 w-5 text-slate-400" />
-                              </span>
-                            </ListboxButton>
-                            <ListboxOptions
-                              anchor="bottom"
-                              className="absolute z-10 mt-1 max-h-60 w-64 overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-slate-900 dark:text-slate-50 sm:text-sm"
-                            >
-                              {allRoles
-                                .filter((r) => !r.isDefault)
-                                .map((role) => (
-                                  <ListboxOption
-                                    key={role.id}
-                                    value={role}
-                                    className="relative cursor-default select-none py-2 pl-3 pr-9 data-[focus]:bg-blue-100 data-[focus]:dark:bg-slate-700"
-                                  >
-                                    {({ selected }) => (
-                                      <>
-                                        <span
-                                          className={
-                                            selected
-                                              ? "font-semibold"
-                                              : "font-normal"
-                                          }
-                                        >
-                                          {role.name}
-                                        </span>
-                                        {selected && (
-                                          <span className="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600">
-                                            <CheckIcon className="h-5 w-5" />
-                                          </span>
-                                        )}
-                                      </>
-                                    )}
-                                  </ListboxOption>
-                                ))}
-                            </ListboxOptions>
-                          </div>
-                        </Listbox>
-                      </div>
-                    );
-                  }}
-                />
-              </div>
-            </DisclosurePanel>
-          </div>
-        )}
-      </Disclosure>
-
-      <div className="flex flex-row-reverse pt-4">
+      <span className="text-sm dark:text-slate-300">
+        See the Readme section on Notifications to see how to add webhooks, to
+        get notified in a channel when reviews are necessary.
+      </span>
+      <InputField
+        label="Teams Webhook URL"
+        type="text"
+        {...register("teamsUrl")}
+        placeholder="Teams URL"
+        error={errors.teamsUrl}
+      ></InputField>
+      <InputField
+        label="Slack Webhook URL"
+        type="text"
+        {...register("slackUrl")}
+        placeholder="Slack URL"
+        error={errors.slackUrl}
+      ></InputField>
+      <div className="flex flex-row-reverse">
         <Button htmlType="submit" variant="primary">
           Save
         </Button>

--- a/frontend/src/routes/settings/RolesSettings.tsx
+++ b/frontend/src/routes/settings/RolesSettings.tsx
@@ -1,10 +1,21 @@
 import { useEffect, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 import { RoleResponse, getRoles, removeRole } from "../../api/RoleApi";
+import { ConfigResponse } from "../../api/ConfigApi";
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { isApiErrorResponse } from "../../api/Errors";
 import useNotification from "../../hooks/useNotification";
+import useConfig from "../../components/ConfigProvider";
 import SettingsTable, { Column } from "../../components/SettingsTable";
+import Button from "../../components/Button";
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from "@headlessui/react";
+import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
 
 const useRoles = (): {
   roles: RoleResponse[];
@@ -58,8 +69,114 @@ const useRoles = (): {
   return { roles, isLoading, error, deleteRole };
 };
 
+const NewUserRolesSection = ({
+  config,
+  roles,
+}: {
+  config: ConfigResponse;
+  roles: RoleResponse[];
+}) => {
+  const { updateConfig } = useConfig();
+  const { addNotification } = useNotification();
+  const { control, handleSubmit } = useForm<{ newUserRoleIds: string[] }>({
+    defaultValues: { newUserRoleIds: config.newUserRoleIds ?? [] },
+  });
+
+  const nonDefaultRoles = roles.filter((r) => !r.isDefault);
+
+  const onSubmit = async ({ newUserRoleIds }: { newUserRoleIds: string[] }) => {
+    await updateConfig({ newUserRoleIds });
+    addNotification({
+      title: "New user roles saved",
+      text: "Default roles for new users have been updated",
+      type: "info",
+    });
+  };
+
+  return (
+    <div className="mb-8 rounded-md border border-slate-200 p-4 dark:border-slate-700">
+      <h2 className="mb-1 text-base font-medium">New User Roles</h2>
+      <p className="mb-4 text-sm dark:text-slate-300">
+        Roles assigned to every new user upon registration, in addition to the
+        Default role.
+      </p>
+      <form onSubmit={(e) => void handleSubmit(onSubmit)(e)}>
+        <Controller
+          name="newUserRoleIds"
+          control={control}
+          render={({ field }) => {
+            const selectedRoles = nonDefaultRoles.filter((r) =>
+              (field.value ?? []).includes(r.id),
+            );
+            return (
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
+                  Select roles
+                </label>
+                <Listbox
+                  value={selectedRoles}
+                  onChange={(roles) => field.onChange(roles.map((r) => r.id))}
+                  multiple
+                >
+                  <div className="relative">
+                    <ListboxButton className="relative w-64 cursor-default rounded-md bg-white py-1.5 pl-3 pr-10 text-left text-slate-900 ring-1 ring-slate-300 focus:outline-none focus:ring-slate-400 dark:bg-slate-900 dark:text-slate-50 dark:ring-slate-700 sm:text-sm sm:leading-6">
+                      <span className="block truncate">
+                        {selectedRoles.length === 0
+                          ? "None"
+                          : selectedRoles.map((r) => r.name).join(", ")}
+                      </span>
+                      <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                        <ChevronUpDownIcon className="h-5 w-5 text-slate-400" />
+                      </span>
+                    </ListboxButton>
+                    <ListboxOptions
+                      anchor="bottom"
+                      className="absolute z-10 mt-1 max-h-60 w-64 overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-slate-900 dark:text-slate-50 sm:text-sm"
+                    >
+                      {nonDefaultRoles.map((role) => (
+                        <ListboxOption
+                          key={role.id}
+                          value={role}
+                          className="relative cursor-default select-none py-2 pl-3 pr-9 data-[focus]:bg-blue-100 data-[focus]:dark:bg-slate-700"
+                        >
+                          {({ selected }) => (
+                            <>
+                              <span
+                                className={
+                                  selected ? "font-semibold" : "font-normal"
+                                }
+                              >
+                                {role.name}
+                              </span>
+                              {selected && (
+                                <span className="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600">
+                                  <CheckIcon className="h-5 w-5" />
+                                </span>
+                              )}
+                            </>
+                          )}
+                        </ListboxOption>
+                      ))}
+                    </ListboxOptions>
+                  </div>
+                </Listbox>
+              </div>
+            );
+          }}
+        />
+        <div className="mt-4">
+          <Button htmlType="submit" variant="primary">
+            Save
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
 const RoleSettings = () => {
   const { roles, isLoading, error, deleteRole } = useRoles();
+  const { config } = useConfig();
   const navigate = useNavigate();
 
   const handleDeleteRole = async (role: RoleResponse) => {
@@ -99,6 +216,7 @@ const RoleSettings = () => {
 
   return (
     <div className="container mx-auto px-4 py-8">
+      {config && <NewUserRolesSection config={config} roles={roles} />}
       <SettingsTable
         title="Roles"
         data={roles}


### PR DESCRIPTION
- Configurable default roles for new users in Role settings — adds a newUserRoleIds config key that assigns a list of roles to every newly registered user in addition to the system Default role
- Partial config updates — PUT /config/ now only overwrites the keys present in the request, so General Settings (notifications) and Role Settings can save independently without clobbering each other
- Test coverage — NewUserDefaultRolesTest
- Testcontainers bump — 1.21.4 for Docker Desktop compatibility in local test runs

<img width="900" height="396" alt="Monosnap Kviklet 2026-05-13 14-25-30" src="https://github.com/user-attachments/assets/9b02cc4d-f6d3-40d4-9024-08db5494075a" />

<img width="900" height="378" alt="Monosnap Kviklet 2026-05-13 14-26-35" src="https://github.com/user-attachments/assets/9979ef53-3e79-499e-a2fd-8e08727b3158" />

