### PR TITLE
add ability to Mask DB results on kviklet side

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConnectionController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConnectionController.kt
@@ -110,6 +110,7 @@ data class CreateDatasourceConnectionRequest(
     val category: String? = null,
     val dryRunEnabled: Boolean = false,
     val dryRunRequiresApproval: Boolean = true,
+    val maskedColumns: List<String> = emptyList(),
 ) : ConnectionRequest()
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "connectionType")
@@ -175,6 +176,8 @@ data class UpdateDatasourceConnectionRequest(
     val dryRunEnabled: Boolean? = null,
 
     val dryRunRequiresApproval: Boolean? = null,
+
+    val maskedColumns: List<String>? = null,
 ) : UpdateConnectionRequest()
 
 data class UpdateKubernetesConnectionRequest(
@@ -257,6 +260,7 @@ data class DatasourceConnectionResponse(
     val category: String?,
     val dryRunEnabled: Boolean,
     val dryRunRequiresApproval: Boolean,
+    val maskedColumns: List<String>,
 ) : ConnectionResponse(ConnectionType.DATASOURCE) {
     companion object {
         fun fromDto(datasourceConnection: DatasourceConnection) = DatasourceConnectionResponse(
@@ -290,6 +294,7 @@ data class DatasourceConnectionResponse(
             category = datasourceConnection.category,
             dryRunEnabled = datasourceConnection.dryRunEnabled,
             dryRunRequiresApproval = datasourceConnection.dryRunRequiresApproval,
+            maskedColumns = datasourceConnection.maskedColumns,
         )
     }
 }
@@ -379,6 +384,7 @@ class ConnectionController(val connectionService: ConnectionService) {
             category = request.category,
             dryRunEnabled = request.dryRunEnabled,
             dryRunRequiresApproval = request.dryRunRequiresApproval,
+            maskedColumns = request.maskedColumns,
         )
 
     private fun testDatabaseConnection(request: CreateDatasourceConnectionRequest): TestConnectionResult =

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/Connection.kt
@@ -78,6 +78,8 @@ class ConnectionEntity(
     var category: String? = null,
     var dryRunEnabled: Boolean = false,
     var dryRunRequiresApproval: Boolean = true,
+    @Column(name = "masked_columns")
+    var maskedColumns: String? = null,
 
     // Kubernetes connection fields
     @Column(name = "kubernetes_exec_initial_wait_timeout_seconds")
@@ -201,6 +203,7 @@ class ConnectionAdapter(
         category: String? = null,
         dryRunEnabled: Boolean = false,
         dryRunRequiresApproval: Boolean = true,
+        maskedColumns: List<String> = emptyList(),
     ): Connection = decryptCredentialsIfNeeded(
         save(
             ConnectionEntity(
@@ -229,6 +232,7 @@ class ConnectionAdapter(
                 category = category,
                 dryRunEnabled = dryRunEnabled,
                 dryRunRequiresApproval = dryRunRequiresApproval,
+                maskedColumns = maskedColumns.joinToString(",").ifEmpty { null },
             ),
         ),
     )
@@ -256,6 +260,7 @@ class ConnectionAdapter(
         category: String? = null,
         dryRunEnabled: Boolean = false,
         dryRunRequiresApproval: Boolean = true,
+        maskedColumns: List<String> = emptyList(),
     ): Connection {
         val datasourceConnection = connectionRepository.findByIdOrNull(id.toString())
             ?: throw EntityNotFound(
@@ -292,6 +297,7 @@ class ConnectionAdapter(
         datasourceConnection.category = category
         datasourceConnection.dryRunEnabled = dryRunEnabled
         datasourceConnection.dryRunRequiresApproval = dryRunRequiresApproval
+        datasourceConnection.maskedColumns = maskedColumns.joinToString(",").ifEmpty { null }
 
         return decryptCredentialsIfNeeded(save(datasourceConnection))
     }
@@ -405,6 +411,11 @@ class ConnectionAdapter(
                 category = connection.category,
                 dryRunEnabled = connection.dryRunEnabled,
                 dryRunRequiresApproval = connection.dryRunRequiresApproval,
+                maskedColumns = connection.maskedColumns
+                    ?.split(",")
+                    ?.map { it.trim() }
+                    ?.filter { it.isNotEmpty() }
+                    ?: emptyList(),
             )
 
         ConnectionType.KUBERNETES ->

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ConnectionService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ConnectionService.kt
@@ -94,6 +94,7 @@ class ConnectionService(
             category = request.category ?: connection.category,
             dryRunEnabled = request.dryRunEnabled ?: connection.dryRunEnabled,
             dryRunRequiresApproval = request.dryRunRequiresApproval ?: connection.dryRunRequiresApproval,
+            maskedColumns = request.maskedColumns ?: connection.maskedColumns,
         )
 
         // Recalculate statuses if reviewConfig or maxExecutions changed
@@ -221,6 +222,7 @@ class ConnectionService(
         category: String?,
         dryRunEnabled: Boolean,
         dryRunRequiresApproval: Boolean,
+        maskedColumns: List<String> = emptyList(),
     ): Connection {
         if (authenticationType == AuthenticationType.USER_PASSWORD && password == null) {
             throw IllegalArgumentException("Password is required for USER_PASSWORD authentication")
@@ -254,6 +256,7 @@ class ConnectionService(
             category,
             dryRunEnabled,
             dryRunRequiresApproval,
+            maskedColumns,
         )
     }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -41,7 +41,9 @@ import dev.kviklet.kviklet.service.dto.KubernetesConnection
 import dev.kviklet.kviklet.service.dto.KubernetesExecutionRequest
 import dev.kviklet.kviklet.service.dto.KubernetesExecutionResult
 import dev.kviklet.kviklet.service.dto.KubernetesOutputResultLog
+import dev.kviklet.kviklet.service.dto.QueryResult
 import dev.kviklet.kviklet.service.dto.QueryResultLog
+import dev.kviklet.kviklet.service.dto.RecordsQueryResult
 import dev.kviklet.kviklet.service.dto.RequestType
 import dev.kviklet.kviklet.service.dto.ReviewAction
 import dev.kviklet.kviklet.service.dto.ReviewStatus
@@ -533,15 +535,17 @@ class ExecutionRequestService(
             }
         }
 
+        val maskedResult = applyColumnMasking(result, connection.maskedColumns)
+
         // Status will be recalculated automatically after adding result logs via event
-        val resultLogs = result.map {
+        val resultLogs = maskedResult.map {
             it.toResultLog()
         }
         val savedEvent = eventService.addResultLogs(event.eventId!!, resultLogs)
 
         return DBExecutionResult(
             executionRequest = executionRequest,
-            results = result,
+            results = maskedResult,
             event = savedEvent,
         )
     }
@@ -598,15 +602,17 @@ class ExecutionRequestService(
             }
         }
 
+        val maskedResult = applyColumnMasking(result, connection.maskedColumns)
+
         // Store results
-        val resultLogs = result.map {
+        val resultLogs = maskedResult.map {
             it.toResultLog()
         }
         val savedEvent = eventService.addResultLogs(event.eventId!!, resultLogs)
 
         return DBExecutionResult(
             executionRequest = executionRequest,
-            results = result,
+            results = maskedResult,
             event = savedEvent,
         )
     }
@@ -789,28 +795,39 @@ class ExecutionRequestService(
 
         try {
             val writer = outputStream.writer(Charsets.UTF_8)
+            val maskedLabels = connection.maskedColumns.toSet()
+            var headers = emptyList<String>()
+
             val streamResult = JDBCExecutor.executeAndStreamDbResponse(
                 connectionString = connection.getConnectionString(),
                 authenticationDetails = connection.auth,
                 query = queryToExecute,
                 maxRowsToStore = maxRowsToStore,
-            ) { row ->
-                writer.write(
-                    row.joinToString(",") { field ->
-                        escapeCsvField(field)
-                    } + "\n",
-                )
-                writer.flush()
-            }
+                onHeader = { columnLabels ->
+                    headers = columnLabels
+                    writer.write(columnLabels.joinToString(",") { escapeCsvField(it) } + "\n")
+                    writer.flush()
+                },
+                onRow = { row ->
+                    val outputRow = row.mapIndexed { idx, value ->
+                        if (headers[idx] in maskedLabels) "***" else value
+                    }
+                    writer.write(outputRow.joinToString(",") { escapeCsvField(it) } + "\n")
+                    writer.flush()
+                },
+            )
 
             // Store results on success if storeResults is enabled
             if (connection.storeResults) {
+                val maskedStoredRows = streamResult.storedRows.map { row ->
+                    maskRow(row, maskedLabels)
+                }
                 val resultLog = QueryResultLog(
                     columnCount = streamResult.columns.size,
                     rowCount = streamResult.rowCount,
                     columns = streamResult.columns,
-                    storedRows = streamResult.storedRows,
-                    storedRowCount = streamResult.storedRows.size,
+                    storedRows = maskedStoredRows,
+                    storedRowCount = maskedStoredRows.size,
                 )
                 eventService.addResultLogs(eventId, listOf(resultLog))
             }
@@ -833,6 +850,25 @@ class ExecutionRequestService(
             return "\"" + field.replace("\"", "\"\"") + "\""
         }
         return field
+    }
+
+    private fun maskRow(row: Map<String, String>, maskedColumnLabels: Set<String>): Map<String, String> =
+        row.mapValues { (key, value) ->
+            if (key in maskedColumnLabels) "***" else value
+        }
+
+    private fun applyColumnMasking(results: List<QueryResult>, maskedColumns: List<String>): List<QueryResult> {
+        if (maskedColumns.isEmpty()) return results
+        val maskedLabels = maskedColumns.toSet()
+        return results.map { result ->
+            when (result) {
+                is RecordsQueryResult -> result.copy(
+                    data = result.data.map { maskRow(it, maskedLabels) },
+                    storedRows = result.storedRows?.map { maskRow(it, maskedLabels) },
+                )
+                else -> result
+            }
+        }
     }
 
     @Policy(Permission.EXECUTION_REQUEST_GET)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/JDBCExecutor.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/JDBCExecutor.kt
@@ -184,7 +184,7 @@ class JDBCExecutor {
             try {
                 dataSource.connection.createStatement().use { statement ->
                     val query = """
-                    SELECT d.datname 
+                    SELECT d.datname
                     FROM pg_catalog.pg_database d
                     WHERE pg_catalog.has_database_privilege(current_user, d.datname, 'CONNECT')
                 """
@@ -212,7 +212,8 @@ class JDBCExecutor {
         authenticationDetails: AuthenticationDetails,
         query: String,
         maxRowsToStore: Int = 0,
-        callback: (List<String>) -> Unit,
+        onHeader: (List<String>) -> Unit,
+        onRow: (List<String>) -> Unit,
     ): StreamingQueryResult {
         createConnection(connectionString, authenticationDetails).use { dataSource: HikariDataSource ->
             try {
@@ -220,7 +221,7 @@ class JDBCExecutor {
                     val hasResults = statement.execute(query)
                     if (hasResults) {
                         statement.resultSet?.use { resultSet ->
-                            return streamResultSet(resultSet, maxRowsToStore, callback)
+                            return streamResultSet(resultSet, maxRowsToStore, onHeader, onRow)
                         } ?: throw IllegalStateException("Can't stream a non-Select statement")
                     } else {
                         throw IllegalStateException("Can't stream a non-Select statement")
@@ -235,7 +236,8 @@ class JDBCExecutor {
     private fun streamResultSet(
         resultSet: ResultSet,
         maxRowsToStore: Int,
-        callback: (List<String>) -> Unit,
+        onHeader: (List<String>) -> Unit,
+        onRow: (List<String>) -> Unit,
     ): StreamingQueryResult {
         val metadata = resultSet.metaData
         val columns = (1..metadata.columnCount).map { i ->
@@ -246,13 +248,13 @@ class JDBCExecutor {
             )
         }
 
-        callback(columns.map { it.label })
+        onHeader(columns.map { it.label })
 
         val storedRows = mutableListOf<Map<String, String>>()
         var rowCount = 0
 
         iterateResultSet(resultSet, columns, forEachRow = { resultMap ->
-            callback(columns.map { resultMap[it.label] ?: "" })
+            onRow(columns.map { resultMap[it.label] ?: "" })
 
             // Only store first N rows for result storage
             if (storedRows.size < maxRowsToStore) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/Connection.kt
@@ -100,6 +100,7 @@ data class DatasourceConnection(
     val maxTemporaryAccessDuration: Long? = null,
     val dryRunEnabled: Boolean,
     val dryRunRequiresApproval: Boolean,
+    val maskedColumns: List<String> = emptyList(),
 ) : Connection(id, displayName, description, reviewConfig, maxExecutions, category) {
     fun getConnectionString(): String = when (auth) {
         is AuthenticationDetails.UserPassword -> when (type) {

--- a/backend/src/main/resources/changelog/000-changelog.yaml
+++ b/backend/src/main/resources/changelog/000-changelog.yaml
@@ -125,3 +125,6 @@ databaseChangeLog:
   - include:
       file: 043-clear-spring-sessions.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 044-add-masked-columns.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/changelog/044-add-masked-columns.yaml
+++ b/backend/src/main/resources/changelog/044-add-masked-columns.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 044-add-masked-columns
+      author: azhurbilo
+      changes:
+        - addColumn:
+            tableName: connection
+            columns:
+              - column:
+                  name: masked_columns
+                  type: text
+                  constraints:
+                    nullable: true

--- a/frontend/src/api/DatasourceApi.ts
+++ b/frontend/src/api/DatasourceApi.ts
@@ -64,6 +64,7 @@ const databaseConnectionResponseSchema = withType(
     maxTemporaryAccessDuration: z.number().nullable().optional(),
     storeResults: z.boolean(),
     category: z.string().nullable(),
+    maskedColumns: z.array(z.string()).optional().default([]),
   }),
   "DATASOURCE",
 );
@@ -124,6 +125,7 @@ interface DatabaseConnectionBase extends ConnectionBase {
   dryRunRequiresApproval: boolean;
   maxTemporaryAccessDuration?: number | null;
   storeResults: boolean;
+  maskedColumns?: string[];
 }
 
 type DatabaseConnection =

--- a/frontend/src/api/DatasourceApi.ts
+++ b/frontend/src/api/DatasourceApi.ts
@@ -125,7 +125,7 @@ interface DatabaseConnectionBase extends ConnectionBase {
   dryRunRequiresApproval: boolean;
   maxTemporaryAccessDuration?: number | null;
   storeResults: boolean;
-  maskedColumns?: string[];
+  maskedColumns?: string | string[];
 }
 
 type DatabaseConnection =

--- a/frontend/src/hooks/connections.ts
+++ b/frontend/src/hooks/connections.ts
@@ -15,6 +15,14 @@ import {
 import useNotification from "./useNotification";
 import { isApiErrorResponse } from "../api/Errors";
 
+const parseMaskedColumns = (raw: string | string[]): string[] =>
+  typeof raw === "string"
+    ? raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : raw;
+
 // Utility function to normalize maxTemporaryAccessDuration field
 // Converts 0 or falsy values to null to match backend expectations
 const normalizeMaxTemporaryAccessDuration = <
@@ -120,13 +128,19 @@ const useConnection = (id: string) => {
       return;
     }
     setLoading(true);
-    if (
-      patchedConnection.connectionType === "DATASOURCE" &&
-      patchedConnection.authenticationType === "USER_PASSWORD" &&
-      patchedConnection.password === ""
-    ) {
-      // ensure that the password is not updated if the user didn't provide a new one
-      patchedConnection.password = undefined;
+    if (patchedConnection.connectionType === "DATASOURCE") {
+      if (
+        patchedConnection.authenticationType === "USER_PASSWORD" &&
+        patchedConnection.password === ""
+      ) {
+        // ensure that the password is not updated if the user didn't provide a new one
+        patchedConnection.password = undefined;
+      }
+      if (patchedConnection.maskedColumns !== undefined) {
+        patchedConnection.maskedColumns = parseMaskedColumns(
+          patchedConnection.maskedColumns,
+        );
+      }
     }
     const normalizedConnection =
       normalizeMaxTemporaryAccessDuration(patchedConnection);

--- a/frontend/src/routes/settings/connection/details/UpdateDatasourceConnectionForm.tsx
+++ b/frontend/src/routes/settings/connection/details/UpdateDatasourceConnectionForm.tsx
@@ -55,6 +55,7 @@ const baseConnectionFormSchema = z.object({
   storeResults: z.boolean(),
   connectionType: z.literal("DATASOURCE").default("DATASOURCE"),
   category: z.string().nullable().optional(),
+  maskedColumnsRaw: z.string().optional().default(""),
 });
 
 const connectionFormSchema = z.discriminatedUnion("authenticationType", [
@@ -154,9 +155,16 @@ export default function UpdateDatasourceConnectionForm({
       roleArn: connection.roleArn,
       storeResults: connection.storeResults,
       category: connection.category,
+      maskedColumnsRaw: (connection.maskedColumns ?? []).join(", "),
     },
     schema: connectionFormSchema,
-    onSubmit: editConnection,
+    onSubmit: (data) => {
+      const maskedColumns = (data.maskedColumnsRaw ?? "")
+        .split(",")
+        .map((s: string) => s.trim())
+        .filter((s: string) => s.length > 0);
+      return editConnection({ ...data, maskedColumns });
+    },
     connectionType: "DATASOURCE",
   });
 
@@ -455,6 +463,36 @@ export default function UpdateDatasourceConnectionForm({
                           className="my-auto h-4 w-4"
                           {...register("storeResults")}
                         />
+                      </div>
+                      <div className="flex w-full flex-col gap-1">
+                        <label
+                          htmlFor="maskedColumnsRaw"
+                          className="flex items-center text-sm font-medium text-slate-700 dark:text-slate-200"
+                          title="Comma-separated list of column names to mask with *** in query results, history, and CSV exports."
+                        >
+                          Masked Columns
+                          <QuestionMarkCircleIcon className="ml-1 h-4 w-4 text-slate-400"></QuestionMarkCircleIcon>
+                        </label>
+                        <input
+                          id="maskedColumnsRaw"
+                          type="text"
+                          placeholder="e.g. password, email, ssn"
+                          className="block w-full rounded-md border border-slate-300 px-3 py-2 text-sm
+                            transition-colors focus:border-indigo-600 focus:outline-none
+                            hover:border-slate-400 focus:hover:border-indigo-600
+                            dark:border-slate-700 dark:bg-slate-900 dark:focus:border-gray-500
+                            dark:hover:border-slate-600 dark:hover:focus:border-gray-500"
+                          {...register("maskedColumnsRaw")}
+                        />
+                        <p className="text-xs text-slate-500 dark:text-slate-400">
+                          Values in these columns are replaced with *** in results, history, and CSV exports.
+                        </p>
+                        <p className="text-xs text-amber-600 dark:text-amber-400">
+                          ⚠ This is an application-level workaround. For production data protection, prefer
+                          native database anonymization (e.g. PostgreSQL anonymizer, column-level security,
+                          or masked views) which enforce masking at the database layer regardless of how
+                          data is accessed.
+                        </p>
                       </div>
                     </div>
                   </DisclosurePanel>

--- a/frontend/src/routes/settings/connection/details/UpdateDatasourceConnectionForm.tsx
+++ b/frontend/src/routes/settings/connection/details/UpdateDatasourceConnectionForm.tsx
@@ -55,7 +55,7 @@ const baseConnectionFormSchema = z.object({
   storeResults: z.boolean(),
   connectionType: z.literal("DATASOURCE").default("DATASOURCE"),
   category: z.string().nullable().optional(),
-  maskedColumnsRaw: z.string().optional().default(""),
+  maskedColumns: z.string().optional().default(""),
 });
 
 const connectionFormSchema = z.discriminatedUnion("authenticationType", [
@@ -155,16 +155,10 @@ export default function UpdateDatasourceConnectionForm({
       roleArn: connection.roleArn,
       storeResults: connection.storeResults,
       category: connection.category,
-      maskedColumnsRaw: (connection.maskedColumns ?? []).join(", "),
+      maskedColumns: (connection.maskedColumns ?? []).join(", "),
     },
     schema: connectionFormSchema,
-    onSubmit: (data) => {
-      const maskedColumns = (data.maskedColumnsRaw ?? "")
-        .split(",")
-        .map((s: string) => s.trim())
-        .filter((s: string) => s.length > 0);
-      return editConnection({ ...data, maskedColumns });
-    },
+    onSubmit: (data) => editConnection(data),
     connectionType: "DATASOURCE",
   });
 
@@ -464,36 +458,21 @@ export default function UpdateDatasourceConnectionForm({
                           {...register("storeResults")}
                         />
                       </div>
-                      <div className="flex w-full flex-col gap-1">
-                        <label
-                          htmlFor="maskedColumnsRaw"
-                          className="flex items-center text-sm font-medium text-slate-700 dark:text-slate-200"
-                          title="Comma-separated list of column names to mask with *** in query results, history, and CSV exports."
-                        >
-                          Masked Columns
-                          <QuestionMarkCircleIcon className="ml-1 h-4 w-4 text-slate-400"></QuestionMarkCircleIcon>
-                        </label>
-                        <input
-                          id="maskedColumnsRaw"
-                          type="text"
-                          placeholder="e.g. password, email, ssn"
-                          className="block w-full rounded-md border border-slate-300 px-3 py-2 text-sm
-                            transition-colors focus:border-indigo-600 focus:outline-none
-                            hover:border-slate-400 focus:hover:border-indigo-600
-                            dark:border-slate-700 dark:bg-slate-900 dark:focus:border-gray-500
-                            dark:hover:border-slate-600 dark:hover:focus:border-gray-500"
-                          {...register("maskedColumnsRaw")}
-                        />
-                        <p className="text-xs text-slate-500 dark:text-slate-400">
-                          Values in these columns are replaced with *** in results, history, and CSV exports.
-                        </p>
-                        <p className="text-xs text-amber-600 dark:text-amber-400">
-                          ⚠ This is an application-level workaround. For production data protection, prefer
-                          native database anonymization (e.g. PostgreSQL anonymizer, column-level security,
-                          or masked views) which enforce masking at the database layer regardless of how
-                          data is accessed.
-                        </p>
-                      </div>
+                      {watchType !== DatabaseType.MONGODB && (
+                        <div className="flex flex-col gap-1">
+                          <InputField
+                            id="maskedColumnsRaw"
+                            label="Masked Columns"
+                            placeholder="e.g. password, email, ssn"
+                            tooltip="Comma-separated column names masked with *** in results, history, and CSV exports."
+                            {...register("maskedColumns")}
+                          />
+                          <p className="text-xs text-amber-600 dark:text-amber-400">
+                            ⚠ Application-level masking only. For production data protection prefer native
+                            DB anonymization (e.g. column-level security, masked views).
+                          </p>
+                        </div>
+                      )}
                     </div>
                   </DisclosurePanel>
                 </>


### PR DESCRIPTION
Adds configurable column masking for datasource connections. Admins can specify a comma-separated list of column names that will be replaced with `***` in query results, event history, and CSV exports.

---

could be helpful when you can not install native anonymizer extension (Heroku or RDS databases)

