### PR TITLE
Add GitHub OAuth2 SSO support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -190,7 +190,7 @@ docker run \
 ghcr.io/kviklet/kviklet:main
 ```
 
-### SSO via OIDC
+### SSO via OIDC / OAuth2
 
 #### Google
 
@@ -228,9 +228,28 @@ For Allowed Origins, simply your hosted kviklet url.
 
 After setting those environment variables the login page should show a Login with Keycloak button that redirects to your keycloak instance. In the enterprise edition you can enable role sync to automatically sync roles from your keycloak instance to kviklet. See the [Role Sync](#role-sync-enterprise) section for more details.
 
+#### GitHub
+
+GitHub is not OIDC-compliant (it's pure OAuth 2.0), so it has dedicated support in Kviklet. Set these environment variables:
+
+```
+KVIKLET_IDENTITYPROVIDER_CLIENTID
+KVIKLET_IDENTITYPROVIDER_CLIENTSECRET
+KVIKLET_IDENTITYPROVIDER_TYPE=github
+```
+
+Create a GitHub OAuth App at https://github.com/settings/developers and configure:
+
+- Authorization callback URL: `https://[kviklet_host]/api/login/oauth2/code/github`
+- Homepage URL: your hosted Kviklet URL
+
+Kviklet requests the `read:user` and `user:email` scopes, so users with private email addresses on their GitHub account will still log in successfully — Kviklet falls back to the GitHub `/user/emails` endpoint to fetch the primary verified email.
+
+After setting those environment variables a "Login with github" button appears on the login page. As with the other SSO methods, new users have no permissions by default — assign them a role after their first login.
+
 #### Other OIDC providers
 
-Other OIDC providers should work similarly to Keycloak. Note that the `redirect URI` will change depending on the type you choose, so if you choose `gitlab` it will be `https://[kviklet_host]/api/login/oauth2/code/gitlab`.
+Other OIDC-compliant providers (GitLab, Auth0, Okta, etc.) should work similarly to Keycloak. Note that the `redirect URI` will change depending on the type you choose, so if you choose `gitlab` it will be `https://[kviklet_host]/api/login/oauth2/code/gitlab`.
 If you run into issues feel free to create an issue, we have not tried every single OIDC provider out there (yet) and there might be slight differences in the implementation that might require updates on Kviklet's side.
 
 ### LDAP

--- a/Readme.md
+++ b/Readme.md
@@ -236,6 +236,7 @@ GitHub is not OIDC-compliant (it's pure OAuth 2.0), so it has dedicated support 
 KVIKLET_IDENTITYPROVIDER_CLIENTID
 KVIKLET_IDENTITYPROVIDER_CLIENTSECRET
 KVIKLET_IDENTITYPROVIDER_TYPE=github
+KVIKLET_IDENTITYPROVIDER_GITHUB_ALLOWEDORGS=your-org,another-org
 ```
 
 Create a GitHub OAuth App at https://github.com/settings/developers and configure:
@@ -243,7 +244,9 @@ Create a GitHub OAuth App at https://github.com/settings/developers and configur
 - Authorization callback URL: `https://[kviklet_host]/api/login/oauth2/code/github`
 - Homepage URL: your hosted Kviklet URL
 
-Kviklet requests the `read:user` and `user:email` scopes, so users with private email addresses on their GitHub account will still log in successfully — Kviklet falls back to the GitHub `/user/emails` endpoint to fetch the primary verified email.
+`KVIKLET_IDENTITYPROVIDER_GITHUB_ALLOWEDORGS` is **required** (Kviklet refuses to start without it). GitHub OAuth Apps cannot restrict who is allowed to authenticate — any user on github.com can complete the OAuth flow against your app — so Kviklet enforces this on its side by calling `/user/orgs` after authentication and rejecting users who are not a member of at least one configured org. Org names are compared case-insensitively; up to 100 of the user's orgs are checked.
+
+Kviklet requests the `read:user`, `user:email` and `read:org` scopes. `read:org` is needed for the membership check and to surface private org memberships. Users with private email addresses on their GitHub account still log in successfully — Kviklet falls back to the GitHub `/user/emails` endpoint to fetch the primary verified email.
 
 After setting those environment variables a "Login with github" button appears on the login page. As with the other SSO methods, new users have no permissions by default — assign them a role after their first login.
 

--- a/Readme.md
+++ b/Readme.md
@@ -228,7 +228,9 @@ For Allowed Origins, simply your hosted kviklet url.
 
 After setting those environment variables the login page should show a Login with Keycloak button that redirects to your keycloak instance. In the enterprise edition you can enable role sync to automatically sync roles from your keycloak instance to kviklet. See the [Role Sync](#role-sync-enterprise) section for more details.
 
-#### GitHub
+#### GitHub (Beta)
+
+> **Beta:** GitHub authentication is new and does **not** support [role sync](#role-sync-enterprise) yet — every new user lands with the default role and has to be assigned roles manually.
 
 GitHub is not OIDC-compliant (it's pure OAuth 2.0), so it has dedicated support in Kviklet. Set these environment variables:
 
@@ -244,11 +246,11 @@ Create a GitHub OAuth App at https://github.com/settings/developers and configur
 - Authorization callback URL: `https://[kviklet_host]/api/login/oauth2/code/github`
 - Homepage URL: your hosted Kviklet URL
 
-`KVIKLET_IDENTITYPROVIDER_GITHUB_ALLOWEDORGS` is **required** (Kviklet refuses to start without it). GitHub OAuth Apps cannot restrict who is allowed to authenticate — any user on github.com can complete the OAuth flow against your app — so Kviklet enforces this on its side by calling `/user/orgs` after authentication and rejecting users who are not a member of at least one configured org. Org names are compared case-insensitively; up to 100 of the user's orgs are checked.
+`KVIKLET_IDENTITYPROVIDER_GITHUB_ALLOWEDORGS` is **required** (Kviklet refuses to start without it). GitHub OAuth Apps can't restrict who completes the OAuth flow, so Kviklet calls `/user/orgs` after authentication and rejects users who are not a member of at least one allowlisted org (case-insensitive, first 100 orgs checked).
 
-Kviklet requests the `read:user`, `user:email` and `read:org` scopes. `read:org` is needed for the membership check and to surface private org memberships. Users with private email addresses on their GitHub account still log in successfully — Kviklet falls back to the GitHub `/user/emails` endpoint to fetch the primary verified email.
+For the org check to see a user's membership, the user must click **Grant** (or **Request**) next to each allowlisted org on the OAuth consent screen. If the org has "Restrict third-party OAuth applications" enabled, an org owner also has to approve the OAuth app once before any member's membership becomes visible.
 
-After setting those environment variables a "Login with github" button appears on the login page. As with the other SSO methods, new users have no permissions by default — assign them a role after their first login.
+Kviklet requests the `read:user`, `user:email` and `read:org` scopes. Emails are always read from `/user/emails` and only a `primary && verified` entry is accepted, so users with private email addresses still log in successfully.
 
 #### Other OIDC providers
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     testImplementation("io.mockk:mockk:1.13.4")
     testImplementation("com.ninja-squad:springmockk:4.0.2")
     testImplementation("net.sourceforge.htmlunit:htmlunit:2.70.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 
     // querydsl
     implementation("com.querydsl:querydsl-core:$queryDslVersion")

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/User.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/User.kt
@@ -44,6 +44,9 @@ class UserEntity(
     var samlNameId: String? = null,
 
     @Column(unique = true)
+    var githubId: String? = null,
+
+    @Column(unique = true)
     var email: String = "",
 
     @ManyToMany(cascade = [CascadeType.PERSIST], fetch = FetchType.LAZY)
@@ -61,6 +64,7 @@ class UserEntity(
         subject = subject,
         ldapIdentifier = ldapIdentifier,
         samlNameId = samlNameId,
+        githubId = githubId,
         email = email,
         roles = roles.map { it.toDto() }.toMutableSet(),
     )
@@ -82,6 +86,7 @@ data class User(
     val subject: String? = null,
     val ldapIdentifier: String? = null,
     val samlNameId: String? = null,
+    val githubId: String? = null,
     val email: String = "",
     val roles: Set<Role> = HashSet(),
 ) : SecuredDomainObject {
@@ -122,6 +127,8 @@ interface UserRepository : JpaRepository<UserEntity, String> {
     fun findByLdapIdentifier(ldapIdentifier: String): UserEntity?
 
     fun findBySamlNameId(samlNameId: String): UserEntity?
+
+    fun findByGithubId(githubId: String): UserEntity?
 }
 
 @Service
@@ -151,6 +158,12 @@ class UserAdapter(private val userRepository: UserRepository, private val roleRe
     }
 
     @Transactional(readOnly = true)
+    fun findByGithubId(githubId: String): User? {
+        val userEntity = userRepository.findByGithubId(githubId) ?: return null
+        return userEntity.toDto()
+    }
+
+    @Transactional(readOnly = true)
     fun findById(id: String): User {
         val userEntity = userRepository.findByIdOrNull(id) ?: throw EntityNotFound(
             "User not found",
@@ -167,6 +180,7 @@ class UserAdapter(private val userRepository: UserRepository, private val roleRe
             password = user.password,
             subject = user.subject,
             samlNameId = user.samlNameId,
+            githubId = user.githubId,
             email = user.email,
             roles = roleRepository.findAllById(user.roles.map { it.getId() }.toSet()).toMutableSet(),
         )
@@ -188,6 +202,7 @@ class UserAdapter(private val userRepository: UserRepository, private val roleRe
             userEntity.password = user.password
             userEntity.subject = user.subject
             userEntity.samlNameId = user.samlNameId
+            userEntity.githubId = user.githubId
             userEntity.email = user.email
             userEntity.roles = roleRepository.findAllById(user.roles.map { it.getId() }.toSet()).toMutableSet()
             val savedUserEntity = userRepository.save(userEntity)
@@ -205,6 +220,7 @@ class UserAdapter(private val userRepository: UserRepository, private val roleRe
         userEntity.password = user.password
         userEntity.subject = user.subject
         userEntity.samlNameId = user.samlNameId
+        userEntity.githubId = user.githubId
         userEntity.email = user.email
         // update Roles
         user.roles.let { newRoleIds ->

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/AuthenticationProviderValidator.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/AuthenticationProviderValidator.kt
@@ -1,6 +1,7 @@
 package dev.kviklet.kviklet.security
 
 import dev.kviklet.kviklet.security.ldap.LdapProperties
+import dev.kviklet.kviklet.security.oauth2.GithubProperties
 import dev.kviklet.kviklet.security.saml.SamlProperties
 import org.springframework.beans.factory.SmartInitializingSingleton
 import org.springframework.context.annotation.Configuration
@@ -10,6 +11,7 @@ class AuthenticationProviderValidator(
     private val ldapProperties: LdapProperties,
     private val identityProviderProperties: IdentityProviderProperties,
     private val samlProperties: SamlProperties,
+    private val githubProperties: GithubProperties,
 ) : SmartInitializingSingleton {
     override fun afterSingletonsInstantiated() {
         val enabledProviders = mutableListOf<String>()
@@ -29,6 +31,18 @@ class AuthenticationProviderValidator(
                 "Only one external authentication provider can be enabled at a time. " +
                     "Currently enabled: ${enabledProviders.joinToString(", ")}. " +
                     "Please disable all but one provider.",
+            )
+        }
+
+        if (identityProviderProperties.type?.lowercase() == "github" &&
+            identityProviderProperties.isOauth2Enabled() &&
+            githubProperties.normalizedAllowedOrgs().isEmpty()
+        ) {
+            throw IllegalStateException(
+                "GitHub authentication requires kviklet.identity-provider.github.allowed-orgs " +
+                    "(env: KVIKLET_IDENTITYPROVIDER_GITHUB_ALLOWEDORGS) to be set to at least one " +
+                    "organization. Without this restriction any GitHub user on github.com could log " +
+                    "in to this Kviklet instance.",
             )
         }
     }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/IdentityProviderConfig.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/IdentityProviderConfig.kt
@@ -1,5 +1,6 @@
 package dev.kviklet.kviklet.security
 
+import dev.kviklet.kviklet.security.oauth2.GithubProperties
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -7,6 +8,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
 import org.springframework.core.env.Environment
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.oauth2.client.CommonOAuth2Provider
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
 import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient
@@ -50,6 +52,7 @@ class IdentityProviderProperties {
 @EnableWebSecurity
 data class IdentityProviderConfig(
     private val properties: IdentityProviderProperties,
+    private val githubProperties: GithubProperties,
     private val environment: Environment,
 ) {
 
@@ -64,6 +67,19 @@ data class IdentityProviderConfig(
             "{baseUrl}/api/login/oauth2/code/{registrationId}"
         } else {
             "{baseUrl}/login/oauth2/code/{registrationId}"
+        }
+        if (properties.type == "github") {
+            val registration = CommonOAuth2Provider.GITHUB
+                .getBuilder("github")
+                .clientId(properties.clientId)
+                .clientSecret(properties.clientSecret)
+                .redirectUri(redirectUri)
+                .scope("read:user", "user:email")
+                .authorizationUri(githubProperties.authorizationUri)
+                .tokenUri(githubProperties.tokenUri)
+                .userInfoUri(githubProperties.userInfoUri)
+                .build()
+            return InMemoryClientRegistrationRepository(registration)
         }
         if (properties.getIssuer().isNullOrBlank() &&
             (

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/IdentityProviderConfig.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/IdentityProviderConfig.kt
@@ -74,7 +74,7 @@ data class IdentityProviderConfig(
                 .clientId(properties.clientId)
                 .clientSecret(properties.clientSecret)
                 .redirectUri(redirectUri)
-                .scope("read:user", "user:email")
+                .scope("read:user", "user:email", "read:org")
                 .authorizationUri(githubProperties.authorizationUri)
                 .tokenUri(githubProperties.tokenUri)
                 .userInfoUri(githubProperties.userInfoUri)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/KvikletOAuthPrincipal.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/KvikletOAuthPrincipal.kt
@@ -1,0 +1,5 @@
+package dev.kviklet.kviklet.security
+
+interface KvikletOAuthPrincipal {
+    fun getUserDetails(): UserDetailsWithId
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
@@ -4,6 +4,7 @@ import dev.kviklet.kviklet.controller.ServerUrlInterceptor
 import dev.kviklet.kviklet.db.UserAdapter
 import dev.kviklet.kviklet.security.ldap.LdapProperties
 import dev.kviklet.kviklet.security.ldap.LdapUserDetailsService
+import dev.kviklet.kviklet.security.oauth2.GithubOAuth2UserService
 import dev.kviklet.kviklet.security.oidc.OidcLoginSuccessHandler
 import dev.kviklet.kviklet.security.oidc.OidcUserService
 import dev.kviklet.kviklet.security.saml.SamlLoginSuccessHandler
@@ -76,6 +77,7 @@ class SecurityConfig(
     private val oidcLoginSuccessHandler: OidcLoginSuccessHandler,
     private val customAuthenticationProvider: CustomAuthenticationProvider,
     private val oidcUserService: OidcUserService,
+    private val githubOAuth2UserService: GithubOAuth2UserService,
     private val idpProperties: IdentityProviderProperties,
     private val ldapProperties: LdapProperties,
     private val samlProperties: SamlProperties,
@@ -194,6 +196,7 @@ class SecurityConfig(
                     authenticationSuccessHandler = oidcLoginSuccessHandler
                     userInfoEndpoint {
                         oidcUserService = this@SecurityConfig.oidcUserService
+                        userService = this@SecurityConfig.githubOAuth2UserService
                     }
                 }
             }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/UserAuthService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/UserAuthService.kt
@@ -17,6 +17,7 @@ sealed class IdpIdentifier {
     data class Saml(val nameId: String) : IdpIdentifier()
     data class Oidc(val subject: String) : IdpIdentifier()
     data class Ldap(val identifier: String) : IdpIdentifier()
+    data class GitHub(val id: String) : IdpIdentifier()
 }
 
 /**
@@ -98,6 +99,7 @@ class UserAuthService(
         is IdpIdentifier.Saml -> userAdapter.findBySamlNameId(idpIdentifier.nameId)
         is IdpIdentifier.Oidc -> userAdapter.findBySubject(idpIdentifier.subject)
         is IdpIdentifier.Ldap -> userAdapter.findByLdapIdentifier(idpIdentifier.identifier)
+        is IdpIdentifier.GitHub -> userAdapter.findByGithubId(idpIdentifier.id)
     }
 
     private fun updateUserIdentifier(
@@ -112,6 +114,7 @@ class UserAuthService(
                 samlNameId = idpIdentifier.nameId,
                 subject = null,
                 ldapIdentifier = null,
+                githubId = null,
                 password = null,
                 email = email,
                 fullName = fullName ?: user.fullName,
@@ -121,6 +124,7 @@ class UserAuthService(
                 subject = idpIdentifier.subject,
                 samlNameId = null,
                 ldapIdentifier = null,
+                githubId = null,
                 password = null,
                 email = email,
                 fullName = fullName ?: user.fullName,
@@ -130,6 +134,17 @@ class UserAuthService(
                 ldapIdentifier = idpIdentifier.identifier,
                 subject = null,
                 samlNameId = null,
+                githubId = null,
+                password = null,
+                email = email,
+                fullName = fullName ?: user.fullName,
+            )
+
+            is IdpIdentifier.GitHub -> user.copy(
+                githubId = idpIdentifier.id,
+                subject = null,
+                samlNameId = null,
+                ldapIdentifier = null,
                 password = null,
                 email = email,
                 fullName = fullName ?: user.fullName,

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/oauth2/GithubOAuth2User.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/oauth2/GithubOAuth2User.kt
@@ -1,0 +1,28 @@
+package dev.kviklet.kviklet.security.oauth2
+
+import dev.kviklet.kviklet.security.KvikletOAuthPrincipal
+import dev.kviklet.kviklet.security.UserDetailsWithId
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.oauth2.core.user.OAuth2User
+import java.io.Serializable
+
+class GithubOAuth2User(
+    private val delegate: OAuth2User,
+    private val userDetails: UserDetailsWithId,
+    private val authorities: Collection<GrantedAuthority>,
+) : OAuth2User,
+    KvikletOAuthPrincipal,
+    Serializable {
+
+    override fun getName(): String = delegate.name
+
+    override fun getAttributes(): Map<String, Any> = delegate.attributes
+
+    override fun getAuthorities(): Collection<GrantedAuthority> = authorities
+
+    override fun getUserDetails(): UserDetailsWithId = userDetails
+
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/oauth2/GithubOAuth2UserService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/oauth2/GithubOAuth2UserService.kt
@@ -6,6 +6,7 @@ import dev.kviklet.kviklet.security.UserAuthService
 import dev.kviklet.kviklet.security.UserDetailsWithId
 import dev.kviklet.kviklet.service.RoleSyncService
 import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
@@ -25,6 +26,8 @@ class GithubOAuth2UserService(
     private val restTemplate: RestTemplate,
 ) : DefaultOAuth2UserService() {
 
+    private val logger = LoggerFactory.getLogger(GithubOAuth2UserService::class.java)
+
     @Transactional
     override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
         if (userRequest.clientRegistration.registrationId != "github") {
@@ -39,10 +42,11 @@ class GithubOAuth2UserService(
                 OAuth2Error("invalid_user_info_response", "GitHub user response missing 'id' attribute", null),
             )
 
+        enforceAllowedOrgMembership(userRequest.accessToken.tokenValue)
+
         val name = attributes["name"] as? String ?: attributes["login"] as? String
 
-        val email = attributes["email"] as? String
-            ?: fetchPrimaryVerifiedEmail(userRequest.accessToken.tokenValue)
+        val email = fetchPrimaryVerifiedEmail(userRequest.accessToken.tokenValue)
 
         val groups = roleSyncService.extractGroups(attributes)
 
@@ -60,6 +64,64 @@ class GithubOAuth2UserService(
         return GithubOAuth2User(oauth2User, userDetails, policies)
     }
 
+    private fun enforceAllowedOrgMembership(accessToken: String) {
+        val allowed = githubProperties.normalizedAllowedOrgs()
+        // AuthenticationProviderValidator guarantees this is non-empty at startup.
+        // Re-check here as a defence-in-depth; without it a misconfigured instance would let any
+        // GitHub user in.
+        if (allowed.isEmpty()) {
+            throw OAuth2AuthenticationException(
+                OAuth2Error(
+                    "server_error",
+                    "GitHub authentication is misconfigured: no allowed organizations set.",
+                    null,
+                ),
+            )
+        }
+
+        val userOrgs = fetchUserOrgs(accessToken).map { it.lowercase() }.toSet()
+        if (userOrgs.intersect(allowed).isEmpty()) {
+            throw OAuth2AuthenticationException(
+                OAuth2Error(
+                    "access_denied",
+                    "Your GitHub account is not a member of an organization allowed to access this Kviklet instance.",
+                    null,
+                ),
+            )
+        }
+    }
+
+    private fun fetchUserOrgs(accessToken: String): List<String> {
+        val headers = HttpHeaders().apply {
+            setBearerAuth(accessToken)
+            set(HttpHeaders.ACCEPT, "application/vnd.github+json")
+        }
+        val uri = if (githubProperties.orgsUri.contains("?")) {
+            "${githubProperties.orgsUri}&per_page=100"
+        } else {
+            "${githubProperties.orgsUri}?per_page=100"
+        }
+        val response = try {
+            restTemplate.exchange(
+                uri,
+                HttpMethod.GET,
+                HttpEntity<Void>(headers),
+                Array<GithubOrg>::class.java,
+            )
+        } catch (e: Exception) {
+            logger.warn("Failed to fetch user organizations from GitHub", e)
+            throw OAuth2AuthenticationException(
+                OAuth2Error(
+                    "user_orgs_unavailable",
+                    "Failed to fetch user organizations from GitHub.",
+                    null,
+                ),
+                e,
+            )
+        }
+        return (response.body ?: emptyArray()).map { it.login }
+    }
+
     private fun fetchPrimaryVerifiedEmail(accessToken: String): String {
         val headers = HttpHeaders().apply {
             setBearerAuth(accessToken)
@@ -73,10 +135,11 @@ class GithubOAuth2UserService(
                 Array<GithubEmail>::class.java,
             )
         } catch (e: Exception) {
+            logger.warn("Failed to fetch user emails from GitHub", e)
             throw OAuth2AuthenticationException(
                 OAuth2Error(
                     "user_email_unavailable",
-                    "Failed to fetch user emails from GitHub: ${e.message}",
+                    "Failed to fetch user emails from GitHub.",
                     null,
                 ),
                 e,
@@ -88,8 +151,7 @@ class GithubOAuth2UserService(
             ?: throw OAuth2AuthenticationException(
                 OAuth2Error(
                     "user_email_unavailable",
-                    "No primary verified email returned by GitHub. " +
-                        "Make your email public on your GitHub account or grant the 'user:email' scope.",
+                    "GitHub did not return a primary verified email for this account.",
                     null,
                 ),
             )
@@ -103,3 +165,5 @@ private data class GithubEmail(
     val verified: Boolean = false,
     val visibility: String? = null,
 )
+
+private data class GithubOrg(val login: String = "")

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/oauth2/GithubOAuth2UserService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/oauth2/GithubOAuth2UserService.kt
@@ -1,0 +1,105 @@
+package dev.kviklet.kviklet.security.oauth2
+
+import dev.kviklet.kviklet.security.IdpIdentifier
+import dev.kviklet.kviklet.security.PolicyGrantedAuthority
+import dev.kviklet.kviklet.security.UserAuthService
+import dev.kviklet.kviklet.security.UserDetailsWithId
+import dev.kviklet.kviklet.service.RoleSyncService
+import jakarta.transaction.Transactional
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException
+import org.springframework.security.oauth2.core.OAuth2Error
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+
+@Service
+class GithubOAuth2UserService(
+    private val userAuthService: UserAuthService,
+    private val roleSyncService: RoleSyncService,
+    private val githubProperties: GithubProperties,
+    private val restTemplate: RestTemplate,
+) : DefaultOAuth2UserService() {
+
+    @Transactional
+    override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
+        if (userRequest.clientRegistration.registrationId != "github") {
+            return super.loadUser(userRequest)
+        }
+
+        val oauth2User = super.loadUser(userRequest)
+        val attributes = oauth2User.attributes
+
+        val id = attributes["id"]?.toString()
+            ?: throw OAuth2AuthenticationException(
+                OAuth2Error("invalid_user_info_response", "GitHub user response missing 'id' attribute", null),
+            )
+
+        val name = attributes["name"] as? String ?: attributes["login"] as? String
+
+        val email = attributes["email"] as? String
+            ?: fetchPrimaryVerifiedEmail(userRequest.accessToken.tokenValue)
+
+        val groups = roleSyncService.extractGroups(attributes)
+
+        val user = userAuthService.findOrCreateUser(
+            idpIdentifier = IdpIdentifier.GitHub(id),
+            email = email,
+            fullName = name,
+            idpGroups = groups,
+            requireLicense = false,
+        )
+
+        val policies = user.roles.flatMap { it.policies }.map { PolicyGrantedAuthority(it) }
+        val userDetails = UserDetailsWithId(user.getId()!!, email, "", policies)
+
+        return GithubOAuth2User(oauth2User, userDetails, policies)
+    }
+
+    private fun fetchPrimaryVerifiedEmail(accessToken: String): String {
+        val headers = HttpHeaders().apply {
+            setBearerAuth(accessToken)
+            set(HttpHeaders.ACCEPT, "application/vnd.github+json")
+        }
+        val response = try {
+            restTemplate.exchange(
+                githubProperties.emailsUri,
+                HttpMethod.GET,
+                HttpEntity<Void>(headers),
+                Array<GithubEmail>::class.java,
+            )
+        } catch (e: Exception) {
+            throw OAuth2AuthenticationException(
+                OAuth2Error(
+                    "user_email_unavailable",
+                    "Failed to fetch user emails from GitHub: ${e.message}",
+                    null,
+                ),
+                e,
+            )
+        }
+
+        val emails = response.body ?: emptyArray()
+        val primary = emails.firstOrNull { it.primary && it.verified }
+            ?: throw OAuth2AuthenticationException(
+                OAuth2Error(
+                    "user_email_unavailable",
+                    "No primary verified email returned by GitHub. " +
+                        "Make your email public on your GitHub account or grant the 'user:email' scope.",
+                    null,
+                ),
+            )
+        return primary.email
+    }
+}
+
+private data class GithubEmail(
+    val email: String = "",
+    val primary: Boolean = false,
+    val verified: Boolean = false,
+    val visibility: String? = null,
+)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/oauth2/GithubProperties.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/oauth2/GithubProperties.kt
@@ -10,4 +10,10 @@ class GithubProperties {
     var tokenUri: String = "https://github.com/login/oauth/access_token"
     var userInfoUri: String = "https://api.github.com/user"
     var emailsUri: String = "https://api.github.com/user/emails"
+    var orgsUri: String = "https://api.github.com/user/orgs"
+    var allowedOrgs: List<String> = emptyList()
+
+    fun normalizedAllowedOrgs(): Set<String> = allowedOrgs.map {
+        it.trim().lowercase()
+    }.filter { it.isNotBlank() }.toSet()
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/oauth2/GithubProperties.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/oauth2/GithubProperties.kt
@@ -1,0 +1,13 @@
+package dev.kviklet.kviklet.security.oauth2
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "kviklet.identity-provider.github")
+class GithubProperties {
+    var authorizationUri: String = "https://github.com/login/oauth/authorize"
+    var tokenUri: String = "https://github.com/login/oauth/access_token"
+    var userInfoUri: String = "https://api.github.com/user"
+    var emailsUri: String = "https://api.github.com/user/emails"
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/oidc/OidcLoginSuccessHandler.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/oidc/OidcLoginSuccessHandler.kt
@@ -1,5 +1,6 @@
 package dev.kviklet.kviklet.security.oidc
 
+import dev.kviklet.kviklet.security.KvikletOAuthPrincipal
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.transaction.Transactional
@@ -18,10 +19,10 @@ class OidcLoginSuccessHandler : SimpleUrlAuthenticationSuccessHandler() {
         response: HttpServletResponse?,
         authentication: Authentication?,
     ) {
-        // Convert OIDC authentication to use UserDetailsWithId as principal
-        if (authentication?.principal is OidcUser) {
-            val oidcUser = authentication.principal as OidcUser
-            val userDetails = oidcUser.getUserDetails()
+        // Convert OAuth/OIDC authentication to use UserDetailsWithId as principal
+        val principal = authentication?.principal
+        if (principal is KvikletOAuthPrincipal) {
+            val userDetails = principal.getUserDetails()
             val newAuth = UsernamePasswordAuthenticationToken(
                 userDetails,
                 authentication.credentials,

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/oidc/OidcUser.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/oidc/OidcUser.kt
@@ -1,5 +1,6 @@
 package dev.kviklet.kviklet.security.oidc
 
+import dev.kviklet.kviklet.security.KvikletOAuthPrincipal
 import dev.kviklet.kviklet.security.UserDetailsWithId
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.oauth2.core.oidc.OidcIdToken
@@ -12,6 +13,7 @@ class OidcUser(
     private val userDetails: UserDetailsWithId,
     private val authorities: Collection<GrantedAuthority>,
 ) : SpringOidcUser,
+    KvikletOAuthPrincipal,
     Serializable {
 
     override fun getClaims(): Map<String, Any> = oidcUser.claims
@@ -26,7 +28,7 @@ class OidcUser(
 
     override fun getAttributes(): Map<String, Any> = oidcUser.attributes
 
-    fun getUserDetails(): UserDetailsWithId = userDetails
+    override fun getUserDetails(): UserDetailsWithId = userDetails
 
     companion object {
         private const val serialVersionUID = 1L

--- a/backend/src/main/resources/changelog/000-changelog.yaml
+++ b/backend/src/main/resources/changelog/000-changelog.yaml
@@ -125,3 +125,6 @@ databaseChangeLog:
   - include:
       file: 043-clear-spring-sessions.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 044-add-github-id-column.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/changelog/044-add-github-id-column.yaml
+++ b/backend/src/main/resources/changelog/044-add-github-id-column.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 044-add-github-id-column
+      author: Jascha
+      changes:
+        - addColumn:
+            tableName: user
+            columns:
+              - column:
+                  name: github_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: true
+                    unique: true

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/GitHubOAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/GitHubOAuthTest.kt
@@ -1,0 +1,192 @@
+package dev.kviklet.kviklet
+
+import com.gargoylesoftware.htmlunit.WebClient
+import com.gargoylesoftware.htmlunit.html.HtmlPage
+import dev.kviklet.kviklet.db.User
+import dev.kviklet.kviklet.db.UserAdapter
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+    properties = ["server.port=8082"],
+)
+@ActiveProfiles("test")
+class GitHubOAuthTest {
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    @Autowired
+    private lateinit var userAdapter: UserAdapter
+
+    companion object {
+        private val mockGithub = MockWebServer().apply { start() }
+
+        @JvmStatic
+        @AfterAll
+        fun shutdownMock() {
+            mockGithub.shutdown()
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            val base = mockGithub.url("/").toString().trimEnd('/')
+            registry.add("kviklet.identity-provider.type") { "github" }
+            registry.add("kviklet.identity-provider.client-id") { "fake-client-id" }
+            registry.add("kviklet.identity-provider.client-secret") { "fake-client-secret" }
+            registry.add("kviklet.identity-provider.github.authorization-uri") { "$base/login/oauth/authorize" }
+            registry.add("kviklet.identity-provider.github.token-uri") { "$base/login/oauth/access_token" }
+            registry.add("kviklet.identity-provider.github.user-info-uri") { "$base/user" }
+            registry.add("kviklet.identity-provider.github.emails-uri") { "$base/user/emails" }
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        userAdapter.deleteAll()
+    }
+
+    private fun setDispatcher(userJson: String, emailsJson: String? = null) {
+        mockGithub.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                val path = request.path ?: ""
+                return when {
+                    path.startsWith("/login/oauth/authorize") -> {
+                        // Extract redirect_uri and state from query params and bounce back with a code
+                        val query = path.substringAfter("?", "")
+                        val params = query.split("&").associate {
+                            val (k, v) = it.split("=", limit = 2).let { p ->
+                                p[0] to (p.getOrNull(1) ?: "")
+                            }
+                            k to java.net.URLDecoder.decode(v, Charsets.UTF_8)
+                        }
+                        val redirect = params["redirect_uri"] ?: error("missing redirect_uri")
+                        val state = params["state"] ?: ""
+                        val location = "$redirect?code=fake-code&state=" +
+                            java.net.URLEncoder.encode(state, Charsets.UTF_8)
+                        MockResponse().setResponseCode(302).addHeader("Location", location)
+                    }
+                    path.startsWith("/login/oauth/access_token") -> {
+                        MockResponse()
+                            .setResponseCode(200)
+                            .addHeader("Content-Type", "application/json")
+                            .setBody(
+                                """{"access_token":"fake-access-token","token_type":"bearer",""" +
+                                    """"scope":"read:user,user:email"}""",
+                            )
+                    }
+                    path == "/user" -> {
+                        MockResponse()
+                            .setResponseCode(200)
+                            .addHeader("Content-Type", "application/json")
+                            .setBody(userJson)
+                    }
+                    path == "/user/emails" -> {
+                        MockResponse()
+                            .setResponseCode(200)
+                            .addHeader("Content-Type", "application/json")
+                            .setBody(emailsJson ?: "[]")
+                    }
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+    }
+
+    private fun runOauthFlow() {
+        val webClient = WebClient().apply {
+            options.apply {
+                isRedirectEnabled = true
+                isJavaScriptEnabled = false
+                isThrowExceptionOnScriptError = false
+                isUseInsecureSSL = true
+                isCssEnabled = false
+            }
+        }
+        try {
+            val loginUrl = "http://localhost:$port/oauth2/authorization/github"
+            try {
+                webClient.getPage<HtmlPage>(loginUrl)
+            } catch (e: Exception) {
+                // Frontend not running on 5173 — Kviklet's success handler redirects there.
+                // The OAuth dance up to that point still completed successfully.
+                assertThat(e.message).contains("Connect to localhost:5173")
+            }
+        } finally {
+            webClient.close()
+        }
+    }
+
+    @Test
+    fun `new user is created when GitHub returns email directly`() {
+        setDispatcher(
+            userJson = """{"id":12345,"login":"octocat","name":"Octo Cat","email":"octo@example.com"}""",
+        )
+        val before = userAdapter.listUsers().size
+
+        runOauthFlow()
+
+        assertThat(userAdapter.listUsers().size).isEqualTo(before + 1)
+        val user = userAdapter.findByEmail("octo@example.com")
+        assertThat(user).isNotNull
+        assertThat(user!!.githubId).isEqualTo("12345")
+        assertThat(user.fullName).isEqualTo("Octo Cat")
+        assertThat(user.password).isNull()
+    }
+
+    @Test
+    fun `existing password user is migrated to GitHub login`() {
+        userAdapter.createUser(
+            User(
+                email = "octo@example.com",
+                fullName = "Old Name",
+                password = "some-bcrypt-hash",
+            ),
+        )
+        val before = userAdapter.listUsers().size
+
+        setDispatcher(
+            userJson = """{"id":12345,"login":"octocat","name":"Octo Cat","email":"octo@example.com"}""",
+        )
+        runOauthFlow()
+
+        assertThat(userAdapter.listUsers().size).isEqualTo(before)
+        val user = userAdapter.findByEmail("octo@example.com")
+        assertThat(user).isNotNull
+        assertThat(user!!.githubId).isEqualTo("12345")
+        assertThat(user.password).isNull()
+    }
+
+    @Test
+    fun `private email falls back to user emails endpoint`() {
+        setDispatcher(
+            userJson = """{"id":67890,"login":"private-user","name":"Private User","email":null}""",
+            emailsJson = """[
+                {"email":"old@example.com","primary":false,"verified":true},
+                {"email":"primary@example.com","primary":true,"verified":true}
+            ]""".trimIndent(),
+        )
+        val before = userAdapter.listUsers().size
+
+        runOauthFlow()
+
+        assertThat(userAdapter.listUsers().size).isEqualTo(before + 1)
+        val user = userAdapter.findByEmail("primary@example.com")
+        assertThat(user).isNotNull
+        assertThat(user!!.githubId).isEqualTo("67890")
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/GitHubOAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/GitHubOAuthTest.kt
@@ -21,7 +21,7 @@ import org.springframework.test.context.DynamicPropertySource
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8082"],
+    properties = ["server.port=8084"],
 )
 @ActiveProfiles("test")
 class GitHubOAuthTest {
@@ -52,6 +52,8 @@ class GitHubOAuthTest {
             registry.add("kviklet.identity-provider.github.token-uri") { "$base/login/oauth/access_token" }
             registry.add("kviklet.identity-provider.github.user-info-uri") { "$base/user" }
             registry.add("kviklet.identity-provider.github.emails-uri") { "$base/user/emails" }
+            registry.add("kviklet.identity-provider.github.orgs-uri") { "$base/user/orgs" }
+            registry.add("kviklet.identity-provider.github.allowed-orgs") { "kviklet" }
         }
     }
 
@@ -60,7 +62,11 @@ class GitHubOAuthTest {
         userAdapter.deleteAll()
     }
 
-    private fun setDispatcher(userJson: String, emailsJson: String? = null) {
+    private fun setDispatcher(
+        userJson: String,
+        emailsJson: String? = null,
+        orgsJson: String = """[{"login":"kviklet"}]""",
+    ) {
         mockGithub.dispatcher = object : Dispatcher() {
             override fun dispatch(request: RecordedRequest): MockResponse {
                 val path = request.path ?: ""
@@ -87,7 +93,7 @@ class GitHubOAuthTest {
                             .addHeader("Content-Type", "application/json")
                             .setBody(
                                 """{"access_token":"fake-access-token","token_type":"bearer",""" +
-                                    """"scope":"read:user,user:email"}""",
+                                    """"scope":"read:user,user:email,read:org"}""",
                             )
                     }
 
@@ -105,6 +111,13 @@ class GitHubOAuthTest {
                             .setBody(emailsJson ?: "[]")
                     }
 
+                    path.startsWith("/user/orgs") -> {
+                        MockResponse()
+                            .setResponseCode(200)
+                            .addHeader("Content-Type", "application/json")
+                            .setBody(orgsJson)
+                    }
+
                     else -> MockResponse().setResponseCode(404)
                 }
             }
@@ -117,6 +130,10 @@ class GitHubOAuthTest {
                 isRedirectEnabled = true
                 isJavaScriptEnabled = false
                 isThrowExceptionOnScriptError = false
+                // Success path redirects to localhost:5173 (frontend) and fails with a connect
+                // exception; rejection path redirects to /login?error which 404s on the backend.
+                // Suppress the latter so both flows are observable via DB state.
+                isThrowExceptionOnFailingStatusCode = false
                 isUseInsecureSSL = true
                 isCssEnabled = false
             }
@@ -136,20 +153,27 @@ class GitHubOAuthTest {
     }
 
     @Test
-    fun `new user is created when GitHub returns email directly`() {
+    fun `primary verified email is used and user-profile email is ignored`() {
         setDispatcher(
-            userJson = """{"id":12345,"login":"octocat","name":"Octo Cat","email":"octo@example.com"}""",
+            userJson = """{"id":12345,"login":"octocat","name":"Octo Cat","email":"public@example.com"}""",
+            emailsJson = """
+                [
+                    {"email":"public@example.com","primary":false,"verified":true},
+                    {"email":"primary@example.com","primary":true,"verified":true}
+                ]
+            """.trimIndent(),
         )
         val before = userAdapter.listUsers().size
 
         runOauthFlow()
 
         assertThat(userAdapter.listUsers().size).isEqualTo(before + 1)
-        val user = userAdapter.findByEmail("octo@example.com")
+        val user = userAdapter.findByEmail("primary@example.com")
         assertThat(user).isNotNull
         assertThat(user!!.githubId).isEqualTo("12345")
         assertThat(user.fullName).isEqualTo("Octo Cat")
         assertThat(user.password).isNull()
+        assertThat(userAdapter.findByEmail("public@example.com")).isNull()
     }
 
     @Test
@@ -165,6 +189,7 @@ class GitHubOAuthTest {
 
         setDispatcher(
             userJson = """{"id":12345,"login":"octocat","name":"Octo Cat","email":"octo@example.com"}""",
+            emailsJson = """[{"email":"octo@example.com","primary":true,"verified":true}]""",
         )
         runOauthFlow()
 
@@ -176,23 +201,56 @@ class GitHubOAuthTest {
     }
 
     @Test
-    fun `private email falls back to user emails endpoint`() {
+    fun `unverified primary email is ignored even if it matches an existing user`() {
+        userAdapter.createUser(
+            User(
+                email = "victim@example.com",
+                fullName = "Real User",
+                password = "some-bcrypt-hash",
+            ),
+        )
+        val before = userAdapter.listUsers().size
+
         setDispatcher(
-            userJson = """{"id":67890,"login":"private-user","name":"Private User","email":null}""",
-            emailsJson = """
-                [
-                    {"email":"old@example.com","primary":false,"verified":true},
-                    {"email":"primary@example.com","primary":true,"verified":true}
-                ]
-            """.trimIndent(),
+            userJson = """{"id":42,"login":"attacker","name":"Attacker","email":"victim@example.com"}""",
+            emailsJson = """[{"email":"victim@example.com","primary":true,"verified":false}]""",
+        )
+        runOauthFlow()
+
+        // No verified email → login fails, existing user is untouched.
+        assertThat(userAdapter.listUsers().size).isEqualTo(before)
+        val victim = userAdapter.findByEmail("victim@example.com")
+        assertThat(victim).isNotNull
+        assertThat(victim!!.githubId).isNull()
+        assertThat(victim.password).isEqualTo("some-bcrypt-hash")
+    }
+
+    @Test
+    fun `login is rejected when user is not in an allowed org`() {
+        setDispatcher(
+            userJson = """{"id":99999,"login":"outsider","name":"Outsider","email":"out@example.com"}""",
+            orgsJson = """[{"login":"some-other-org"}]""",
+        )
+        val before = userAdapter.listUsers().size
+
+        runOauthFlow()
+
+        assertThat(userAdapter.listUsers().size).isEqualTo(before)
+        assertThat(userAdapter.findByEmail("out@example.com")).isNull()
+    }
+
+    @Test
+    fun `org name comparison is case-insensitive`() {
+        setDispatcher(
+            userJson = """{"id":11111,"login":"mixedcase","name":"Mixed Case","email":"mixed@example.com"}""",
+            emailsJson = """[{"email":"mixed@example.com","primary":true,"verified":true}]""",
+            orgsJson = """[{"login":"KVIKLET"}]""",
         )
         val before = userAdapter.listUsers().size
 
         runOauthFlow()
 
         assertThat(userAdapter.listUsers().size).isEqualTo(before + 1)
-        val user = userAdapter.findByEmail("primary@example.com")
-        assertThat(user).isNotNull
-        assertThat(user!!.githubId).isEqualTo("67890")
+        assertThat(userAdapter.findByEmail("mixed@example.com")).isNotNull
     }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/GitHubOAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/GitHubOAuthTest.kt
@@ -80,6 +80,7 @@ class GitHubOAuthTest {
                             java.net.URLEncoder.encode(state, Charsets.UTF_8)
                         MockResponse().setResponseCode(302).addHeader("Location", location)
                     }
+
                     path.startsWith("/login/oauth/access_token") -> {
                         MockResponse()
                             .setResponseCode(200)
@@ -89,18 +90,21 @@ class GitHubOAuthTest {
                                     """"scope":"read:user,user:email"}""",
                             )
                     }
+
                     path == "/user" -> {
                         MockResponse()
                             .setResponseCode(200)
                             .addHeader("Content-Type", "application/json")
                             .setBody(userJson)
                     }
+
                     path == "/user/emails" -> {
                         MockResponse()
                             .setResponseCode(200)
                             .addHeader("Content-Type", "application/json")
                             .setBody(emailsJson ?: "[]")
                     }
+
                     else -> MockResponse().setResponseCode(404)
                 }
             }
@@ -175,10 +179,12 @@ class GitHubOAuthTest {
     fun `private email falls back to user emails endpoint`() {
         setDispatcher(
             userJson = """{"id":67890,"login":"private-user","name":"Private User","email":null}""",
-            emailsJson = """[
-                {"email":"old@example.com","primary":false,"verified":true},
-                {"email":"primary@example.com","primary":true,"verified":true}
-            ]""".trimIndent(),
+            emailsJson = """
+                [
+                    {"email":"old@example.com","primary":false,"verified":true},
+                    {"email":"primary@example.com","primary":true,"verified":true}
+                ]
+            """.trimIndent(),
         )
         val before = userAdapter.listUsers().size
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/helper/ExecutionRequestFactory.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/helper/ExecutionRequestFactory.kt
@@ -237,14 +237,14 @@ class UserFactory : Factory() {
         email: String = "test" + nextId() + "@user.com",
         roles: Set<Role>? = null,
     ): User = User(
-        id,
-        fullName,
-        password,
-        subject,
-        ldapIdentifier,
-        samlNameId,
-        email,
-        roles ?: setOf(roleFactory.createRole()),
+        id = id,
+        fullName = fullName,
+        password = password,
+        subject = subject,
+        ldapIdentifier = ldapIdentifier,
+        samlNameId = samlNameId,
+        email = email,
+        roles = roles ?: setOf(roleFactory.createRole()),
     )
 }
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/security/AuthenticationProviderValidatorTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/security/AuthenticationProviderValidatorTest.kt
@@ -1,6 +1,7 @@
 package dev.kviklet.kviklet.security
 
 import dev.kviklet.kviklet.security.ldap.LdapProperties
+import dev.kviklet.kviklet.security.oauth2.GithubProperties
 import dev.kviklet.kviklet.security.saml.SamlProperties
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -22,6 +23,7 @@ class AuthenticationProviderValidatorTest {
             LdapProperties::class.java,
             IdentityProviderProperties::class.java,
             SamlProperties::class.java,
+            GithubProperties::class.java,
             AuthenticationProviderValidator::class.java,
         )
         .withPropertyValues(
@@ -153,6 +155,59 @@ class AuthenticationProviderValidatorTest {
                     .hasMessageContaining("Only one external authentication provider can be enabled at a time")
                     .hasMessageContaining("OAuth2/OIDC")
                     .hasMessageContaining("SAML")
+            }
+    }
+
+    @Test
+    fun `context fails when GitHub is enabled without allowed orgs`() {
+        contextRunner
+            .withPropertyValues(
+                "ldap.enabled=false",
+                "saml.enabled=false",
+                "kviklet.identity-provider.type=github",
+                "kviklet.identity-provider.client-id=test-client",
+                "kviklet.identity-provider.client-secret=test-secret",
+            )
+            .run { context ->
+                assertThat(context).hasFailed()
+                assertThat(context.startupFailure)
+                    .isInstanceOf(IllegalStateException::class.java)
+                    .hasMessageContaining("kviklet.identity-provider.github.allowed-orgs")
+            }
+    }
+
+    @Test
+    fun `context fails when GitHub allowed orgs contains only blank entries`() {
+        contextRunner
+            .withPropertyValues(
+                "ldap.enabled=false",
+                "saml.enabled=false",
+                "kviklet.identity-provider.type=github",
+                "kviklet.identity-provider.client-id=test-client",
+                "kviklet.identity-provider.client-secret=test-secret",
+                "kviklet.identity-provider.github.allowed-orgs=  , ",
+            )
+            .run { context ->
+                assertThat(context).hasFailed()
+                assertThat(context.startupFailure)
+                    .isInstanceOf(IllegalStateException::class.java)
+                    .hasMessageContaining("kviklet.identity-provider.github.allowed-orgs")
+            }
+    }
+
+    @Test
+    fun `context loads when GitHub is enabled with allowed orgs`() {
+        contextRunner
+            .withPropertyValues(
+                "ldap.enabled=false",
+                "saml.enabled=false",
+                "kviklet.identity-provider.type=github",
+                "kviklet.identity-provider.client-id=test-client",
+                "kviklet.identity-provider.client-secret=test-secret",
+                "kviklet.identity-provider.github.allowed-orgs=my-org",
+            )
+            .run { context ->
+                assertThat(context).hasNotFailed()
             }
     }
 


### PR DESCRIPTION
## Summary

GitHub is OAuth2-only (not OIDC), so the existing OIDC login path silently breaks when `KVIKLET_IDENTITYPROVIDER_TYPE=github` is set — there's no discovery document, no JWKS, no `sub` claim. This PR adds a dedicated GitHub path:

- New `IdpIdentifier.GitHub(id)` with its own `github_id` column on the `user` table (Liquibase 044).
- New `GithubOAuth2UserService` extending `DefaultOAuth2UserService` — uses GitHub's `id` as the IdP subject, and falls back to `/user/emails` when the user has a private email (requires the `user:email` scope, which we now request).
- New `KvikletOAuthPrincipal` interface so `OidcLoginSuccessHandler` handles both `OidcUser` and the new `GithubOAuth2User`.
- `IdentityProviderConfig` adds a `type=github` branch using Spring Security's `CommonOAuth2Provider.GITHUB`, with overridable URLs via `GithubProperties` (defaults point at real GitHub; useful for testing).
- `SecurityConfig` wires the new user service into `userInfoEndpoint { userService = ... }`. OIDC providers are unaffected.
- Frontend needs no changes — the existing fallback in `Login.tsx` already renders a working "Login with github" button.
- README documents the GitHub setup, including the callback URL and the email-scope behavior.

Setup for users:

```
KVIKLET_IDENTITYPROVIDER_TYPE=github
KVIKLET_IDENTITYPROVIDER_CLIENTID=...
KVIKLET_IDENTITYPROVIDER_CLIENTSECRET=...
```

GitHub OAuth App callback URL: `https://[kviklet_host]/api/login/oauth2/code/github`.

Tests: new `GitHubOAuthTest` integration test using OkHttp `MockWebServer` covers new-user creation, password→GitHub migration, and the private-email fallback path.