### PR TITLE
Add fallback if JSQLParser fails. Closes #460.

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
@@ -380,7 +380,12 @@ data class ExecutionRequestDetails(val request: ExecutionRequest, val events: Mu
             }
             return Pair(true, "")
         } catch (e: JSQLParserException) {
-            return Pair(false, "Error parsing query: ${e.message}")
+            // JSQLParser doesn't support all database-specific syntax (e.g. JSON_TABLE).
+            // Fall back to a simple check that the query starts with SELECT.
+            if (queryToExecute.trimStart().uppercase().startsWith("SELECT")) {
+                return Pair(true, "")
+            }
+            return Pair(false, "Can only download results for select queries!")
         }
     }
 }


### PR DESCRIPTION
Download as CSV does not work if query contains `JSON_TABLE`. See #460 

This adds a fallback if parsing fails. It is a naive solution that can miss some invalid SQL but seeing as there is no validation at all on "Run Query" I figured it's better than nothing?

Feel free to close this in favor of a more informed solution. 🙂