### PR TITLE
Redirect SSO failures to frontend login with error code

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExceptionHandlerController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExceptionHandlerController.kt
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -109,6 +110,15 @@ class ExceptionHandlerController {
     fun handleEntityNotFound(ex: EntityNotFound, request: HttpServletRequest): ResponseEntity<Any> {
         logger.error("Entity not found at ${request.requestURI}", ex)
         return ResponseEntity(ErrorResponse(ex.message), HttpStatus.NOT_FOUND)
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    fun handleMethodNotSupported(
+        ex: HttpRequestMethodNotSupportedException,
+        request: HttpServletRequest,
+    ): ResponseEntity<Any> {
+        logger.info("Method not allowed at ${request.requestURI}: ${ex.message}")
+        return ResponseEntity(ErrorResponse(ex.message ?: "Method not allowed"), HttpStatus.METHOD_NOT_ALLOWED)
     }
 
     @ExceptionHandler(Exception::class)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/FrontendUrlResolver.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/FrontendUrlResolver.kt
@@ -1,0 +1,15 @@
+package dev.kviklet.kviklet.security
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.stereotype.Component
+
+@Component
+class FrontendUrlResolver {
+    fun resolve(request: HttpServletRequest): String {
+        val scheme = request.scheme
+        val serverName = request.serverName
+        val serverPort = request.serverPort
+
+        return "$scheme://$serverName${if (serverPort != 80 && serverPort != 443) ":5173" else ""}"
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
@@ -75,6 +75,7 @@ class CorsSettings {
 @EnableWebSecurity
 class SecurityConfig(
     private val oidcLoginSuccessHandler: OidcLoginSuccessHandler,
+    private val ssoAuthenticationFailureHandler: SsoAuthenticationFailureHandler,
     private val customAuthenticationProvider: CustomAuthenticationProvider,
     private val oidcUserService: OidcUserService,
     private val githubOAuth2UserService: GithubOAuth2UserService,
@@ -194,6 +195,7 @@ class SecurityConfig(
             if (idpProperties.isOauth2Enabled()) {
                 oauth2Login {
                     authenticationSuccessHandler = oidcLoginSuccessHandler
+                    authenticationFailureHandler = ssoAuthenticationFailureHandler
                     userInfoEndpoint {
                         oidcUserService = this@SecurityConfig.oidcUserService
                         userService = this@SecurityConfig.githubOAuth2UserService
@@ -204,6 +206,7 @@ class SecurityConfig(
             if (samlProperties.isSamlEnabled()) {
                 saml2Login {
                     samlLoginSuccessHandler?.let { authenticationSuccessHandler = it }
+                    authenticationFailureHandler = ssoAuthenticationFailureHandler
                 }
 
                 saml2Metadata { }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/SsoAuthenticationFailureHandler.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/SsoAuthenticationFailureHandler.kt
@@ -1,0 +1,60 @@
+package dev.kviklet.kviklet.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException
+import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationException
+import org.springframework.security.web.DefaultRedirectStrategy
+import org.springframework.security.web.authentication.AuthenticationFailureHandler
+import org.springframework.stereotype.Component
+import java.net.URLEncoder
+
+@Component
+class SsoAuthenticationFailureHandler(private val frontendUrlResolver: FrontendUrlResolver) :
+    AuthenticationFailureHandler {
+
+    private val logger = LoggerFactory.getLogger(SsoAuthenticationFailureHandler::class.java)
+    private val redirectStrategy = DefaultRedirectStrategy()
+
+    override fun onAuthenticationFailure(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        exception: AuthenticationException,
+    ) {
+        val (code, message) = extractErrorDetails(exception)
+        logger.info("SSO authentication failed: code={}, message={}", code, message)
+
+        val baseUrl = frontendUrlResolver.resolve(request)
+        val encodedMessage = URLEncoder.encode(message.take(MAX_MESSAGE_LENGTH), Charsets.UTF_8)
+        val encodedCode = URLEncoder.encode(code, Charsets.UTF_8)
+        val redirectUrl = "$baseUrl/login?sso_error=$encodedCode&sso_message=$encodedMessage"
+
+        redirectStrategy.sendRedirect(request, response, redirectUrl)
+    }
+
+    private fun extractErrorDetails(exception: AuthenticationException): Pair<String, String> = when (exception) {
+        is OAuth2AuthenticationException -> {
+            val code = exception.error?.errorCode?.takeIf { it.isNotBlank() } ?: "sso_failure"
+            val description = exception.error?.description?.takeIf { it.isNotBlank() }
+                ?: exception.message
+                ?: "SSO login failed."
+            code to description
+        }
+
+        is Saml2AuthenticationException -> {
+            val code = exception.saml2Error?.errorCode?.takeIf { it.isNotBlank() } ?: "sso_failure"
+            val description = exception.saml2Error?.description?.takeIf { it.isNotBlank() }
+                ?: exception.message
+                ?: "SAML login failed."
+            code to description
+        }
+
+        else -> "sso_failure" to (exception.message ?: "SSO login failed.")
+    }
+
+    companion object {
+        private const val MAX_MESSAGE_LENGTH = 500
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/oidc/OidcLoginSuccessHandler.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/oidc/OidcLoginSuccessHandler.kt
@@ -1,5 +1,6 @@
 package dev.kviklet.kviklet.security.oidc
 
+import dev.kviklet.kviklet.security.FrontendUrlResolver
 import dev.kviklet.kviklet.security.KvikletOAuthPrincipal
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -11,7 +12,8 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component
 
 @Component
-class OidcLoginSuccessHandler : SimpleUrlAuthenticationSuccessHandler() {
+class OidcLoginSuccessHandler(private val frontendUrlResolver: FrontendUrlResolver) :
+    SimpleUrlAuthenticationSuccessHandler() {
 
     @Transactional
     override fun onAuthenticationSuccess(
@@ -31,16 +33,8 @@ class OidcLoginSuccessHandler : SimpleUrlAuthenticationSuccessHandler() {
             SecurityContextHolder.getContext().authentication = newAuth
         }
 
-        val baseUrl = request?.let { getBaseUrl(it) }
+        val baseUrl = request?.let { frontendUrlResolver.resolve(it) }
         val redirectUrl = "$baseUrl/requests"
         redirectStrategy.sendRedirect(request, response, redirectUrl)
-    }
-
-    private fun getBaseUrl(request: HttpServletRequest): String {
-        val scheme = request.scheme
-        val serverName = request.serverName
-        val serverPort = request.serverPort
-
-        return "$scheme://$serverName${if (serverPort != 80 && serverPort != 443) ":5173" else ""}"
     }
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/saml/SamlLoginSuccessHandler.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/saml/SamlLoginSuccessHandler.kt
@@ -1,6 +1,7 @@
 // This file is not MIT licensed
 package dev.kviklet.kviklet.security.saml
 
+import dev.kviklet.kviklet.security.FrontendUrlResolver
 import dev.kviklet.kviklet.security.PolicyGrantedAuthority
 import dev.kviklet.kviklet.security.UserDetailsWithId
 import jakarta.servlet.http.HttpServletRequest
@@ -16,8 +17,10 @@ import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnProperty(prefix = "saml", name = ["enabled"], havingValue = "true")
-class SamlLoginSuccessHandler(private val samlUserService: SamlUserService) :
-    SimpleUrlAuthenticationSuccessHandler() {
+class SamlLoginSuccessHandler(
+    private val samlUserService: SamlUserService,
+    private val frontendUrlResolver: FrontendUrlResolver,
+) : SimpleUrlAuthenticationSuccessHandler() {
 
     private val securityContextRepository = HttpSessionSecurityContextRepository()
 
@@ -52,23 +55,15 @@ class SamlLoginSuccessHandler(private val samlUserService: SamlUserService) :
                 request.session?.invalidate()
 
                 // Redirect to error page
-                val baseUrl = getBaseUrl(request)
+                val baseUrl = frontendUrlResolver.resolve(request)
                 val errorMessage = java.net.URLEncoder.encode(e.message ?: "SAML login failed", "UTF-8")
                 redirectStrategy.sendRedirect(request, response, "$baseUrl/login?error=$errorMessage")
                 return
             }
         }
 
-        val baseUrl = getBaseUrl(request)
+        val baseUrl = frontendUrlResolver.resolve(request)
         val redirectUrl = "$baseUrl/requests"
         redirectStrategy.sendRedirect(request, response, redirectUrl)
-    }
-
-    private fun getBaseUrl(request: HttpServletRequest): String {
-        val scheme = request.scheme
-        val serverName = request.serverName
-        val serverPort = request.serverPort
-
-        return "$scheme://$serverName${if (serverPort != 80 && serverPort != 443) ":5173" else ""}"
     }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/GitHubOAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/GitHubOAuthTest.kt
@@ -1,7 +1,7 @@
 package dev.kviklet.kviklet
 
+import com.gargoylesoftware.htmlunit.Page
 import com.gargoylesoftware.htmlunit.WebClient
-import com.gargoylesoftware.htmlunit.html.HtmlPage
 import dev.kviklet.kviklet.db.User
 import dev.kviklet.kviklet.db.UserAdapter
 import okhttp3.mockwebserver.Dispatcher
@@ -124,32 +124,54 @@ class GitHubOAuthTest {
         }
     }
 
-    private fun runOauthFlow() {
+    /**
+     * Runs the OAuth flow with manual redirect following so we can capture the
+     * final redirect URL Kviklet sends the browser to (the frontend). Both
+     * success and failure paths now redirect to the frontend, so we follow all
+     * hops on the backend and mock-GitHub origins and return the first
+     * redirect that leaves both — that is the URL the frontend would have
+     * received.
+     */
+    private fun runOauthFlow(): String {
         val webClient = WebClient().apply {
             options.apply {
-                isRedirectEnabled = true
+                isRedirectEnabled = false
                 isJavaScriptEnabled = false
                 isThrowExceptionOnScriptError = false
-                // Success path redirects to localhost:5173 (frontend) and fails with a connect
-                // exception; rejection path redirects to /login?error which 404s on the backend.
-                // Suppress the latter so both flows are observable via DB state.
                 isThrowExceptionOnFailingStatusCode = false
                 isUseInsecureSSL = true
                 isCssEnabled = false
             }
         }
+        val backendOrigin = "http://localhost:$port"
+        val mockOrigin = mockGithub.url("/").toString().trimEnd('/')
         try {
-            val loginUrl = "http://localhost:$port/oauth2/authorization/github"
-            try {
-                webClient.getPage<HtmlPage>(loginUrl)
-            } catch (e: Exception) {
-                // Frontend not running on 5173 — Kviklet's success handler redirects there.
-                // The OAuth dance up to that point still completed successfully.
-                assertThat(e.message).contains("Connect to localhost:5173")
+            var currentUrl = "$backendOrigin/oauth2/authorization/github"
+            repeat(25) {
+                val page = webClient.getPage<Page>(currentUrl)
+                val location = page.webResponse.getResponseHeaderValue("Location")
+                    ?: error("No redirect from $currentUrl (status=${page.webResponse.statusCode})")
+                val nextUrl = java.net.URI(currentUrl).resolve(location).toString()
+                if (!nextUrl.startsWith(backendOrigin) && !nextUrl.startsWith(mockOrigin)) {
+                    return nextUrl
+                }
+                currentUrl = nextUrl
             }
+            error("Too many redirects in OAuth flow")
         } finally {
             webClient.close()
         }
+    }
+
+    private fun assertSsoErrorRedirect(redirectUrl: String, expectedCode: String) {
+        assertThat(redirectUrl).startsWith("http://localhost:5173/login?")
+        val query = redirectUrl.substringAfter("?")
+        val params = query.split("&").associate {
+            val (k, v) = it.split("=", limit = 2).let { p -> p[0] to (p.getOrNull(1) ?: "") }
+            k to java.net.URLDecoder.decode(v, Charsets.UTF_8)
+        }
+        assertThat(params["sso_error"]).isEqualTo(expectedCode)
+        assertThat(params["sso_message"]).isNotEmpty()
     }
 
     @Test
@@ -215,7 +237,7 @@ class GitHubOAuthTest {
             userJson = """{"id":42,"login":"attacker","name":"Attacker","email":"victim@example.com"}""",
             emailsJson = """[{"email":"victim@example.com","primary":true,"verified":false}]""",
         )
-        runOauthFlow()
+        val redirectUrl = runOauthFlow()
 
         // No verified email → login fails, existing user is untouched.
         assertThat(userAdapter.listUsers().size).isEqualTo(before)
@@ -223,6 +245,7 @@ class GitHubOAuthTest {
         assertThat(victim).isNotNull
         assertThat(victim!!.githubId).isNull()
         assertThat(victim.password).isEqualTo("some-bcrypt-hash")
+        assertSsoErrorRedirect(redirectUrl, "user_email_unavailable")
     }
 
     @Test
@@ -233,10 +256,11 @@ class GitHubOAuthTest {
         )
         val before = userAdapter.listUsers().size
 
-        runOauthFlow()
+        val redirectUrl = runOauthFlow()
 
         assertThat(userAdapter.listUsers().size).isEqualTo(before)
         assertThat(userAdapter.findByEmail("out@example.com")).isNull()
+        assertSsoErrorRedirect(redirectUrl, "access_denied")
     }
 
     @Test

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FormEvent, useContext, useState } from "react";
 import Button from "../components/Button";
 import GoogleButton from "react-google-button";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { UserStatusContext } from "../components/UserStatusProvider";
 import image from "../logo.png";
 import baseUrl from "../api/base";
@@ -10,6 +10,37 @@ import Spinner from "../components/Spinner";
 import { isApiErrorResponse } from "../api/Errors";
 import useNotification from "../hooks/useNotification";
 import { attemptLogin } from "../api/LoginApi";
+
+const SSO_ERROR_COPY: Record<string, string> = {
+  access_denied:
+    "Your account isn't allowed to sign in. Contact your administrator if you think this is a mistake.",
+  user_email_unavailable:
+    "We couldn't read a verified email from your account. Verify your primary email with the SSO provider and try again.",
+  user_orgs_unavailable:
+    "We couldn't verify your organization membership. Try again or contact your administrator.",
+  server_error: "Single sign-on is misconfigured. Contact your administrator.",
+  invalid_user_info_response:
+    "We received an unexpected response from the SSO provider. Try again or contact your administrator.",
+};
+
+const SsoErrorBanner = ({
+  code,
+  message,
+}: {
+  code: string;
+  message: string | null;
+}) => {
+  const text = SSO_ERROR_COPY[code] ?? message ?? "SSO login failed.";
+  return (
+    <div
+      role="alert"
+      data-testid="sso-error-banner"
+      className="mb-4 rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-800 dark:border-red-700 dark:bg-red-900/20 dark:text-red-200"
+    >
+      {text}
+    </div>
+  );
+};
 
 const StyledInput = (props: {
   name: string;
@@ -44,6 +75,10 @@ const Login = () => {
   const { config, loading } = useConfig();
 
   const { addNotification } = useNotification();
+
+  const [searchParams] = useSearchParams();
+  const ssoError = searchParams.get("sso_error");
+  const ssoMessage = searchParams.get("sso_message");
 
   const hasSso = !!config?.oauthProvider || !!config?.samlEnabled;
   const showForm = !hasSso || showLocalLogin;
@@ -122,6 +157,9 @@ const Login = () => {
           </div>
           <div className="mb-6 text-center text-2xl">Sign in to Kviklet</div>
           <div className="rounded-md p-6 shadow-xl dark:bg-slate-900 dark:shadow-none">
+            {ssoError && (
+              <SsoErrorBanner code={ssoError} message={ssoMessage} />
+            )}
             {oAuthButton()}
             {samlButton()}
 


### PR DESCRIPTION
## Summary

Failed SSO logins (GitHub OAuth, OIDC, SAML) used to land on Spring Security's default `/login?error` URL, which is a POST-only API endpoint in Kviklet. That fell through to the generic `Exception` handler and returned `{"message":"An unexpected error occurred :("}` as JSON, losing the actual reason for the failure.

This PR routes SSO failures back to the frontend `/login` route with structured query params so the user sees an actionable banner.

- New `SsoAuthenticationFailureHandler` extracts `errorCode` / `description` from `OAuth2AuthenticationException` and `Saml2AuthenticationException` and redirects to `${frontend}/login?sso_error=<code>&sso_message=<encoded>` (message capped at 500 chars).
- Wired into both `oauth2Login` and `saml2Login` (latter only when SAML is enabled).
- Frontend `Login.tsx` reads `sso_error` / `sso_message` and renders an inline red banner with friendly copy keyed off the code (`access_denied`, `user_email_unavailable`, `user_orgs_unavailable`, `server_error`, `invalid_user_info_response`), falling back to the raw `sso_message` for unknown codes.
- Extracted the duplicated `getBaseUrl(request)` helper from `OidcLoginSuccessHandler` and `SamlLoginSuccessHandler` into a shared `FrontendUrlResolver` so the new failure handler doesn't add a fourth copy.
- Defence-in-depth: `ExceptionHandlerController` now maps `HttpRequestMethodNotSupportedException` to 405 instead of falling through to the generic 500 handler.
- `GitHubOAuthTest`'s `runOauthFlow()` was rewritten to follow redirects manually and return the final external redirect URL, so the rejection-path tests now assert the redirect lands on `/login` with the expected `sso_error` code.