### PR TITLE
Add time-range filtering to audit log (enterprise)

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionsController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionsController.kt
@@ -1,7 +1,9 @@
 package dev.kviklet.kviklet.controller
 
+import dev.kviklet.kviklet.security.EnterpriseFeatureException
 import dev.kviklet.kviklet.security.EnterpriseOnly
 import dev.kviklet.kviklet.service.ExecutionRequestService
+import dev.kviklet.kviklet.service.LicenseService
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -10,8 +12,11 @@ import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 data class ExecutionLogResponse(
@@ -31,12 +36,29 @@ data class ExecutionsResponse(val executions: List<ExecutionLogResponse>)
     name = "Executions",
     description = "List all exections that have been run",
 )
-class ExecutionsController(private val executionRequestService: ExecutionRequestService) {
+class ExecutionsController(
+    private val executionRequestService: ExecutionRequestService,
+    private val licenseService: LicenseService,
+) {
     @GetMapping("/")
-    fun getExecutions(): ExecutionsResponse {
-        val executions = executionRequestService.getExecutions()
+    fun getExecutions(
+        @RequestParam(required = false) from: Instant?,
+        @RequestParam(required = false) to: Instant?,
+    ): ExecutionsResponse {
+        if (from != null || to != null) {
+            val license = licenseService.getActiveLicense()
+            if (license == null || !license.isValid()) {
+                throw EnterpriseFeatureException(
+                    "Enterprise license required for: Audit Log Time Filtering. " +
+                        "Please install a valid license file to use this feature.",
+                )
+            }
+        }
+        val fromLocalDateTime = from?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
+        val toLocalDateTime = to?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
+        val executions = executionRequestService.getExecutions(fromLocalDateTime, toLocalDateTime)
         return ExecutionsResponse(
-            executions = executions.sortedByDescending { it.createdAt }.map {
+            executions = executions.map {
                 ExecutionLogResponse(
                     requestId = it.request.getId(),
                     name = it.author.fullName ?: "",

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionsController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionsController.kt
@@ -45,6 +45,8 @@ class ExecutionsController(
         @RequestParam(required = false) from: Instant?,
         @RequestParam(required = false) to: Instant?,
     ): ExecutionsResponse {
+        // The following block is not MIT licensed - it gates the audit log date filter
+        // behind a valid enterprise license. Removing it bypasses license enforcement.
         if (from != null || to != null) {
             val license = licenseService.getActiveLicense()
             if (license == null || !license.isValid()) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/Event.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/Event.kt
@@ -157,6 +157,8 @@ class CustomEventRepositoryImpl(private val entityManager: EntityManager) : Cust
             .from(qEventEntity)
             .where(qEventEntity.type.eq(EventType.EXECUTE))
 
+        // The following two lines are not MIT licensed - they implement the date-range
+        // filter, an enterprise feature gated in ExecutionsController.getExecutions.
         from?.let { query.where(qEventEntity.createdAt.goe(it)) }
         to?.let { query.where(qEventEntity.createdAt.loe(it)) }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/Event.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/Event.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
+import com.querydsl.jpa.impl.JPAQuery
 import dev.kviklet.kviklet.db.util.BaseEntity
 import dev.kviklet.kviklet.db.util.EventPayloadConverter
 import dev.kviklet.kviklet.service.ColumnInfo
@@ -19,6 +20,7 @@ import dev.kviklet.kviklet.service.dto.utcTimeNow
 import jakarta.persistence.Column
 import jakarta.persistence.Convert
 import jakarta.persistence.Entity
+import jakarta.persistence.EntityManager
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.JoinColumn
@@ -142,14 +144,38 @@ class EventEntity(
     }
 }
 
-interface EventRepository : JpaRepository<EventEntity, String> {
+interface CustomEventRepository {
+    fun findExecutionsFiltered(from: LocalDateTime?, to: LocalDateTime?): List<EventEntity>
+}
+
+class CustomEventRepositoryImpl(private val entityManager: EntityManager) : CustomEventRepository {
+
+    private val qEventEntity: QEventEntity = QEventEntity.eventEntity
+
+    override fun findExecutionsFiltered(from: LocalDateTime?, to: LocalDateTime?): List<EventEntity> {
+        val query = JPAQuery<EventEntity>(entityManager)
+            .from(qEventEntity)
+            .where(qEventEntity.type.eq(EventType.EXECUTE))
+
+        from?.let { query.where(qEventEntity.createdAt.goe(it)) }
+        to?.let { query.where(qEventEntity.createdAt.loe(it)) }
+
+        return query
+            .orderBy(qEventEntity.createdAt.desc())
+            .fetch()
+    }
+}
+
+interface EventRepository :
+    JpaRepository<EventEntity, String>,
+    CustomEventRepository {
     fun findByType(type: EventType): List<EventEntity>
 }
 
 @Service
 class EventAdapter(private val eventRepository: EventRepository, private val connectionAdapter: ConnectionAdapter) {
-    fun getExecutions(): List<ExecuteEvent> {
-        val events = eventRepository.findByType(EventType.EXECUTE)
+    fun getExecutions(from: LocalDateTime? = null, to: LocalDateTime? = null): List<ExecuteEvent> {
+        val events = eventRepository.findExecutionsFiltered(from, to)
         return events.map {
             it.toDto(
                 connection = connectionAdapter.toDto(it.executionRequest.connection),

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/EventService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/EventService.kt
@@ -23,6 +23,7 @@ import dev.kviklet.kviklet.service.dto.ResultLog
 import dev.kviklet.kviklet.service.dto.UpdateResultLog
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 
 @Service
 class EventService(
@@ -51,7 +52,8 @@ class EventService(
     }
 
     @Policy(Permission.EXECUTION_REQUEST_GET)
-    fun getAllExecutions(): List<ExecuteEvent> = eventAdapter.getExecutions()
+    fun getAllExecutions(from: LocalDateTime? = null, to: LocalDateTime? = null): List<ExecuteEvent> =
+        eventAdapter.getExecutions(from, to)
 }
 
 fun ExecuteEvent.toPayload(): Payload = ExecutePayload(

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -877,7 +877,8 @@ class ExecutionRequestService(
 
     @Transactional
     @Policy(Permission.EXECUTION_REQUEST_GET)
-    fun getExecutions(): List<ExecuteEvent> = eventService.getAllExecutions()
+    fun getExecutions(from: LocalDateTime? = null, to: LocalDateTime? = null): List<ExecuteEvent> =
+        eventService.getAllExecutions(from, to)
 
     // The following function is not MIT licensed
     @Transactional

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/AuditlogFilterLicenseTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/AuditlogFilterLicenseTest.kt
@@ -1,0 +1,109 @@
+package dev.kviklet.kviklet
+
+import dev.kviklet.kviklet.db.LicenseAdapter
+import dev.kviklet.kviklet.db.User
+import dev.kviklet.kviklet.helper.ConnectionHelper
+import dev.kviklet.kviklet.helper.ExecutionRequestHelper
+import dev.kviklet.kviklet.helper.RoleHelper
+import dev.kviklet.kviklet.helper.UserHelper
+import dev.kviklet.kviklet.service.dto.Connection
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.core.io.FileUrlResource
+import org.springframework.jdbc.datasource.init.ScriptUtils
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+import java.time.Instant
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuditlogFilterLicenseTest {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+
+    @Autowired private lateinit var userHelper: UserHelper
+
+    @Autowired private lateinit var roleHelper: RoleHelper
+
+    @Autowired private lateinit var connectionHelper: ConnectionHelper
+
+    @Autowired private lateinit var executionRequestHelper: ExecutionRequestHelper
+
+    @Autowired private lateinit var licenseAdapter: LicenseAdapter
+
+    private lateinit var testUser: User
+    private lateinit var testConnection: Connection
+
+    companion object {
+        val db: PostgreSQLContainer<*> = PostgreSQLContainer(DockerImageName.parse("postgres:11.1"))
+            .withUsername("root")
+            .withPassword("root")
+            .withReuse(true)
+            .withDatabaseName("test_db")
+
+        init {
+            db.start()
+        }
+    }
+
+    @BeforeEach
+    fun setup() {
+        val initScript = this::class.java.classLoader.getResource("psql_init.sql")!!
+        ScriptUtils.executeSqlScript(db.createConnection(""), FileUrlResource(initScript))
+
+        // Deliberately do NOT set up a license — these tests verify unlicensed behaviour.
+        testUser = userHelper.createUser(permissions = listOf("*"))
+        testConnection = connectionHelper.createPostgresConnection(db)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        executionRequestHelper.deleteAll()
+        connectionHelper.deleteAll()
+        userHelper.deleteAll()
+        roleHelper.deleteAll()
+        licenseAdapter.deleteAll()
+    }
+
+    @Test
+    fun `GET executions with from param without license returns 402`() {
+        val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+        val fromTimestamp = Instant.now().minusSeconds(3600).toString()
+
+        mockMvc.perform(
+            get("/executions/")
+                .param("from", fromTimestamp)
+                .cookie(userCookie),
+        ).andExpect(status().isPaymentRequired)
+    }
+
+    @Test
+    fun `GET executions with to param without license returns 402`() {
+        val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+        val toTimestamp = Instant.now().toString()
+
+        mockMvc.perform(
+            get("/executions/")
+                .param("to", toTimestamp)
+                .cookie(userCookie),
+        ).andExpect(status().isPaymentRequired)
+    }
+
+    @Test
+    fun `GET executions with no filter params without license returns 200`() {
+        val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+        mockMvc.perform(
+            get("/executions/").cookie(userCookie),
+        ).andExpect(status().isOk)
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/AuditlogFilterTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/AuditlogFilterTest.kt
@@ -1,0 +1,305 @@
+package dev.kviklet.kviklet
+
+import dev.kviklet.kviklet.db.LicenseAdapter
+import dev.kviklet.kviklet.db.User
+import dev.kviklet.kviklet.helper.ConnectionHelper
+import dev.kviklet.kviklet.helper.ExecutionRequestHelper
+import dev.kviklet.kviklet.helper.RoleHelper
+import dev.kviklet.kviklet.helper.UserHelper
+import dev.kviklet.kviklet.service.dto.Connection
+import dev.kviklet.kviklet.service.dto.ExecutionRequestDetails
+import dev.kviklet.kviklet.service.dto.LicenseFile
+import jakarta.servlet.http.Cookie
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.core.io.FileUrlResource
+import org.springframework.jdbc.datasource.init.ScriptUtils
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+import java.time.Instant
+import java.time.LocalDateTime
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuditlogFilterTest {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+
+    @Autowired private lateinit var userHelper: UserHelper
+
+    @Autowired private lateinit var roleHelper: RoleHelper
+
+    @Autowired private lateinit var connectionHelper: ConnectionHelper
+
+    @Autowired private lateinit var executionRequestHelper: ExecutionRequestHelper
+
+    @Autowired private lateinit var licenseAdapter: LicenseAdapter
+
+    private lateinit var testUser: User
+    private lateinit var testReviewer: User
+    private lateinit var testConnection: Connection
+
+    companion object {
+        val db: PostgreSQLContainer<*> = PostgreSQLContainer(DockerImageName.parse("postgres:11.1"))
+            .withUsername("root")
+            .withPassword("root")
+            .withReuse(true)
+            .withDatabaseName("test_db")
+
+        init {
+            db.start()
+        }
+    }
+
+    @BeforeEach
+    fun setup() {
+        val initScript = this::class.java.classLoader.getResource("psql_init.sql")!!
+        ScriptUtils.executeSqlScript(db.createConnection(""), FileUrlResource(initScript))
+
+        val licenseJson = """
+            {
+                "license_data":{"max_users":2,"expiry_date":"2100-01-01","test_license":true},
+                "signature":"E3cqrsVzWccsyWwIeCE2J4Mn/eHyP8j4T05Q4o2dtXH1lhum71rEyPqv9MLn//IcVGsLBY6MwWJGxxa+IBqZTvx0fkLix7e44BRJ5xnV83WzZbKyacNCsNqYEbNpeRcDmtC0pbk7/OSff8VDs5xdqWl7zsI+HA5KNdw878BZKVxusHkHhLtxOhHtbm7Gvcyia4XE86USTWUMYf6aCgNkQgRSOnTo5Zrs+vBUvgSI33l3XyBDx+cQcr9Mell2ytOYrTxQ4zUbRkzcsQtGRTHbh8uXQb5wS389F0zQWSLh7RrCRuaEZ0IDTt8tFkN+72fZ64504bsSR9mNgkgKTv/FvQiVCppKO8vpW0T0hg2xziXMnNSJ3MbihcNlpFsz9C2SEnGm18rQ4UagnLCWTqhz5DtWCxeaAExIT261o6J/wBwlsHHMJRiDaLo/cQOLVOUm43psOt4nlTdbijPoKhBejBuSgqSxTid1R7+8YaFlco/SaprzEspWHcOcVIPUN2jk"
+            }
+        """.trimIndent()
+        val licenseFile = LicenseFile(
+            fileContent = licenseJson,
+            fileName = "test-license.json",
+            createdAt = LocalDateTime.now(),
+        )
+        licenseAdapter.createLicense(licenseFile)
+
+        testUser = userHelper.createUser(permissions = listOf("*"))
+        testReviewer = userHelper.createUser(permissions = listOf("*"))
+        testConnection = connectionHelper.createPostgresConnection(db)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        executionRequestHelper.deleteAll()
+        connectionHelper.deleteAll()
+        userHelper.deleteAll()
+        roleHelper.deleteAll()
+        licenseAdapter.deleteAll()
+    }
+
+    /**
+     * Creates an approved request and executes it via the HTTP endpoint, producing an EXECUTE event.
+     * Returns the execution request details (containing the createdAt of the request itself,
+     * but the execute event's createdAt is created at execution time).
+     */
+    private fun createAndExecute(sql: String = "SELECT 1;"): ExecutionRequestDetails {
+        val request = executionRequestHelper.createApprovedRequest(
+            dbcontainer = db,
+            author = testUser,
+            approver = testReviewer,
+            sql = sql,
+            connection = testConnection,
+        )
+        val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+        mockMvc.perform(
+            post("/execution-requests/${request.getId()}/execute")
+                .cookie(userCookie)
+                .contentType("application/json"),
+        ).andExpect(status().isOk)
+        return request
+    }
+
+    @Nested
+    inner class DateRangeFilterTests {
+
+        @Test
+        fun `from only returns executions on or after the given timestamp`() {
+            val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+            createAndExecute("SELECT 1;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 2;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 3;")
+
+            val allExecutions = mockMvc.perform(
+                get("/executions/").cookie(userCookie),
+            ).andExpect(status().isOk)
+                .andReturn()
+
+            // Executions are sorted desc; index 0 is newest (3rd), index 1 is 2nd, index 2 is 1st
+            // Use the 2nd execution's time as the "from" boundary — should return 2nd and 3rd
+            val secondExecutionTime = com.jayway.jsonpath.JsonPath.read<String>(
+                allExecutions.response.contentAsString,
+                "$.executions[1].executionTime",
+            )
+
+            // The field is already an ISO instant string (e.g. 2026-05-09T19:56:20.143985Z)
+            mockMvc.perform(
+                get("/executions/")
+                    .param("from", secondExecutionTime)
+                    .cookie(userCookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.executions", hasSize<Collection<*>>(2)))
+        }
+
+        @Test
+        fun `to only returns executions on or before the given timestamp`() {
+            val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+            createAndExecute("SELECT 1;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 2;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 3;")
+
+            val allExecutions = mockMvc.perform(
+                get("/executions/").cookie(userCookie),
+            ).andExpect(status().isOk)
+                .andReturn()
+
+            // Desc order: index 0=3rd, index 1=2nd, index 2=1st
+            // Use the 2nd execution's time as the "to" boundary — should return 1st and 2nd
+            val secondExecutionTime = com.jayway.jsonpath.JsonPath.read<String>(
+                allExecutions.response.contentAsString,
+                "$.executions[1].executionTime",
+            )
+
+            mockMvc.perform(
+                get("/executions/")
+                    .param("to", secondExecutionTime)
+                    .cookie(userCookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.executions", hasSize<Collection<*>>(2)))
+        }
+
+        @Test
+        fun `from and to together define an inclusive window and boundary records are included`() {
+            val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+            createAndExecute("SELECT 1;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 2;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 3;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 4;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 5;")
+
+            val allExecutions = mockMvc.perform(
+                get("/executions/").cookie(userCookie),
+            ).andExpect(status().isOk)
+                .andReturn()
+
+            // Desc order: index 0=5th, 1=4th, 2=3rd, 3=2nd, 4=1st
+            // from=2nd, to=4th → should return 2nd, 3rd, 4th (3 records)
+            val fourthExecutionTime = com.jayway.jsonpath.JsonPath.read<String>(
+                allExecutions.response.contentAsString,
+                "$.executions[1].executionTime",
+            )
+            val secondExecutionTime = com.jayway.jsonpath.JsonPath.read<String>(
+                allExecutions.response.contentAsString,
+                "$.executions[3].executionTime",
+            )
+
+            // Should return 2nd, 3rd, 4th executions (inclusive bounds)
+            mockMvc.perform(
+                get("/executions/")
+                    .param("from", secondExecutionTime)
+                    .param("to", fourthExecutionTime)
+                    .cookie(userCookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.executions", hasSize<Collection<*>>(3)))
+        }
+
+        @Test
+        fun `boundary records at exact from and to timestamps are included`() {
+            val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+            createAndExecute("SELECT 1;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 2;")
+
+            val allExecutions = mockMvc.perform(
+                get("/executions/").cookie(userCookie),
+            ).andExpect(status().isOk)
+                .andReturn()
+
+            // Desc order: index 0=2nd, index 1=1st
+            val firstExecutionTime = com.jayway.jsonpath.JsonPath.read<String>(
+                allExecutions.response.contentAsString,
+                "$.executions[1].executionTime",
+            )
+            val secondExecutionTime = com.jayway.jsonpath.JsonPath.read<String>(
+                allExecutions.response.contentAsString,
+                "$.executions[0].executionTime",
+            )
+
+            // Use both boundary timestamps as from/to — both records must be included (goe/loe inclusive)
+            mockMvc.perform(
+                get("/executions/")
+                    .param("from", firstExecutionTime)
+                    .param("to", secondExecutionTime)
+                    .cookie(userCookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.executions", hasSize<Collection<*>>(2)))
+        }
+
+        @Test
+        fun `no filter returns all executions`() {
+            val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+            createAndExecute("SELECT 1;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 2;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 3;")
+
+            mockMvc.perform(
+                get("/executions/").cookie(userCookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.executions", hasSize<Collection<*>>(3)))
+        }
+
+        @Test
+        fun `results are sorted descending by executionTime`() {
+            val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+            createAndExecute("SELECT 1;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 2;")
+            Thread.sleep(15)
+            createAndExecute("SELECT 3;")
+
+            val result = mockMvc.perform(
+                get("/executions/").cookie(userCookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.executions", hasSize<Collection<*>>(3)))
+                .andReturn()
+
+            val times = com.jayway.jsonpath.JsonPath.read<List<String>>(
+                result.response.contentAsString,
+                "$.executions[*].executionTime",
+            )
+
+            // Verify descending order: each time must be >= the next (as ISO instant strings)
+            for (i in 0 until times.size - 1) {
+                val t1 = Instant.parse(times[i])
+                val t2 = Instant.parse(times[i + 1])
+                assert(!t1.isBefore(t2)) {
+                    "Expected executions sorted desc by time, but got $t1 before $t2 at index $i"
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/api/ExecutionsApi.ts
+++ b/frontend/src/api/ExecutionsApi.ts
@@ -20,9 +20,20 @@ const ExecutionsResponseSchema = z.object({
 type ExecutionLogResponse = z.infer<typeof ExecutionLogResponseSchema>;
 type ExecutionsResponse = z.infer<typeof ExecutionsResponseSchema>;
 
-const getExecutions = async (): Promise<ApiResponse<ExecutionsResponse>> => {
+const getExecutions = async (params?: {
+  from?: Date;
+  to?: Date;
+}): Promise<ApiResponse<ExecutionsResponse>> => {
+  const searchParams = new URLSearchParams();
+  if (params?.from) {
+    searchParams.append("from", params.from.toISOString());
+  }
+  if (params?.to) {
+    searchParams.append("to", params.to.toISOString());
+  }
+  const query = searchParams.toString();
   return await fetchWithErrorHandling(
-    `${baseUrl}/executions/`,
+    `${baseUrl}/executions/${query ? `?${query}` : ""}`,
     {
       method: "GET",
       headers: {

--- a/frontend/src/routes/Auditlog.tsx
+++ b/frontend/src/routes/Auditlog.tsx
@@ -15,6 +15,8 @@ import {
   ChevronRightIcon,
   ArrowDownTrayIcon,
   LockClosedIcon,
+  XMarkIcon,
+  CalendarDaysIcon,
 } from "@heroicons/react/20/solid";
 import InitialBubble from "../components/InitialBubble";
 import { Link } from "react-router-dom";
@@ -23,7 +25,7 @@ import {
   getExecutions,
   exportExecutions,
 } from "../api/ExecutionsApi";
-import { ChangeEvent, useEffect, useState } from "react";
+import { ChangeEvent, useEffect, useRef, useState } from "react";
 import { timeSince } from "./Requests";
 import { isApiErrorResponse } from "../api/Errors";
 import SearchInput from "../components/SearchInput";
@@ -68,48 +70,219 @@ function ExportButton() {
     }
   };
 
-  const buttonContent = (
-    <Button
-      variant={hasEnterpriseLicense && !isExporting ? "primary" : "disabled"}
-      onClick={() => void handleExport()}
-      className={`flex items-center ${
-        !hasEnterpriseLicense ? "cursor-not-allowed" : ""
-      }`}
-    >
-      {hasEnterpriseLicense ? (
-        <>
-          <ArrowDownTrayIcon className="mr-1.5 h-4 w-4 flex-shrink-0" />
-          <span className="whitespace-nowrap">
-            {isExporting ? "Exporting..." : "Export"}
-          </span>
-        </>
-      ) : (
-        <>
-          <LockClosedIcon className="mr-1.5 h-4 w-4 flex-shrink-0" />
-          <span className="whitespace-nowrap">Export</span>
-        </>
-      )}
-    </Button>
-  );
-
   if (!hasEnterpriseLicense) {
     return (
       <Tooltip content="Enterprise feature - License required">
-        {buttonContent}
+        <button
+          type="button"
+          disabled
+          className="flex cursor-not-allowed items-center gap-1.5 rounded-md border border-slate-300 bg-slate-100 px-3 py-1 text-sm font-medium leading-5 text-slate-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500"
+        >
+          <LockClosedIcon className="h-4 w-4 flex-shrink-0" />
+          <span className="whitespace-nowrap">Export</span>
+        </button>
       </Tooltip>
     );
   }
 
-  return buttonContent;
+  return (
+    <Button
+      variant={isExporting ? "disabled" : "primary"}
+      onClick={() => void handleExport()}
+      className="flex items-center"
+    >
+      <ArrowDownTrayIcon className="mr-1.5 h-4 w-4 flex-shrink-0" />
+      <span className="whitespace-nowrap">
+        {isExporting ? "Exporting..." : "Export"}
+      </span>
+    </Button>
+  );
 }
 
-function useExecutions() {
+const toLocalInputValue = (d: Date | null): string => {
+  if (!d) return "";
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours(),
+  )}:${pad(d.getMinutes())}`;
+};
+
+const formatRangeChip = (from: Date | null, to: Date | null): string => {
+  const fmt = (d: Date) =>
+    d.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  if (from && to) return `${fmt(from)} – ${fmt(to)}`;
+  if (from) return `From ${fmt(from)}`;
+  if (to) return `Until ${fmt(to)}`;
+  return "Date range";
+};
+
+function DateRangeFilter({
+  from,
+  to,
+  onChange,
+  disabled = false,
+}: {
+  from: Date | null;
+  to: Date | null;
+  onChange: (from: Date | null, to: Date | null) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const hasFilter = from !== null || to !== null;
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointer = (e: MouseEvent) => {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  const inputClasses =
+    "w-full rounded-md border border-slate-300 bg-white px-2.5 py-1.5 text-sm text-slate-900 [color-scheme:light] focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:[color-scheme:dark] dark:focus:border-indigo-500 dark:focus:ring-indigo-500";
+
+  if (disabled) {
+    return (
+      <Tooltip content="Enterprise feature - License required">
+        <button
+          type="button"
+          disabled
+          className="flex cursor-not-allowed items-center gap-1.5 rounded-md border border-slate-300 bg-slate-100 px-3 py-1 text-sm font-medium leading-5 text-slate-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500"
+        >
+          <LockClosedIcon className="h-4 w-4 flex-shrink-0" />
+          <span>Date range</span>
+        </button>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className={`flex max-w-full items-center gap-1.5 rounded-md border px-3 py-1 text-sm font-medium leading-5 transition-colors ${
+          hasFilter
+            ? "border-indigo-300 bg-indigo-50 text-indigo-700 hover:border-indigo-400 hover:bg-indigo-100 dark:border-indigo-500/40 dark:bg-indigo-500/10 dark:text-indigo-300 dark:hover:border-indigo-500/60 dark:hover:bg-indigo-500/15"
+            : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
+        }`}
+      >
+        <CalendarDaysIcon className="h-4 w-4 flex-shrink-0" />
+        <span className="truncate">{formatRangeChip(from, to)}</span>
+        {hasFilter && (
+          <span
+            role="button"
+            tabIndex={0}
+            aria-label="Clear date range"
+            onClick={(e) => {
+              e.stopPropagation();
+              onChange(null, null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.stopPropagation();
+                onChange(null, null);
+              }
+            }}
+            className="-mr-1 ml-0.5 inline-flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-sm text-indigo-500 hover:bg-indigo-200/70 hover:text-indigo-800 dark:text-indigo-300/70 dark:hover:bg-indigo-500/30 dark:hover:text-indigo-100"
+          >
+            <XMarkIcon className="h-3.5 w-3.5" />
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Filter by date range"
+          className="absolute right-0 z-20 mt-2 w-72 max-w-[calc(100vw-2rem)] origin-top-right rounded-lg border border-slate-200 bg-white p-3.5 shadow-lg ring-1 ring-black/5 dark:border-slate-700 dark:bg-slate-900 dark:ring-white/5"
+        >
+          <div className="space-y-3">
+            <div>
+              <label className="mb-1 block text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                From
+              </label>
+              <input
+                type="datetime-local"
+                value={toLocalInputValue(from)}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  onChange(val ? new Date(val) : null, to);
+                }}
+                className={inputClasses}
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                To
+              </label>
+              <input
+                type="datetime-local"
+                value={toLocalInputValue(to)}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  onChange(from, val ? new Date(val) : null);
+                }}
+                className={inputClasses}
+              />
+            </div>
+            <div className="flex items-center justify-between border-t border-slate-100 pt-3 dark:border-slate-800">
+              <button
+                type="button"
+                disabled={!hasFilter}
+                onClick={() => onChange(null, null)}
+                className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-xs text-slate-500 disabled:cursor-not-allowed disabled:opacity-40 hover:bg-slate-100 hover:text-slate-700 disabled:hover:bg-transparent disabled:hover:text-slate-500 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+              >
+                <XMarkIcon className="h-3.5 w-3.5" />
+                Clear
+              </button>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-md bg-indigo-600 px-3 py-1 text-xs font-medium text-white hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function useExecutions(from: Date | null, to: Date | null) {
   const [executions, setExecutions] = useState<ExecutionLogResponse[]>([]);
   const [loading, setLoading] = useState(true);
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
-      const response = await getExecutions();
+      const response = await getExecutions({
+        from: from ?? undefined,
+        to: to ?? undefined,
+      });
       if (isApiErrorResponse(response)) {
         console.error(response);
       } else {
@@ -118,12 +291,19 @@ function useExecutions() {
       setLoading(false);
     };
     void fetchData();
-  }, []);
+  }, [from, to]);
   return { executions, loading };
 }
 
 function List() {
-  const { executions, loading } = useExecutions();
+  const { config } = useConfig();
+  const hasEnterpriseLicense =
+    !!config?.licenseValid &&
+    !!config?.validUntil &&
+    config.validUntil > new Date();
+  const [from, setFrom] = useState<Date | null>(null);
+  const [to, setTo] = useState<Date | null>(null);
+  const { executions, loading } = useExecutions(from, to);
   const [searchTerm, setSearchTerm] = useState("");
   const filteredExecutions = executions.filter(
     (execution) =>
@@ -131,16 +311,26 @@ function List() {
       execution.statement.toLowerCase().includes(searchTerm.toLowerCase()) ||
       execution.connectionId.toLowerCase().includes(searchTerm.toLowerCase()),
   );
+
   return (
     <div>
-      <div className="my-4 flex gap-2">
+      <div className="my-4 flex flex-wrap items-center gap-2">
         <SearchInput
           value={searchTerm}
           onChange={(e: ChangeEvent<HTMLInputElement>) => {
             setSearchTerm(e.target.value);
           }}
           placeholder="Search Auditlog"
-          className="flex-1"
+          className="min-w-40 flex-1 [&_input]:py-1"
+        />
+        <DateRangeFilter
+          from={from}
+          to={to}
+          disabled={!hasEnterpriseLicense}
+          onChange={(nextFrom, nextTo) => {
+            setFrom(nextFrom);
+            setTo(nextTo);
+          }}
         />
         <ExportButton />
       </div>


### PR DESCRIPTION
## Summary

Adds the ability to filter the audit log by execution timestamp — answering "what was executed between X and Y?". Closes the loop on #451 (the original request was for the execution requests page, but the audit log is the more natural home).

## Changes

**Backend**
- `GET /executions/` accepts optional `from` / `to` ISO-Instant query params (inclusive bounds, converted to UTC `LocalDateTime`).
- New `CustomEventRepository` with a QueryDSL filter that scopes to `EventType.EXECUTE`, applies `goe`/`loe` on `createdAt`, and orders descending. Replaces the in-memory `findByType` + sort.
- License gating: when either `from` or `to` is set, the controller throws `EnterpriseFeatureException` (HTTP 402) unless a valid license is present. Unfiltered listing remains free.

**Frontend**
- New `DateRangeFilter` chip-style component on the audit log page: shows the active range inline, opens a popover with two `datetime-local` inputs and Done / Clear actions. Uses `[color-scheme:light dark]` so the native picker themes correctly in both modes.
- Without a license: chip renders disabled with a lock icon and a tooltip ("Enterprise feature - License required"). The Export button's disabled state was retouched to match this design language.
- `getExecutions` accepts `{ from?, to? }` and sends them as ISO Instants.

**Tests**
- `AuditlogFilterTest` (with license set up) — 6 cases covering only-from, only-to, both, boundary inclusivity, no-filter, and ordering.
- `AuditlogFilterLicenseTest` (no license) — verifies 402 when filtering, 200 when not.