### PR TITLE
Add MySQL and MariaDB support to the query-auditing proxy

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
@@ -8,6 +8,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
+import java.nio.BufferUnderflowException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.security.MessageDigest
@@ -118,64 +119,72 @@ class HandshakeResponse(
 ) {
     companion object {
         fun parse(payload: ByteArray): HandshakeResponse {
-            val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
-            val capabilities = buffer.int
-            val maxPacketSize = buffer.int
-            val charset = buffer.get()
-            // Skip 23 bytes of reserved/filler
-            for (i in 0 until 23) {
-                buffer.get()
-            }
-            // Read null-terminated username
-            val usernameBytes = ByteArrayOutputStream()
-            while (true) {
-                val b = buffer.get()
-                if (b == 0.toByte()) break
-                usernameBytes.write(b.toInt())
-            }
-            val username = String(usernameBytes.toByteArray(), Charsets.UTF_8)
-            
-            // Read auth response
-            var authResponseLen = 0
-            val hasSecureConnection = (capabilities and 0x8000) != 0
-            val authResponse = if (hasSecureConnection) {
-                authResponseLen = buffer.get().toInt() and 0xFF
-                val authBytes = ByteArray(authResponseLen)
-                buffer.get(authBytes)
-                authBytes
-            } else {
-                val authBytesStream = ByteArrayOutputStream()
+            try {
+                val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+                val capabilities = buffer.int
+                val maxPacketSize = buffer.int
+                val charset = buffer.get()
+                // Skip 23 bytes of reserved/filler
+                for (i in 0 until 23) {
+                    buffer.get()
+                }
+                // Read null-terminated username
+                val usernameBytes = ByteArrayOutputStream()
                 while (true) {
                     val b = buffer.get()
                     if (b == 0.toByte()) break
-                    authBytesStream.write(b.toInt())
+                    usernameBytes.write(b.toInt())
                 }
-                authBytesStream.toByteArray()
-            }
-            
-            var database: String? = null
-            if ((capabilities and 0x0008) != 0) {
-                val dbBytes = ByteArrayOutputStream()
-                while (buffer.hasRemaining()) {
-                    val b = buffer.get()
-                    if (b == 0.toByte()) break
-                    dbBytes.write(b.toInt())
+                val username = String(usernameBytes.toByteArray(), Charsets.UTF_8)
+
+                // Reject lenenc-encoded auth data — we don't advertise this capability
+                if ((capabilities and 0x00200000) != 0) {
+                    throw IOException("CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA is not supported by this proxy")
                 }
-                database = String(dbBytes.toByteArray(), Charsets.UTF_8)
-            }
-            
-            var authPluginName: String? = null
-            if ((capabilities and 0x00080000) != 0) {
-                val pluginBytes = ByteArrayOutputStream()
-                while (buffer.hasRemaining()) {
-                    val b = buffer.get()
-                    if (b == 0.toByte()) break
-                    pluginBytes.write(b.toInt())
+
+                // Read auth response
+                val hasSecureConnection = (capabilities and 0x8000) != 0
+                val authResponse = if (hasSecureConnection) {
+                    val authResponseLen = buffer.get().toInt() and 0xFF
+                    val authBytes = ByteArray(authResponseLen)
+                    buffer.get(authBytes)
+                    authBytes
+                } else {
+                    val authBytesStream = ByteArrayOutputStream()
+                    while (true) {
+                        val b = buffer.get()
+                        if (b == 0.toByte()) break
+                        authBytesStream.write(b.toInt())
+                    }
+                    authBytesStream.toByteArray()
                 }
-                authPluginName = String(pluginBytes.toByteArray(), Charsets.UTF_8)
+
+                var database: String? = null
+                if ((capabilities and 0x0008) != 0) {
+                    val dbBytes = ByteArrayOutputStream()
+                    while (buffer.hasRemaining()) {
+                        val b = buffer.get()
+                        if (b == 0.toByte()) break
+                        dbBytes.write(b.toInt())
+                    }
+                    database = String(dbBytes.toByteArray(), Charsets.UTF_8)
+                }
+
+                var authPluginName: String? = null
+                if ((capabilities and 0x00080000) != 0) {
+                    val pluginBytes = ByteArrayOutputStream()
+                    while (buffer.hasRemaining()) {
+                        val b = buffer.get()
+                        if (b == 0.toByte()) break
+                        pluginBytes.write(b.toInt())
+                    }
+                    authPluginName = String(pluginBytes.toByteArray(), Charsets.UTF_8)
+                }
+
+                return HandshakeResponse(username, authResponse, database, authPluginName)
+            } catch (e: BufferUnderflowException) {
+                throw IOException("Malformed HandshakeResponse packet (truncated)", e)
             }
-            
-            return HandshakeResponse(username, authResponse, database, authPluginName)
         }
     }
 }
@@ -205,7 +214,7 @@ fun verifyPassword(scramble: ByteArray, password: String, clientHash: ByteArray)
     val sha1Concat = sha1(concat)
     val expectedClientHash = xor(sha1Password, sha1Concat)
     
-    return expectedClientHash.contentEquals(clientHash)
+    return MessageDigest.isEqual(expectedClientHash, clientHash)
 }
 
 fun buildOkPacket(): ByteArray {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
@@ -2,6 +2,7 @@ package dev.kviklet.kviklet.proxy.mysql
 
 import dev.kviklet.kviklet.proxy.postgres.TLSCertificate
 import dev.kviklet.kviklet.proxy.postgres.enableSSL
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayOutputStream
 import java.io.EOFException
 import java.io.IOException
@@ -13,6 +14,8 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.security.MessageDigest
 import java.security.SecureRandom
+
+private val logger = LoggerFactory.getLogger("ClientMySqlConnectionSetup")
 
 fun readPacket(input: InputStream): Pair<Byte, ByteArray> {
     val header = ByteArray(4)
@@ -282,26 +285,25 @@ fun setupClientMySql(
     }
 
     // 4. Parse Handshake Response
-    println("Parsing Handshake Response. Payload size: ${payload.size}")
+    logger.debug("Parsing handshake response, payload size: {}", payload.size)
     val response = HandshakeResponse.parse(payload)
-    println("Parsed Handshake Response. Username: '${response.username}', Database: '${response.database}', Plugin: '${response.authPluginName}'")
 
     // 5. Verify username and password (indistinguishable paths to prevent username enumeration and timing attacks)
     val isUsernameValid = (response.username == username)
     val isPasswordValid = verifyPassword(salt, password, response.authResponse)
 
     if (!isUsernameValid || !isPasswordValid) {
-        println("Authentication failed for user '${response.username}'")
+        // Echo the client-supplied username back in the wire-protocol error packet only;
+        // never log it or embed it in the server-side exception to avoid leaking attempted usernames.
         val errPayload = buildErrPacket(1045, "28000", "Access denied for user '${response.username}' (using password: YES)")
         writePacket(output, (seqId + 1).toByte(), errPayload)
-        throw IOException("Authentication failed: Access denied for user '${response.username}'")
+        throw IOException("Authentication failed: access denied")
     }
 
-    println("Authentication successful! Sending OK packet...")
     // 6. Send OK packet
     val okPayload = buildOkPacket()
     writePacket(output, (seqId + 1).toByte(), okPayload)
-    println("OK packet sent with sequence ID: ${(seqId + 1)}")
+    logger.debug("Authentication successful, OK packet sent")
 
     return finalSocket
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
@@ -76,9 +76,8 @@ fun buildInitialHandshake(connectionId: Int, salt: ByteArray): ByteArray {
     
     // Capability flags lower 2 bytes (0x820c)
     // CLIENT_LONG_PASSWORD | CLIENT_FOUND_ROWS | CLIENT_CONNECT_WITH_DB | CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION
-    // Also add CLIENT_SSL (0x0800) if we want to allow SSL!
     bos.write(0x0c)
-    bos.write(0x8a) // 0x8a has CLIENT_SSL set! (0x82 | 0x08)
+    bos.write(0x82) 
     
     bos.write(45) // Character set: utf8mb4_general_ci
     
@@ -270,24 +269,30 @@ fun setupClientMySql(
     }
 
     // 4. Parse Handshake Response
+    println("Parsing Handshake Response. Payload size: ${payload.size}")
     val response = HandshakeResponse.parse(payload)
+    println("Parsed Handshake Response. Username: '${response.username}', Database: '${response.database}', Plugin: '${response.authPluginName}'")
 
     // 5. Verify username and password
     if (response.username != username) {
+        println("Username mismatch: expected '$username', got '${response.username}'")
         val errPayload = buildErrPacket(1045, "28000", "Access denied for user '${response.username}'")
         writePacket(output, (seqId + 1).toByte(), errPayload)
         throw IOException("Authentication failed: invalid username '${response.username}'")
     }
 
     if (!verifyPassword(salt, password, response.authResponse)) {
+        println("Password validation failed")
         val errPayload = buildErrPacket(1045, "28000", "Access denied for user '${response.username}' (using password: YES)")
         writePacket(output, (seqId + 1).toByte(), errPayload)
         throw IOException("Authentication failed: invalid password")
     }
 
+    println("Authentication successful! Sending OK packet...")
     // 6. Send OK packet
     val okPayload = buildOkPacket()
     writePacket(output, (seqId + 1).toByte(), okPayload)
+    println("OK packet sent with sequence ID: ${(seqId + 1)}")
 
     return finalSocket
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
@@ -26,8 +26,8 @@ fun readPacket(input: InputStream): Pair<Byte, ByteArray> {
         read += r
     }
     val length = (header[0].toInt() and 0xFF) or
-                 ((header[1].toInt() and 0xFF) shl 8) or
-                 ((header[2].toInt() and 0xFF) shl 16)
+        ((header[1].toInt() and 0xFF) shl 8) or
+        ((header[2].toInt() and 0xFF) shl 16)
     val sequenceId = header[3]
     val payload = ByteArray(length)
     read = 0
@@ -67,17 +67,17 @@ fun buildInitialHandshake(connectionId: Int, salt: ByteArray, supportSsl: Boolea
     bos.write(10) // Protocol version
     bos.write(serverVersion.toByteArray(Charsets.US_ASCII))
     bos.write(0) // Null terminator
-    
+
     // Connection ID
     bos.write(connectionId and 0xFF)
     bos.write((connectionId ushr 8) and 0xFF)
     bos.write((connectionId ushr 16) and 0xFF)
     bos.write((connectionId ushr 24) and 0xFF)
-    
+
     // Auth-plugin-data-part-1 (8 bytes)
     bos.write(salt, 0, 8)
     bos.write(0) // filler
-    
+
     // Capability flags lower 2 bytes (0x820c or 0x8a0c)
     // CLIENT_LONG_PASSWORD | CLIENT_FOUND_ROWS | CLIENT_CONNECT_WITH_DB | CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION
     bos.write(0x0c)
@@ -85,32 +85,32 @@ fun buildInitialHandshake(connectionId: Int, salt: ByteArray, supportSsl: Boolea
         bos.write(0x8a) // 0x8a has CLIENT_SSL set! (0x82 | 0x08)
     } else {
         bos.write(0x82)
-    } 
-    
+    }
+
     bos.write(45) // Character set: utf8mb4_general_ci
-    
+
     // Status flags: SERVER_STATUS_AUTOCOMMIT (0x0002)
     bos.write(0x02)
     bos.write(0x00)
-    
+
     // Capability flags upper 2 bytes (0x0008)
     // CLIENT_PLUGIN_AUTH
     bos.write(0x08)
     bos.write(0x00)
-    
+
     bos.write(21) // Auth-plugin-data-len
-    
+
     // Reserved (10 bytes)
     for (i in 0 until 10) bos.write(0)
-    
+
     // Auth-plugin-data-part-2 (12 bytes)
     bos.write(salt, 8, 12)
     bos.write(0) // filler
-    
+
     // Auth-plugin-name
     bos.write("mysql_native_password".toByteArray(Charsets.US_ASCII))
     bos.write(0) // Null terminator
-    
+
     return bos.toByteArray()
 }
 
@@ -118,7 +118,7 @@ class HandshakeResponse(
     val username: String,
     val authResponse: ByteArray,
     val database: String?,
-    val authPluginName: String?
+    val authPluginName: String?,
 ) {
     companion object {
         fun parse(payload: ByteArray): HandshakeResponse {
@@ -209,14 +209,14 @@ fun verifyPassword(scramble: ByteArray, password: String, clientHash: ByteArray)
     val passwordBytes = password.toByteArray(Charsets.UTF_8)
     val sha1Password = sha1(passwordBytes)
     val sha1Sha1Password = sha1(sha1Password)
-    
+
     val concat = ByteArray(scramble.size + sha1Sha1Password.size)
     System.arraycopy(scramble, 0, concat, 0, scramble.size)
     System.arraycopy(sha1Sha1Password, 0, concat, scramble.size, sha1Sha1Password.size)
-    
+
     val sha1Concat = sha1(concat)
     val expectedClientHash = xor(sha1Password, sha1Concat)
-    
+
     return MessageDigest.isEqual(expectedClientHash, clientHash)
 }
 
@@ -243,12 +243,7 @@ fun buildErrPacket(errorCode: Int, sqlState: String, message: String): ByteArray
     return bos.toByteArray()
 }
 
-fun setupClientMySql(
-    client: Socket,
-    tlsCert: TLSCertificate?,
-    username: String,
-    password: String,
-): Socket {
+fun setupClientMySql(client: Socket, tlsCert: TLSCertificate?, username: String, password: String): Socket {
     var input = client.getInputStream()
     var output = client.getOutputStream()
     var finalSocket: Socket = client
@@ -264,12 +259,13 @@ fun setupClientMySql(
     // 3. Check for SSL Request
     if (payload.size >= 4) {
         val capabilities = (payload[0].toInt() and 0xFF) or
-                           ((payload[1].toInt() and 0xFF) shl 8) or
-                           ((payload[2].toInt() and 0xFF) shl 16) or
-                           ((payload[3].toInt() and 0xFF) shl 24)
+            ((payload[1].toInt() and 0xFF) shl 8) or
+            ((payload[2].toInt() and 0xFF) shl 16) or
+            ((payload[3].toInt() and 0xFF) shl 24)
         if ((capabilities and 0x0800) != 0) { // CLIENT_SSL
             if (tlsCert == null) {
-                val errPayload = buildErrPacket(2000, "HY000", "SSL connection requested but SSL is not supported by proxy")
+                val errPayload =
+                    buildErrPacket(2000, "HY000", "SSL connection requested but SSL is not supported by proxy")
                 writePacket(output, (seqId + 1).toByte(), errPayload)
                 throw IOException("Client requested SSL but SSL is not supported by proxy")
             }
@@ -295,7 +291,8 @@ fun setupClientMySql(
     if (!isUsernameValid || !isPasswordValid) {
         // Echo the client-supplied username back in the wire-protocol error packet only;
         // never log it or embed it in the server-side exception to avoid leaking attempted usernames.
-        val errPayload = buildErrPacket(1045, "28000", "Access denied for user '${response.username}' (using password: YES)")
+        val errPayload =
+            buildErrPacket(1045, "28000", "Access denied for user '${response.username}' (using password: YES)")
         writePacket(output, (seqId + 1).toByte(), errPayload)
         throw IOException("Authentication failed: access denied")
     }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
@@ -57,7 +57,7 @@ fun generateRandomSalt(): ByteArray {
     return salt
 }
 
-fun buildInitialHandshake(connectionId: Int, salt: ByteArray): ByteArray {
+fun buildInitialHandshake(connectionId: Int, salt: ByteArray, supportSsl: Boolean): ByteArray {
     val serverVersion = "8.0.35-kviklet"
     val bos = ByteArrayOutputStream()
     bos.write(10) // Protocol version
@@ -74,10 +74,14 @@ fun buildInitialHandshake(connectionId: Int, salt: ByteArray): ByteArray {
     bos.write(salt, 0, 8)
     bos.write(0) // filler
     
-    // Capability flags lower 2 bytes (0x820c)
+    // Capability flags lower 2 bytes (0x820c or 0x8a0c)
     // CLIENT_LONG_PASSWORD | CLIENT_FOUND_ROWS | CLIENT_CONNECT_WITH_DB | CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION
     bos.write(0x0c)
-    bos.write(0x82) 
+    if (supportSsl) {
+        bos.write(0x8a) // 0x8a has CLIENT_SSL set! (0x82 | 0x08)
+    } else {
+        bos.write(0x82)
+    } 
     
     bos.write(45) // Character set: utf8mb4_general_ci
     
@@ -239,7 +243,7 @@ fun setupClientMySql(
 
     // 1. Send Initial Handshake
     val salt = generateRandomSalt()
-    val handshakePayload = buildInitialHandshake(1, salt)
+    val handshakePayload = buildInitialHandshake(1, salt, tlsCert != null)
     writePacket(output, 0, handshakePayload)
 
     // 2. Read Client Handshake Response
@@ -273,19 +277,15 @@ fun setupClientMySql(
     val response = HandshakeResponse.parse(payload)
     println("Parsed Handshake Response. Username: '${response.username}', Database: '${response.database}', Plugin: '${response.authPluginName}'")
 
-    // 5. Verify username and password
-    if (response.username != username) {
-        println("Username mismatch: expected '$username', got '${response.username}'")
-        val errPayload = buildErrPacket(1045, "28000", "Access denied for user '${response.username}'")
-        writePacket(output, (seqId + 1).toByte(), errPayload)
-        throw IOException("Authentication failed: invalid username '${response.username}'")
-    }
+    // 5. Verify username and password (indistinguishable paths to prevent username enumeration and timing attacks)
+    val isUsernameValid = (response.username == username)
+    val isPasswordValid = verifyPassword(salt, password, response.authResponse)
 
-    if (!verifyPassword(salt, password, response.authResponse)) {
-        println("Password validation failed")
+    if (!isUsernameValid || !isPasswordValid) {
+        println("Authentication failed for user '${response.username}'")
         val errPayload = buildErrPacket(1045, "28000", "Access denied for user '${response.username}' (using password: YES)")
         writePacket(output, (seqId + 1).toByte(), errPayload)
-        throw IOException("Authentication failed: invalid password")
+        throw IOException("Authentication failed: Access denied for user '${response.username}'")
     }
 
     println("Authentication successful! Sending OK packet...")

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
@@ -1,0 +1,293 @@
+package dev.kviklet.kviklet.proxy.mysql
+
+import dev.kviklet.kviklet.proxy.postgres.TLSCertificate
+import dev.kviklet.kviklet.proxy.postgres.enableSSL
+import java.io.ByteArrayOutputStream
+import java.io.EOFException
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+fun readPacket(input: InputStream): Pair<Byte, ByteArray> {
+    val header = ByteArray(4)
+    var read = 0
+    while (read < 4) {
+        val r = input.read(header, read, 4 - read)
+        if (r == -1) throw EOFException("EOF while reading packet header")
+        read += r
+    }
+    val length = (header[0].toInt() and 0xFF) or
+                 ((header[1].toInt() and 0xFF) shl 8) or
+                 ((header[2].toInt() and 0xFF) shl 16)
+    val sequenceId = header[3]
+    val payload = ByteArray(length)
+    read = 0
+    while (read < length) {
+        val r = input.read(payload, read, length - read)
+        if (r == -1) throw EOFException("EOF while reading packet payload")
+        read += r
+    }
+    return Pair(sequenceId, payload)
+}
+
+fun writePacket(output: OutputStream, sequenceId: Byte, payload: ByteArray) {
+    val header = ByteArray(4)
+    val length = payload.size
+    header[0] = (length and 0xFF).toByte()
+    header[1] = ((length ushr 8) and 0xFF).toByte()
+    header[2] = ((length ushr 16) and 0xFF).toByte()
+    header[3] = sequenceId
+    output.write(header)
+    output.write(payload)
+    output.flush()
+}
+
+fun generateRandomSalt(): ByteArray {
+    val random = SecureRandom()
+    val salt = ByteArray(20)
+    for (i in 0 until 20) {
+        // Keep within safe ASCII printable range and non-zero
+        salt[i] = (random.nextInt(90) + 33).toByte()
+    }
+    return salt
+}
+
+fun buildInitialHandshake(connectionId: Int, salt: ByteArray): ByteArray {
+    val serverVersion = "8.0.35-kviklet"
+    val bos = ByteArrayOutputStream()
+    bos.write(10) // Protocol version
+    bos.write(serverVersion.toByteArray(Charsets.US_ASCII))
+    bos.write(0) // Null terminator
+    
+    // Connection ID
+    bos.write(connectionId and 0xFF)
+    bos.write((connectionId ushr 8) and 0xFF)
+    bos.write((connectionId ushr 16) and 0xFF)
+    bos.write((connectionId ushr 24) and 0xFF)
+    
+    // Auth-plugin-data-part-1 (8 bytes)
+    bos.write(salt, 0, 8)
+    bos.write(0) // filler
+    
+    // Capability flags lower 2 bytes (0x820c)
+    // CLIENT_LONG_PASSWORD | CLIENT_FOUND_ROWS | CLIENT_CONNECT_WITH_DB | CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION
+    // Also add CLIENT_SSL (0x0800) if we want to allow SSL!
+    bos.write(0x0c)
+    bos.write(0x8a) // 0x8a has CLIENT_SSL set! (0x82 | 0x08)
+    
+    bos.write(45) // Character set: utf8mb4_general_ci
+    
+    // Status flags: SERVER_STATUS_AUTOCOMMIT (0x0002)
+    bos.write(0x02)
+    bos.write(0x00)
+    
+    // Capability flags upper 2 bytes (0x0008)
+    // CLIENT_PLUGIN_AUTH
+    bos.write(0x08)
+    bos.write(0x00)
+    
+    bos.write(21) // Auth-plugin-data-len
+    
+    // Reserved (10 bytes)
+    for (i in 0 until 10) bos.write(0)
+    
+    // Auth-plugin-data-part-2 (12 bytes)
+    bos.write(salt, 8, 12)
+    bos.write(0) // filler
+    
+    // Auth-plugin-name
+    bos.write("mysql_native_password".toByteArray(Charsets.US_ASCII))
+    bos.write(0) // Null terminator
+    
+    return bos.toByteArray()
+}
+
+class HandshakeResponse(
+    val username: String,
+    val authResponse: ByteArray,
+    val database: String?,
+    val authPluginName: String?
+) {
+    companion object {
+        fun parse(payload: ByteArray): HandshakeResponse {
+            val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+            val capabilities = buffer.int
+            val maxPacketSize = buffer.int
+            val charset = buffer.get()
+            // Skip 23 bytes of reserved/filler
+            for (i in 0 until 23) {
+                buffer.get()
+            }
+            // Read null-terminated username
+            val usernameBytes = ByteArrayOutputStream()
+            while (true) {
+                val b = buffer.get()
+                if (b == 0.toByte()) break
+                usernameBytes.write(b.toInt())
+            }
+            val username = String(usernameBytes.toByteArray(), Charsets.UTF_8)
+            
+            // Read auth response
+            var authResponseLen = 0
+            val hasSecureConnection = (capabilities and 0x8000) != 0
+            val authResponse = if (hasSecureConnection) {
+                authResponseLen = buffer.get().toInt() and 0xFF
+                val authBytes = ByteArray(authResponseLen)
+                buffer.get(authBytes)
+                authBytes
+            } else {
+                val authBytesStream = ByteArrayOutputStream()
+                while (true) {
+                    val b = buffer.get()
+                    if (b == 0.toByte()) break
+                    authBytesStream.write(b.toInt())
+                }
+                authBytesStream.toByteArray()
+            }
+            
+            var database: String? = null
+            if ((capabilities and 0x0008) != 0) {
+                val dbBytes = ByteArrayOutputStream()
+                while (buffer.hasRemaining()) {
+                    val b = buffer.get()
+                    if (b == 0.toByte()) break
+                    dbBytes.write(b.toInt())
+                }
+                database = String(dbBytes.toByteArray(), Charsets.UTF_8)
+            }
+            
+            var authPluginName: String? = null
+            if ((capabilities and 0x00080000) != 0) {
+                val pluginBytes = ByteArrayOutputStream()
+                while (buffer.hasRemaining()) {
+                    val b = buffer.get()
+                    if (b == 0.toByte()) break
+                    pluginBytes.write(b.toInt())
+                }
+                authPluginName = String(pluginBytes.toByteArray(), Charsets.UTF_8)
+            }
+            
+            return HandshakeResponse(username, authResponse, database, authPluginName)
+        }
+    }
+}
+
+fun sha1(data: ByteArray): ByteArray {
+    val md = MessageDigest.getInstance("SHA-1")
+    return md.digest(data)
+}
+
+fun xor(a: ByteArray, b: ByteArray): ByteArray {
+    val result = ByteArray(a.size)
+    for (i in a.indices) {
+        result[i] = (a[i].toInt() xor b[i].toInt()).toByte()
+    }
+    return result
+}
+
+fun verifyPassword(scramble: ByteArray, password: String, clientHash: ByteArray): Boolean {
+    val passwordBytes = password.toByteArray(Charsets.UTF_8)
+    val sha1Password = sha1(passwordBytes)
+    val sha1Sha1Password = sha1(sha1Password)
+    
+    val concat = ByteArray(scramble.size + sha1Sha1Password.size)
+    System.arraycopy(scramble, 0, concat, 0, scramble.size)
+    System.arraycopy(sha1Sha1Password, 0, concat, scramble.size, sha1Sha1Password.size)
+    
+    val sha1Concat = sha1(concat)
+    val expectedClientHash = xor(sha1Password, sha1Concat)
+    
+    return expectedClientHash.contentEquals(clientHash)
+}
+
+fun buildOkPacket(): ByteArray {
+    val bos = ByteArrayOutputStream()
+    bos.write(0x00) // OK header
+    bos.write(0x00) // Affected rows (0)
+    bos.write(0x00) // Last insert ID (0)
+    bos.write(0x02) // Status flags lower byte (SERVER_STATUS_AUTOCOMMIT)
+    bos.write(0x00) // Status flags upper byte
+    bos.write(0x00) // Warnings lower byte (0)
+    bos.write(0x00) // Warnings upper byte
+    return bos.toByteArray()
+}
+
+fun buildErrPacket(errorCode: Int, sqlState: String, message: String): ByteArray {
+    val bos = ByteArrayOutputStream()
+    bos.write(0xFF)
+    bos.write(errorCode and 0xFF)
+    bos.write((errorCode ushr 8) and 0xFF)
+    bos.write('#'.code)
+    bos.write(sqlState.toByteArray(Charsets.US_ASCII))
+    bos.write(message.toByteArray(Charsets.UTF_8))
+    return bos.toByteArray()
+}
+
+fun setupClientMySql(
+    client: Socket,
+    tlsCert: TLSCertificate?,
+    username: String,
+    password: String,
+): Socket {
+    var input = client.getInputStream()
+    var output = client.getOutputStream()
+    var finalSocket: Socket = client
+
+    // 1. Send Initial Handshake
+    val salt = generateRandomSalt()
+    val handshakePayload = buildInitialHandshake(1, salt)
+    writePacket(output, 0, handshakePayload)
+
+    // 2. Read Client Handshake Response
+    var (seqId, payload) = readPacket(input)
+
+    // 3. Check for SSL Request
+    if (payload.size >= 4) {
+        val capabilities = (payload[0].toInt() and 0xFF) or
+                           ((payload[1].toInt() and 0xFF) shl 8) or
+                           ((payload[2].toInt() and 0xFF) shl 16) or
+                           ((payload[3].toInt() and 0xFF) shl 24)
+        if ((capabilities and 0x0800) != 0) { // CLIENT_SSL
+            if (tlsCert == null) {
+                val errPayload = buildErrPacket(2000, "HY000", "SSL connection requested but SSL is not supported by proxy")
+                writePacket(output, (seqId + 1).toByte(), errPayload)
+                throw IOException("Client requested SSL but SSL is not supported by proxy")
+            }
+            finalSocket = enableSSL(client, tlsCert)
+            input = finalSocket.getInputStream()
+            output = finalSocket.getOutputStream()
+
+            // Read the actual Handshake Response from the encrypted stream
+            val nextPacket = readPacket(input)
+            seqId = nextPacket.first
+            payload = nextPacket.second
+        }
+    }
+
+    // 4. Parse Handshake Response
+    val response = HandshakeResponse.parse(payload)
+
+    // 5. Verify username and password
+    if (response.username != username) {
+        val errPayload = buildErrPacket(1045, "28000", "Access denied for user '${response.username}'")
+        writePacket(output, (seqId + 1).toByte(), errPayload)
+        throw IOException("Authentication failed: invalid username '${response.username}'")
+    }
+
+    if (!verifyPassword(salt, password, response.authResponse)) {
+        val errPayload = buildErrPacket(1045, "28000", "Access denied for user '${response.username}' (using password: YES)")
+        writePacket(output, (seqId + 1).toByte(), errPayload)
+        throw IOException("Authentication failed: invalid password")
+    }
+
+    // 6. Send OK packet
+    val okPayload = buildOkPacket()
+    writePacket(output, (seqId + 1).toByte(), okPayload)
+
+    return finalSocket
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -23,7 +23,43 @@ class MySqlConnection(
     private var terminationMessageReceived: Boolean = false
     private var serverTerminating: Boolean = false
 
-    private val parser = MySqlClientPacketParser { query ->
+    @Volatile
+    private var awaitingPrepareResponse = false
+    private var lastPreparedQuery: String? = null
+    private val preparedQueries = java.util.concurrent.ConcurrentHashMap<Int, String>()
+
+    private val clientParser = MySqlClientPacketParser(
+        onQuery = { query ->
+            auditQuery(query)
+        },
+        onPrepare = { query ->
+            synchronized(this) {
+                lastPreparedQuery = query
+                awaitingPrepareResponse = true
+            }
+        },
+        onExecute = { stmtId ->
+            val query = preparedQueries[stmtId]
+            if (query != null) {
+                auditQuery(query)
+            }
+        },
+        onQuit = {
+            terminationMessageReceived = true
+        }
+    )
+
+    private val serverParser = MySqlServerPacketParser { stmtId ->
+        synchronized(this) {
+            if (awaitingPrepareResponse) {
+                lastPreparedQuery?.let { preparedQueries[stmtId] = it }
+                awaitingPrepareResponse = false
+                lastPreparedQuery = null
+            }
+        }
+    }
+
+    private fun auditQuery(query: String) {
         try {
             val executePayload = ExecutePayload(query = query)
             eventService.saveEvent(executionRequest.id!!, userId, executePayload)
@@ -37,30 +73,43 @@ class MySqlConnection(
     }
 
     fun startHandling() {
-        while (!terminationMessageReceived && !serverTerminating) {
-            readFromAnyStream(clientInput) { handleClientData(it) }
-            readFromAnyStream(serverInput) { clientOutput.writeAndFlush(it) }
+        try {
+            while (!terminationMessageReceived && !serverTerminating) {
+                val clientOk = readFromAnyStream(clientInput) { handleClientData(it) }
+                if (!clientOk) break
+                val serverOk = readFromAnyStream(serverInput) { handleServerData(it) }
+                if (!serverOk) break
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        } finally {
+            close()
         }
     }
 
     private fun handleClientData(clientBuffer: ByteArray) {
-        // Feed raw bytes to parser for query auditing
-        parser.addBytes(clientBuffer)
-        
-        // Check for COM_QUIT (sequence id doesn't matter, first payload byte of packet can be 0x01)
-        if (clientBuffer.size >= 5) {
-            val cmd = clientBuffer[4].toInt() and 0xFF
-            if (cmd == 0x01) { // COM_QUIT
-                terminationMessageReceived = true
-            }
-        }
+        // Feed raw bytes to client parser for query/prepare/execute/quit auditing
+        clientParser.addBytes(clientBuffer)
         
         // Forward raw bytes to the server
         serverOutput.writeAndFlush(clientBuffer)
     }
+
+    private fun handleServerData(serverBuffer: ByteArray) {
+        // Feed raw bytes to server parser to match generated statement IDs
+        serverParser.addBytes(serverBuffer)
+        
+        // Forward raw bytes to the client
+        clientOutput.writeAndFlush(serverBuffer)
+    }
 }
 
-class MySqlClientPacketParser(private val onQuery: (String) -> Unit) {
+class MySqlClientPacketParser(
+    private val onQuery: (String) -> Unit,
+    private val onPrepare: (String) -> Unit,
+    private val onExecute: (Int) -> Unit,
+    private val onQuit: () -> Unit
+) {
     private val buffer = ByteArrayOutputStream()
 
     fun addBytes(bytes: ByteArray) {
@@ -87,12 +136,83 @@ class MySqlClientPacketParser(private val onQuery: (String) -> Unit) {
             
             if (payload.isNotEmpty()) {
                 val cmd = payload[0].toInt() and 0xFF
-                if (cmd == 0x03 || cmd == 0x16) { // COM_QUERY or COM_STMT_PREPARE
-                    try {
-                        val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
-                        if (query.trim().isNotEmpty()) {
-                            onQuery(query)
+                try {
+                    when (cmd) {
+                        0x01 -> { // COM_QUIT
+                            onQuit()
                         }
+                        0x03 -> { // COM_QUERY
+                            val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
+                            if (query.trim().isNotEmpty()) {
+                                onQuery(query)
+                            }
+                        }
+                        0x16 -> { // COM_STMT_PREPARE
+                            val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
+                            if (query.trim().isNotEmpty()) {
+                                onPrepare(query)
+                            }
+                        }
+                        0x17 -> { // COM_STMT_EXECUTE
+                            if (payload.size >= 5) {
+                                val stmtId = (payload[1].toInt() and 0xFF) or
+                                             ((payload[2].toInt() and 0xFF) shl 8) or
+                                             ((payload[3].toInt() and 0xFF) shl 16) or
+                                             ((payload[4].toInt() and 0xFF) shl 24)
+                                onExecute(stmtId)
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }
+            
+            offset += 4 + length
+        }
+        
+        buffer.reset()
+        if (data.size > offset) {
+            buffer.write(data, offset, data.size - offset)
+        }
+    }
+}
+
+class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit) {
+    private val buffer = ByteArrayOutputStream()
+
+    fun addBytes(bytes: ByteArray) {
+        synchronized(this) {
+            buffer.write(bytes)
+            processBuffer()
+        }
+    }
+
+    private fun processBuffer() {
+        var data = buffer.toByteArray()
+        var offset = 0
+        while (data.size - offset >= 4) {
+            val length = (data[offset].toInt() and 0xFF) or
+                         ((data[offset + 1].toInt() and 0xFF) shl 8) or
+                         ((data[offset + 2].toInt() and 0xFF) shl 16)
+            
+            if (data.size - offset < 4 + length) {
+                break // Need more data for a full packet
+            }
+            
+            val payload = ByteArray(length)
+            System.arraycopy(data, offset + 4, payload, 0, length)
+            
+            if (payload.isNotEmpty()) {
+                val status = payload[0].toInt() and 0xFF
+                // STMT_PREPARE_OK starts with 0x00 status and is 12 bytes long
+                if (status == 0x00 && payload.size >= 9) {
+                    try {
+                        val stmtId = (payload[1].toInt() and 0xFF) or
+                                     ((payload[2].toInt() and 0xFF) shl 8) or
+                                     ((payload[3].toInt() and 0xFF) shl 16) or
+                                     ((payload[4].toInt() and 0xFF) shl 24)
+                        onPrepareOk(stmtId)
                     } catch (e: Exception) {
                         e.printStackTrace()
                     }
@@ -109,7 +229,7 @@ class MySqlClientPacketParser(private val onQuery: (String) -> Unit) {
     }
 }
 
-fun readFromAnyStream(input: InputStream, onInputAvailable: (input: ByteArray) -> Unit) {
+fun readFromAnyStream(input: InputStream, onInputAvailable: (input: ByteArray) -> Unit): Boolean {
     val singleByte = ByteArray(1)
     val bytesRead: Int = try {
         input.read(singleByte, 0, 1)
@@ -117,11 +237,24 @@ fun readFromAnyStream(input: InputStream, onInputAvailable: (input: ByteArray) -
         0
     }
 
+    if (bytesRead < 0) {
+        return false // Connection reached EOF / was closed
+    }
+
     if (bytesRead > 0) {
         val buff = ByteArray(8192)
-        val read = input.read(buff)
-        onInputAvailable(singleByte + buff.copyOfRange(0, read))
+        val read: Int = try {
+            input.read(buff)
+        } catch (e: SocketTimeoutException) {
+            0
+        }
+        if (read > 0) {
+            onInputAvailable(singleByte + buff.copyOfRange(0, read))
+        } else {
+            onInputAvailable(singleByte)
+        }
     }
+    return true
 }
 
 fun OutputStream.writeAndFlush(b: ByteArray) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -7,11 +7,10 @@ import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
-import java.net.SocketTimeoutException
 
 class MySqlConnection(
-    clientSocket: Socket,
-    targetSocket: Socket,
+    private val clientSocket: Socket,
+    private val targetSocket: Socket,
     private val eventService: EventService,
     private val executionRequest: ExecutionRequest,
     private val userId: String,
@@ -20,8 +19,8 @@ class MySqlConnection(
     private var clientOutput: OutputStream = clientSocket.getOutputStream()
     private var serverInput: InputStream = targetSocket.getInputStream()
     private var serverOutput: OutputStream = targetSocket.getOutputStream()
-    private var terminationMessageReceived: Boolean = false
-    private var serverTerminating: Boolean = false
+    @Volatile private var terminationMessageReceived: Boolean = false
+    @Volatile private var serverTerminating: Boolean = false
 
     @Volatile
     private var awaitingPrepareResponse = false
@@ -69,22 +68,47 @@ class MySqlConnection(
     }
 
     fun close() {
-        this.serverTerminating = true
+        serverTerminating = true
+        // Close both sockets to unblock any pending reads in the forwarding threads
+        try { clientSocket.close() } catch (_: Exception) {}
+        try { targetSocket.close() } catch (_: Exception) {}
     }
 
     fun startHandling() {
-        try {
-            while (!terminationMessageReceived && !serverTerminating) {
-                val clientOk = readFromAnyStream(clientInput) { handleClientData(it) }
-                if (!clientOk) break
-                val serverOk = readFromAnyStream(serverInput) { handleServerData(it) }
-                if (!serverOk) break
+        val clientToServer = Thread {
+            try {
+                val buf = ByteArray(8192)
+                while (!terminationMessageReceived && !serverTerminating) {
+                    val n = try { clientInput.read(buf) } catch (_: Exception) { -1 }
+                    if (n < 0) break
+                    if (n > 0) handleClientData(buf.copyOfRange(0, n))
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            } finally {
+                close()
             }
-        } catch (e: Exception) {
-            e.printStackTrace()
-        } finally {
-            close()
         }
+        val serverToClient = Thread {
+            try {
+                val buf = ByteArray(8192)
+                while (!serverTerminating) {
+                    val n = try { serverInput.read(buf) } catch (_: Exception) { -1 }
+                    if (n < 0) break
+                    if (n > 0) handleServerData(buf.copyOfRange(0, n))
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            } finally {
+                close()
+            }
+        }
+        clientToServer.isDaemon = true
+        serverToClient.isDaemon = true
+        clientToServer.start()
+        serverToClient.start()
+        clientToServer.join()
+        serverToClient.join()
     }
 
     private fun handleClientData(clientBuffer: ByteArray) {
@@ -227,34 +251,6 @@ class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit) {
             buffer.write(data, offset, data.size - offset)
         }
     }
-}
-
-fun readFromAnyStream(input: InputStream, onInputAvailable: (input: ByteArray) -> Unit): Boolean {
-    val singleByte = ByteArray(1)
-    val bytesRead: Int = try {
-        input.read(singleByte, 0, 1)
-    } catch (e: SocketTimeoutException) {
-        0
-    }
-
-    if (bytesRead < 0) {
-        return false // Connection reached EOF / was closed
-    }
-
-    if (bytesRead > 0) {
-        val buff = ByteArray(8192)
-        val read: Int = try {
-            input.read(buff)
-        } catch (e: SocketTimeoutException) {
-            0
-        }
-        if (read > 0) {
-            onInputAvailable(singleByte + buff.copyOfRange(0, read))
-        } else {
-            onInputAvailable(singleByte)
-        }
-    }
-    return true
 }
 
 fun OutputStream.writeAndFlush(b: ByteArray) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -43,20 +43,34 @@ class MySqlConnection(
                 auditQuery(query)
             }
         },
+        onClose = { stmtId ->
+            // Release the stored query when the client closes the prepared statement
+            preparedQueries.remove(stmtId)
+        },
         onQuit = {
             terminationMessageReceived = true
         }
     )
 
-    private val serverParser = MySqlServerPacketParser { stmtId ->
-        synchronized(this) {
-            if (awaitingPrepareResponse) {
-                lastPreparedQuery?.let { preparedQueries[stmtId] = it }
+    private val serverParser = MySqlServerPacketParser(
+        onPrepareOk = { stmtId ->
+            synchronized(this) {
+                if (awaitingPrepareResponse) {
+                    lastPreparedQuery?.let { preparedQueries[stmtId] = it }
+                    awaitingPrepareResponse = false
+                    lastPreparedQuery = null
+                }
+            }
+        },
+        onPrepareErr = {
+            // The server rejected the COM_STMT_PREPARE; drop the pending state so the
+            // next unrelated OK packet is not mistaken for this prepare's response.
+            synchronized(this) {
                 awaitingPrepareResponse = false
                 lastPreparedQuery = null
             }
-        }
-    }
+        },
+    )
 
     private fun auditQuery(query: String) {
         try {
@@ -132,6 +146,7 @@ class MySqlClientPacketParser(
     private val onQuery: (String) -> Unit,
     private val onPrepare: (String) -> Unit,
     private val onExecute: (Int) -> Unit,
+    private val onClose: (Int) -> Unit = {},
     private val onQuit: () -> Unit
 ) {
     private val buffer = ByteArrayOutputStream()
@@ -186,6 +201,15 @@ class MySqlClientPacketParser(
                                 onExecute(stmtId)
                             }
                         }
+                        0x19 -> { // COM_STMT_CLOSE
+                            if (payload.size >= 5) {
+                                val stmtId = (payload[1].toInt() and 0xFF) or
+                                             ((payload[2].toInt() and 0xFF) shl 8) or
+                                             ((payload[3].toInt() and 0xFF) shl 16) or
+                                             ((payload[4].toInt() and 0xFF) shl 24)
+                                onClose(stmtId)
+                            }
+                        }
                     }
                 } catch (e: Exception) {
                     e.printStackTrace()
@@ -202,7 +226,10 @@ class MySqlClientPacketParser(
     }
 }
 
-class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit) {
+class MySqlServerPacketParser(
+    private val onPrepareOk: (Int) -> Unit,
+    private val onPrepareErr: () -> Unit = {},
+) {
     private val buffer = ByteArrayOutputStream()
 
     fun addBytes(bytes: ByteArray) {
@@ -229,8 +256,13 @@ class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit) {
             
             if (payload.isNotEmpty()) {
                 val status = payload[0].toInt() and 0xFF
-                // STMT_PREPARE_OK starts with 0x00 status and is 12 bytes long
-                if (status == 0x00 && payload.size >= 9) {
+                // COM_STMT_PREPARE_OK has a fixed 12-byte payload (0x00 status + 4 stmt_id
+                // + 2 columns + 2 params + 1 reserved + 2 warnings). Requiring the exact
+                // length avoids mistaking a generic OK packet (also 0x00) for a prepare-ok.
+                // ERR packets (0xFF) clear any pending prepare so a later OK is not misread.
+                if (status == 0xFF) {
+                    onPrepareErr()
+                } else if (status == 0x00 && payload.size == 12) {
                     try {
                         val stmtId = (payload[1].toInt() and 0xFF) or
                                      ((payload[2].toInt() and 0xFF) shl 8) or

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -3,10 +3,13 @@ package dev.kviklet.kviklet.proxy.mysql
 import dev.kviklet.kviklet.db.ExecutePayload
 import dev.kviklet.kviklet.service.EventService
 import dev.kviklet.kviklet.service.dto.ExecutionRequest
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
+
+private val logger = LoggerFactory.getLogger("MySqlConnection")
 
 class MySqlConnection(
     private val clientSocket: Socket,
@@ -79,7 +82,7 @@ class MySqlConnection(
             val executePayload = ExecutePayload(query = query)
             eventService.saveEvent(executionRequest.id!!, userId, executePayload)
         } catch (e: Exception) {
-            e.printStackTrace()
+            logger.error("Failed to audit query", e)
         }
     }
 
@@ -108,7 +111,7 @@ class MySqlConnection(
                     if (n > 0) handleClientData(buf.copyOfRange(0, n))
                 }
             } catch (e: Exception) {
-                e.printStackTrace()
+                logger.error("Error forwarding client-to-server traffic", e)
             } finally {
                 close()
             }
@@ -126,7 +129,7 @@ class MySqlConnection(
                     if (n > 0) handleServerData(buf.copyOfRange(0, n))
                 }
             } catch (e: Exception) {
-                e.printStackTrace()
+                logger.error("Error forwarding server-to-client traffic", e)
             } finally {
                 close()
             }
@@ -230,7 +233,7 @@ class MySqlClientPacketParser(
                         }
                     }
                 } catch (e: Exception) {
-                    e.printStackTrace()
+                    logger.error("Error parsing client packet", e)
                 }
             }
 
@@ -285,7 +288,7 @@ class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit, private va
                             ((payload[4].toInt() and 0xFF) shl 24)
                         onPrepareOk(stmtId)
                     } catch (e: Exception) {
-                        e.printStackTrace()
+                        logger.error("Error parsing server prepare-ok packet", e)
                     }
                 }
             }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -19,7 +19,9 @@ class MySqlConnection(
     private var clientOutput: OutputStream = clientSocket.getOutputStream()
     private var serverInput: InputStream = targetSocket.getInputStream()
     private var serverOutput: OutputStream = targetSocket.getOutputStream()
+
     @Volatile private var terminationMessageReceived: Boolean = false
+
     @Volatile private var serverTerminating: Boolean = false
 
     @Volatile
@@ -49,7 +51,7 @@ class MySqlConnection(
         },
         onQuit = {
             terminationMessageReceived = true
-        }
+        },
     )
 
     private val serverParser = MySqlServerPacketParser(
@@ -84,8 +86,12 @@ class MySqlConnection(
     fun close() {
         serverTerminating = true
         // Close both sockets to unblock any pending reads in the forwarding threads
-        try { clientSocket.close() } catch (_: Exception) {}
-        try { targetSocket.close() } catch (_: Exception) {}
+        try {
+            clientSocket.close()
+        } catch (_: Exception) {}
+        try {
+            targetSocket.close()
+        } catch (_: Exception) {}
     }
 
     fun startHandling() {
@@ -93,7 +99,11 @@ class MySqlConnection(
             try {
                 val buf = ByteArray(8192)
                 while (!terminationMessageReceived && !serverTerminating) {
-                    val n = try { clientInput.read(buf) } catch (_: Exception) { -1 }
+                    val n = try {
+                        clientInput.read(buf)
+                    } catch (_: Exception) {
+                        -1
+                    }
                     if (n < 0) break
                     if (n > 0) handleClientData(buf.copyOfRange(0, n))
                 }
@@ -107,7 +117,11 @@ class MySqlConnection(
             try {
                 val buf = ByteArray(8192)
                 while (!serverTerminating) {
-                    val n = try { serverInput.read(buf) } catch (_: Exception) { -1 }
+                    val n = try {
+                        serverInput.read(buf)
+                    } catch (_: Exception) {
+                        -1
+                    }
                     if (n < 0) break
                     if (n > 0) handleServerData(buf.copyOfRange(0, n))
                 }
@@ -128,7 +142,7 @@ class MySqlConnection(
     private fun handleClientData(clientBuffer: ByteArray) {
         // Feed raw bytes to client parser for query/prepare/execute/quit auditing
         clientParser.addBytes(clientBuffer)
-        
+
         // Forward raw bytes to the server
         serverOutput.writeAndFlush(clientBuffer)
     }
@@ -136,7 +150,7 @@ class MySqlConnection(
     private fun handleServerData(serverBuffer: ByteArray) {
         // Feed raw bytes to server parser to match generated statement IDs
         serverParser.addBytes(serverBuffer)
-        
+
         // Forward raw bytes to the client
         clientOutput.writeAndFlush(serverBuffer)
     }
@@ -147,7 +161,7 @@ class MySqlClientPacketParser(
     private val onPrepare: (String) -> Unit,
     private val onExecute: (Int) -> Unit,
     private val onClose: (Int) -> Unit = {},
-    private val onQuit: () -> Unit
+    private val onQuit: () -> Unit,
 ) {
     private val buffer = ByteArrayOutputStream()
 
@@ -163,16 +177,16 @@ class MySqlClientPacketParser(
         var offset = 0
         while (data.size - offset >= 4) {
             val length = (data[offset].toInt() and 0xFF) or
-                         ((data[offset + 1].toInt() and 0xFF) shl 8) or
-                         ((data[offset + 2].toInt() and 0xFF) shl 16)
-            
+                ((data[offset + 1].toInt() and 0xFF) shl 8) or
+                ((data[offset + 2].toInt() and 0xFF) shl 16)
+
             if (data.size - offset < 4 + length) {
                 break // Need more data for a full packet
             }
-            
+
             val payload = ByteArray(length)
             System.arraycopy(data, offset + 4, payload, 0, length)
-            
+
             if (payload.isNotEmpty()) {
                 val cmd = payload[0].toInt() and 0xFF
                 try {
@@ -180,33 +194,37 @@ class MySqlClientPacketParser(
                         0x01 -> { // COM_QUIT
                             onQuit()
                         }
+
                         0x03 -> { // COM_QUERY
                             val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
                             if (query.trim().isNotEmpty()) {
                                 onQuery(query)
                             }
                         }
+
                         0x16 -> { // COM_STMT_PREPARE
                             val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
                             if (query.trim().isNotEmpty()) {
                                 onPrepare(query)
                             }
                         }
+
                         0x17 -> { // COM_STMT_EXECUTE
                             if (payload.size >= 5) {
                                 val stmtId = (payload[1].toInt() and 0xFF) or
-                                             ((payload[2].toInt() and 0xFF) shl 8) or
-                                             ((payload[3].toInt() and 0xFF) shl 16) or
-                                             ((payload[4].toInt() and 0xFF) shl 24)
+                                    ((payload[2].toInt() and 0xFF) shl 8) or
+                                    ((payload[3].toInt() and 0xFF) shl 16) or
+                                    ((payload[4].toInt() and 0xFF) shl 24)
                                 onExecute(stmtId)
                             }
                         }
+
                         0x19 -> { // COM_STMT_CLOSE
                             if (payload.size >= 5) {
                                 val stmtId = (payload[1].toInt() and 0xFF) or
-                                             ((payload[2].toInt() and 0xFF) shl 8) or
-                                             ((payload[3].toInt() and 0xFF) shl 16) or
-                                             ((payload[4].toInt() and 0xFF) shl 24)
+                                    ((payload[2].toInt() and 0xFF) shl 8) or
+                                    ((payload[3].toInt() and 0xFF) shl 16) or
+                                    ((payload[4].toInt() and 0xFF) shl 24)
                                 onClose(stmtId)
                             }
                         }
@@ -215,10 +233,10 @@ class MySqlClientPacketParser(
                     e.printStackTrace()
                 }
             }
-            
+
             offset += 4 + length
         }
-        
+
         buffer.reset()
         if (data.size > offset) {
             buffer.write(data, offset, data.size - offset)
@@ -226,10 +244,7 @@ class MySqlClientPacketParser(
     }
 }
 
-class MySqlServerPacketParser(
-    private val onPrepareOk: (Int) -> Unit,
-    private val onPrepareErr: () -> Unit = {},
-) {
+class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit, private val onPrepareErr: () -> Unit = {}) {
     private val buffer = ByteArrayOutputStream()
 
     fun addBytes(bytes: ByteArray) {
@@ -244,16 +259,16 @@ class MySqlServerPacketParser(
         var offset = 0
         while (data.size - offset >= 4) {
             val length = (data[offset].toInt() and 0xFF) or
-                         ((data[offset + 1].toInt() and 0xFF) shl 8) or
-                         ((data[offset + 2].toInt() and 0xFF) shl 16)
-            
+                ((data[offset + 1].toInt() and 0xFF) shl 8) or
+                ((data[offset + 2].toInt() and 0xFF) shl 16)
+
             if (data.size - offset < 4 + length) {
                 break // Need more data for a full packet
             }
-            
+
             val payload = ByteArray(length)
             System.arraycopy(data, offset + 4, payload, 0, length)
-            
+
             if (payload.isNotEmpty()) {
                 val status = payload[0].toInt() and 0xFF
                 // COM_STMT_PREPARE_OK has a fixed 12-byte payload (0x00 status + 4 stmt_id
@@ -265,19 +280,19 @@ class MySqlServerPacketParser(
                 } else if (status == 0x00 && payload.size == 12) {
                     try {
                         val stmtId = (payload[1].toInt() and 0xFF) or
-                                     ((payload[2].toInt() and 0xFF) shl 8) or
-                                     ((payload[3].toInt() and 0xFF) shl 16) or
-                                     ((payload[4].toInt() and 0xFF) shl 24)
+                            ((payload[2].toInt() and 0xFF) shl 8) or
+                            ((payload[3].toInt() and 0xFF) shl 16) or
+                            ((payload[4].toInt() and 0xFF) shl 24)
                         onPrepareOk(stmtId)
                     } catch (e: Exception) {
                         e.printStackTrace()
                     }
                 }
             }
-            
+
             offset += 4 + length
         }
-        
+
         buffer.reset()
         if (data.size > offset) {
             buffer.write(data, offset, data.size - offset)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -1,0 +1,130 @@
+package dev.kviklet.kviklet.proxy.mysql
+
+import dev.kviklet.kviklet.db.ExecutePayload
+import dev.kviklet.kviklet.service.EventService
+import dev.kviklet.kviklet.service.dto.ExecutionRequest
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.Socket
+import java.net.SocketTimeoutException
+
+class MySqlConnection(
+    clientSocket: Socket,
+    targetSocket: Socket,
+    private val eventService: EventService,
+    private val executionRequest: ExecutionRequest,
+    private val userId: String,
+) {
+    private var clientInput: InputStream = clientSocket.getInputStream()
+    private var clientOutput: OutputStream = clientSocket.getOutputStream()
+    private var serverInput: InputStream = targetSocket.getInputStream()
+    private var serverOutput: OutputStream = targetSocket.getOutputStream()
+    private var terminationMessageReceived: Boolean = false
+    private var serverTerminating: Boolean = false
+
+    private val parser = MySqlClientPacketParser { query ->
+        try {
+            val executePayload = ExecutePayload(query = query)
+            eventService.saveEvent(executionRequest.id!!, userId, executePayload)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    fun close() {
+        this.serverTerminating = true
+    }
+
+    fun startHandling() {
+        while (!terminationMessageReceived && !serverTerminating) {
+            readFromAnyStream(clientInput) { handleClientData(it) }
+            readFromAnyStream(serverInput) { clientOutput.writeAndFlush(it) }
+        }
+    }
+
+    private fun handleClientData(clientBuffer: ByteArray) {
+        // Feed raw bytes to parser for query auditing
+        parser.addBytes(clientBuffer)
+        
+        // Check for COM_QUIT (sequence id doesn't matter, first payload byte of packet can be 0x01)
+        if (clientBuffer.size >= 5) {
+            val cmd = clientBuffer[4].toInt() and 0xFF
+            if (cmd == 0x01) { // COM_QUIT
+                terminationMessageReceived = true
+            }
+        }
+        
+        // Forward raw bytes to the server
+        serverOutput.writeAndFlush(clientBuffer)
+    }
+}
+
+class MySqlClientPacketParser(private val onQuery: (String) -> Unit) {
+    private val buffer = ByteArrayOutputStream()
+
+    fun addBytes(bytes: ByteArray) {
+        synchronized(this) {
+            buffer.write(bytes)
+            processBuffer()
+        }
+    }
+
+    private fun processBuffer() {
+        var data = buffer.toByteArray()
+        var offset = 0
+        while (data.size - offset >= 4) {
+            val length = (data[offset].toInt() and 0xFF) or
+                         ((data[offset + 1].toInt() and 0xFF) shl 8) or
+                         ((data[offset + 2].toInt() and 0xFF) shl 16)
+            
+            if (data.size - offset < 4 + length) {
+                break // Need more data for a full packet
+            }
+            
+            val payload = ByteArray(length)
+            System.arraycopy(data, offset + 4, payload, 0, length)
+            
+            if (payload.isNotEmpty()) {
+                val cmd = payload[0].toInt() and 0xFF
+                if (cmd == 0x03 || cmd == 0x16) { // COM_QUERY or COM_STMT_PREPARE
+                    try {
+                        val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
+                        if (query.trim().isNotEmpty()) {
+                            onQuery(query)
+                        }
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                    }
+                }
+            }
+            
+            offset += 4 + length
+        }
+        
+        buffer.reset()
+        if (data.size > offset) {
+            buffer.write(data, offset, data.size - offset)
+        }
+    }
+}
+
+fun readFromAnyStream(input: InputStream, onInputAvailable: (input: ByteArray) -> Unit) {
+    val singleByte = ByteArray(1)
+    val bytesRead: Int = try {
+        input.read(singleByte, 0, 1)
+    } catch (e: SocketTimeoutException) {
+        0
+    }
+
+    if (bytesRead > 0) {
+        val buff = ByteArray(8192)
+        val read = input.read(buff)
+        onInputAvailable(singleByte + buff.copyOfRange(0, read))
+    }
+}
+
+fun OutputStream.writeAndFlush(b: ByteArray) {
+    this.write(b)
+    this.flush()
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProxy.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProxy.kt
@@ -8,6 +8,7 @@ import dev.kviklet.kviklet.service.EventService
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
 import dev.kviklet.kviklet.service.dto.DatasourceType
 import dev.kviklet.kviklet.service.dto.ExecutionRequest
+import org.slf4j.LoggerFactory
 import java.net.ServerSocket
 import java.net.Socket
 import java.time.LocalDateTime
@@ -16,6 +17,8 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.schedule
+
+private val logger = LoggerFactory.getLogger("MySqlProxy")
 
 class MySqlProxy(
     datasourceType: DatasourceType,
@@ -101,7 +104,7 @@ class MySqlProxy(
                 currentConnections.incrementAndGet()
                 handleClient(clientSocket)
             } catch (e: Exception) {
-                e.printStackTrace()
+                logger.error("Error handling client connection", e)
             } finally {
                 // Guard for the case where handleClient threw before MySqlConnection took ownership
                 if (!clientSocket.isClosed) clientSocket.close()

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProxy.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProxy.kt
@@ -37,6 +37,7 @@ class MySqlProxy(
     private val currentConnections = AtomicInteger(0)
     private var targetMySql: TargetMySqlSocketFactory =
         TargetMySqlSocketFactory(datasourceType, authenticationDetails, databaseName, targetHost, targetPort)
+
     @Volatile var isRunning: Boolean = false
         private set
 
@@ -119,7 +120,8 @@ class MySqlProxy(
                 this.proxyUsername,
                 this.proxyPassword,
             )
-            val clientConnection = MySqlConnection(configuredSocket, forwardSocket, eventService, executionRequest, userId)
+            val clientConnection =
+                MySqlConnection(configuredSocket, forwardSocket, eventService, executionRequest, userId)
             clientConnections.add(clientConnection)
             try {
                 clientConnection.startHandling()

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProxy.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProxy.kt
@@ -1,0 +1,124 @@
+package dev.kviklet.kviklet.proxy.mysql
+
+import dev.kviklet.kviklet.proxy.postgres.INFINITE_ACCESS
+import dev.kviklet.kviklet.proxy.postgres.TLSCertificate
+import dev.kviklet.kviklet.proxy.postgres.getShutdownDate
+import dev.kviklet.kviklet.proxy.postgres.tlsCertificateFactory
+import dev.kviklet.kviklet.service.EventService
+import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.ExecutionRequest
+import java.net.ServerSocket
+import java.net.Socket
+import java.time.LocalDateTime
+import java.util.*
+import java.util.concurrent.Executors
+import kotlin.concurrent.schedule
+
+class MySqlProxy(
+    targetHost: String,
+    targetPort: Int,
+    databaseName: String,
+    authenticationDetails: AuthenticationDetails.UserPassword,
+    private val eventService: EventService,
+    private val executionRequest: ExecutionRequest,
+    private val userId: String,
+    private val tlsCertificate: TLSCertificate? = tlsCertificateFactory(),
+) {
+    private val threadPool = Executors.newCachedThreadPool()
+    private val clientConnections: ArrayList<MySqlConnection> = arrayListOf()
+    private lateinit var serverSocket: ServerSocket
+    private var proxyUsername = "mysql"
+    private var proxyPassword = "mysql"
+    private val maxConnections = 15
+    private var currentConnections = 0
+    private var targetMySql: TargetMySqlSocketFactory =
+        TargetMySqlSocketFactory(authenticationDetails, databaseName, targetHost, targetPort)
+    var isRunning: Boolean = false
+        private set
+
+    fun startServer(
+        port: Int,
+        proxyUsername: String,
+        proxyPassword: String,
+        startTime: LocalDateTime,
+        maxTimeMinutes: Long,
+    ) {
+        this.proxyUsername = proxyUsername
+        this.proxyPassword = proxyPassword
+        Thread { this.startTcpListener(port) }.start()
+        if (maxTimeMinutes != INFINITE_ACCESS) {
+            scheduleShutdown(
+                getShutdownDate(startTime, maxTimeMinutes),
+            )
+        }
+    }
+
+    private fun scheduleShutdown(shutdownTime: Date) {
+        Timer().schedule(shutdownTime) {
+            shutdownServer()
+        }
+    }
+
+    fun shutdownServer() {
+        this.isRunning = false
+        this.clientConnections.forEach { it.close() }
+        this.threadPool.shutdownNow()
+        this.serverSocket.close()
+    }
+
+    private fun acceptClientConnection(): Socket? = try {
+        serverSocket.accept()
+    } catch (e: Exception) {
+        null
+    }
+
+    private fun startTcpListener(port: Int) {
+        this.serverSocket = ServerSocket(port)
+        this.isRunning = true
+        startListeningLoop()
+    }
+
+    private fun startListeningLoop() {
+        while (this.isRunning) {
+            if (currentConnections >= maxConnections) {
+                Thread.sleep(1000)
+                continue
+            }
+
+            val clientSocket = acceptClientConnection() ?: continue
+            handleClientConnection(clientSocket)
+        }
+    }
+
+    private fun handleClientConnection(clientSocket: Socket) {
+        threadPool.submit {
+            try {
+                currentConnections++
+                handleClient(clientSocket)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            } finally {
+                if (!clientSocket.isClosed) {
+                    clientSocket.close()
+                }
+                currentConnections--
+            }
+        }
+    }
+
+    private fun handleClient(clientSocket: Socket) {
+        val remoteMySqlConn = targetMySql.createTargetMySqlConnection()
+        val configuredSocket = setupClientMySql(
+            clientSocket,
+            this.tlsCertificate,
+            this.proxyUsername,
+            this.proxyPassword,
+        )
+        val forwardSocket = remoteMySqlConn.socket
+        configuredSocket.soTimeout = 10
+        forwardSocket.soTimeout = 10
+        val clientConnection = MySqlConnection(configuredSocket, forwardSocket, eventService, executionRequest, userId)
+        this.clientConnections.add(clientConnection)
+        clientConnection.startHandling()
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProxy.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProxy.kt
@@ -6,6 +6,7 @@ import dev.kviklet.kviklet.proxy.postgres.getShutdownDate
 import dev.kviklet.kviklet.proxy.postgres.tlsCertificateFactory
 import dev.kviklet.kviklet.service.EventService
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.DatasourceType
 import dev.kviklet.kviklet.service.dto.ExecutionRequest
 import java.net.ServerSocket
 import java.net.Socket
@@ -15,6 +16,7 @@ import java.util.concurrent.Executors
 import kotlin.concurrent.schedule
 
 class MySqlProxy(
+    datasourceType: DatasourceType,
     targetHost: String,
     targetPort: Int,
     databaseName: String,
@@ -32,7 +34,7 @@ class MySqlProxy(
     private val maxConnections = 15
     private var currentConnections = 0
     private var targetMySql: TargetMySqlSocketFactory =
-        TargetMySqlSocketFactory(authenticationDetails, databaseName, targetHost, targetPort)
+        TargetMySqlSocketFactory(datasourceType, authenticationDetails, databaseName, targetHost, targetPort)
     var isRunning: Boolean = false
         private set
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProxy.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProxy.kt
@@ -12,7 +12,9 @@ import java.net.ServerSocket
 import java.net.Socket
 import java.time.LocalDateTime
 import java.util.*
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.schedule
 
 class MySqlProxy(
@@ -27,15 +29,15 @@ class MySqlProxy(
     private val tlsCertificate: TLSCertificate? = tlsCertificateFactory(),
 ) {
     private val threadPool = Executors.newCachedThreadPool()
-    private val clientConnections: ArrayList<MySqlConnection> = arrayListOf()
+    private val clientConnections: CopyOnWriteArrayList<MySqlConnection> = CopyOnWriteArrayList()
     private lateinit var serverSocket: ServerSocket
     private var proxyUsername = "mysql"
     private var proxyPassword = "mysql"
     private val maxConnections = 15
-    private var currentConnections = 0
+    private val currentConnections = AtomicInteger(0)
     private var targetMySql: TargetMySqlSocketFactory =
         TargetMySqlSocketFactory(datasourceType, authenticationDetails, databaseName, targetHost, targetPort)
-    var isRunning: Boolean = false
+    @Volatile var isRunning: Boolean = false
         private set
 
     fun startServer(
@@ -82,8 +84,8 @@ class MySqlProxy(
 
     private fun startListeningLoop() {
         while (this.isRunning) {
-            if (currentConnections >= maxConnections) {
-                Thread.sleep(1000)
+            if (currentConnections.get() >= maxConnections) {
+                Thread.sleep(100)
                 continue
             }
 
@@ -95,32 +97,38 @@ class MySqlProxy(
     private fun handleClientConnection(clientSocket: Socket) {
         threadPool.submit {
             try {
-                currentConnections++
+                currentConnections.incrementAndGet()
                 handleClient(clientSocket)
             } catch (e: Exception) {
                 e.printStackTrace()
             } finally {
-                if (!clientSocket.isClosed) {
-                    clientSocket.close()
-                }
-                currentConnections--
+                // Guard for the case where handleClient threw before MySqlConnection took ownership
+                if (!clientSocket.isClosed) clientSocket.close()
+                currentConnections.decrementAndGet()
             }
         }
     }
 
     private fun handleClient(clientSocket: Socket) {
         val remoteMySqlConn = targetMySql.createTargetMySqlConnection()
-        val configuredSocket = setupClientMySql(
-            clientSocket,
-            this.tlsCertificate,
-            this.proxyUsername,
-            this.proxyPassword,
-        )
         val forwardSocket = remoteMySqlConn.socket
-        configuredSocket.soTimeout = 10
-        forwardSocket.soTimeout = 10
-        val clientConnection = MySqlConnection(configuredSocket, forwardSocket, eventService, executionRequest, userId)
-        this.clientConnections.add(clientConnection)
-        clientConnection.startHandling()
+        try {
+            val configuredSocket = setupClientMySql(
+                clientSocket,
+                this.tlsCertificate,
+                this.proxyUsername,
+                this.proxyPassword,
+            )
+            val clientConnection = MySqlConnection(configuredSocket, forwardSocket, eventService, executionRequest, userId)
+            clientConnections.add(clientConnection)
+            try {
+                clientConnection.startHandling()
+            } finally {
+                clientConnections.remove(clientConnection)
+            }
+        } catch (e: Exception) {
+            if (!forwardSocket.isClosed) forwardSocket.close()
+            throw e
+        }
     }
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
@@ -1,0 +1,49 @@
+package dev.kviklet.kviklet.proxy.mysql
+
+import com.mysql.cj.jdbc.ConnectionImpl
+import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import java.net.Socket
+import java.sql.DriverManager
+import java.util.*
+
+class TargetMySqlConnection(val socket: Socket)
+
+class TargetMySqlSocketFactory(
+    private val authenticationDetails: AuthenticationDetails.UserPassword,
+    private val databaseName: String,
+    private val targetHost: String,
+    private val targetPort: Int,
+) {
+    fun createTargetMySqlConnection(): TargetMySqlConnection {
+        val props = Properties()
+        props.setProperty("user", authenticationDetails.username)
+        props.setProperty("password", authenticationDetails.password)
+        
+        val dbName = if (databaseName.isNotEmpty()) databaseName else ""
+        val url = "jdbc:mysql://$targetHost:$targetPort/$dbName"
+        
+        Class.forName("com.mysql.cj.jdbc.Driver")
+        
+        val conn = DriverManager.getConnection(url, props) as ConnectionImpl
+        
+        try {
+            val sessionField = ConnectionImpl::class.java.getDeclaredField("session")
+            sessionField.isAccessible = true
+            val session = sessionField.get(conn)
+            
+            val getProtocolMethod = session.javaClass.getMethod("getProtocol")
+            val protocol = getProtocolMethod.invoke(session)
+            
+            val getSocketConnectionMethod = protocol.javaClass.getMethod("getSocketConnection")
+            val socketConnection = getSocketConnectionMethod.invoke(protocol)
+            
+            val getMysqlSocketMethod = socketConnection.javaClass.getMethod("getMysqlSocket")
+            val mysqlSocket = getMysqlSocketMethod.invoke(socketConnection) as Socket
+            
+            return TargetMySqlConnection(mysqlSocket)
+        } catch (e: Exception) {
+            conn.close()
+            throw e
+        }
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
@@ -2,6 +2,7 @@ package dev.kviklet.kviklet.proxy.mysql
 
 import com.mysql.cj.jdbc.ConnectionImpl
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.DatasourceType
 import java.net.Socket
 import java.sql.DriverManager
 import java.util.*
@@ -9,6 +10,7 @@ import java.util.*
 class TargetMySqlConnection(val socket: Socket)
 
 class TargetMySqlSocketFactory(
+    private val datasourceType: DatasourceType,
     private val authenticationDetails: AuthenticationDetails.UserPassword,
     private val databaseName: String,
     private val targetHost: String,
@@ -20,30 +22,57 @@ class TargetMySqlSocketFactory(
         props.setProperty("password", authenticationDetails.password)
         
         val dbName = if (databaseName.isNotEmpty()) databaseName else ""
-        val url = "jdbc:mysql://$targetHost:$targetPort/$dbName"
         
-        Class.forName("com.mysql.cj.jdbc.Driver")
-        
-        val conn = DriverManager.getConnection(url, props) as ConnectionImpl
-        
-        try {
-            val sessionField = ConnectionImpl::class.java.getDeclaredField("session")
-            sessionField.isAccessible = true
-            val session = sessionField.get(conn)
-            
-            val getProtocolMethod = session.javaClass.getMethod("getProtocol")
-            val protocol = getProtocolMethod.invoke(session)
-            
-            val getSocketConnectionMethod = protocol.javaClass.getMethod("getSocketConnection")
-            val socketConnection = getSocketConnectionMethod.invoke(protocol)
-            
-            val getMysqlSocketMethod = socketConnection.javaClass.getMethod("getMysqlSocket")
-            val mysqlSocket = getMysqlSocketMethod.invoke(socketConnection) as Socket
-            
-            return TargetMySqlConnection(mysqlSocket)
-        } catch (e: Exception) {
-            conn.close()
-            throw e
+        if (datasourceType == DatasourceType.MARIADB) {
+            val url = "jdbc:mariadb://$targetHost:$targetPort/$dbName"
+            Class.forName("org.mariadb.jdbc.Driver")
+            val conn = DriverManager.getConnection(url, props)
+            try {
+                val socket = getMariaDbSocket(conn)
+                return TargetMySqlConnection(socket)
+            } catch (e: Exception) {
+                conn.close()
+                throw e
+            }
+        } else {
+            val url = "jdbc:mysql://$targetHost:$targetPort/$dbName"
+            Class.forName("com.mysql.cj.jdbc.Driver")
+            val conn = DriverManager.getConnection(url, props) as ConnectionImpl
+            try {
+                val sessionField = ConnectionImpl::class.java.getDeclaredField("session")
+                sessionField.isAccessible = true
+                val session = sessionField.get(conn)
+                
+                val getProtocolMethod = session.javaClass.getMethod("getProtocol")
+                val protocol = getProtocolMethod.invoke(session)
+                
+                val getSocketConnectionMethod = protocol.javaClass.getMethod("getSocketConnection")
+                val socketConnection = getSocketConnectionMethod.invoke(protocol)
+                
+                val getMysqlSocketMethod = socketConnection.javaClass.getMethod("getMysqlSocket")
+                val mysqlSocket = getMysqlSocketMethod.invoke(socketConnection) as Socket
+                
+                return TargetMySqlConnection(mysqlSocket)
+            } catch (e: Exception) {
+                conn.close()
+                throw e
+            }
         }
+    }
+
+    private fun getMariaDbSocket(conn: java.sql.Connection): Socket {
+        val getClientMethod = conn.javaClass.getMethod("getClient")
+        val client = getClientMethod.invoke(conn)
+        var currentClass: Class<*>? = client.javaClass
+        while (currentClass != null) {
+            try {
+                val socketField = currentClass.getDeclaredField("socket")
+                socketField.isAccessible = true
+                return socketField.get(client) as Socket
+            } catch (e: NoSuchFieldException) {
+                currentClass = currentClass.superclass
+            }
+        }
+        throw NoSuchFieldException("Could not find field 'socket' on MariaDB client class")
     }
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
@@ -61,8 +61,11 @@ class TargetMySqlSocketFactory(
             if (reply.isEmpty()) throw IOException("Empty response from MySQL server during authentication")
 
             when (reply[0].toInt() and 0xFF) {
-                0x00 -> return // OK — authenticated
+                0x00 -> return
+
+                // OK — authenticated
                 0xFF -> throw IOException("MySQL server rejected credentials: ${parseErrMessage(reply)}")
+
                 0xFE -> {
                     // AuthSwitchRequest: 0xFE + plugin name (null-terminated) + auth data
                     val (newPlugin, newNonce) = parseAuthSwitch(reply)
@@ -71,6 +74,7 @@ class TargetMySqlSocketFactory(
                     seq += 1
                     writePacket(output, seq.toByte(), computeAuthToken(plugin, authenticationDetails.password, nonce))
                 }
+
                 0x01 -> {
                     // AuthMoreData — currently only used by caching_sha2_password
                     if (plugin != "caching_sha2_password") {
@@ -78,6 +82,7 @@ class TargetMySqlSocketFactory(
                     }
                     when (reply.getOrNull(1)?.toInt()?.and(0xFF)) {
                         0x03 -> { /* fast_auth_success — server will send OK next */ }
+
                         0x04 -> {
                             // perform_full_authentication: over a plaintext socket we must
                             // request the server's RSA public key and send the encrypted password.
@@ -86,19 +91,27 @@ class TargetMySqlSocketFactory(
                             val (keySeq, keyReply) = readPacket(input)
                             seq = keySeq.toInt()
                             if (keyReply.isEmpty() || (keyReply[0].toInt() and 0xFF) != 0x01) {
-                                throw IOException("Expected RSA public key from server, got 0x${(keyReply.getOrNull(0)?.toInt()?.and(0xFF) ?: -1).toString(16)}")
+                                throw IOException(
+                                    "Expected RSA public key from server, got 0x${(
+                                        keyReply.getOrNull(
+                                            0,
+                                        )?.toInt()?.and(0xFF) ?: -1
+                                        ).toString(16)}",
+                                )
                             }
                             val pem = String(keyReply, 1, keyReply.size - 1, Charsets.US_ASCII)
                             val encrypted = encryptPasswordRsa(authenticationDetails.password, nonce, pem)
                             seq += 1
                             writePacket(output, seq.toByte(), encrypted)
                         }
+
                         else -> throw IOException(
                             "Unexpected caching_sha2_password more-data byte: " +
                                 "0x${(reply.getOrNull(1)?.toInt()?.and(0xFF) ?: -1).toString(16)}",
                         )
                     }
                 }
+
                 else -> throw IOException(
                     "Unexpected server response byte: 0x${(reply[0].toInt() and 0xFF).toString(16)}",
                 )

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
@@ -1,11 +1,10 @@
 package dev.kviklet.kviklet.proxy.mysql
 
-import com.mysql.cj.jdbc.ConnectionImpl
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
 import dev.kviklet.kviklet.service.dto.DatasourceType
+import java.io.ByteArrayOutputStream
+import java.io.IOException
 import java.net.Socket
-import java.sql.DriverManager
-import java.util.*
 
 class TargetMySqlConnection(val socket: Socket)
 
@@ -17,62 +16,108 @@ class TargetMySqlSocketFactory(
     private val targetPort: Int,
 ) {
     fun createTargetMySqlConnection(): TargetMySqlConnection {
-        val props = Properties()
-        props.setProperty("user", authenticationDetails.username)
-        props.setProperty("password", authenticationDetails.password)
-        
-        val dbName = if (databaseName.isNotEmpty()) databaseName else ""
-        
-        if (datasourceType == DatasourceType.MARIADB) {
-            val url = "jdbc:mariadb://$targetHost:$targetPort/$dbName"
-            Class.forName("org.mariadb.jdbc.Driver")
-            val conn = DriverManager.getConnection(url, props)
-            try {
-                val socket = getMariaDbSocket(conn)
-                return TargetMySqlConnection(socket)
-            } catch (e: Exception) {
-                conn.close()
-                throw e
-            }
-        } else {
-            val url = "jdbc:mysql://$targetHost:$targetPort/$dbName"
-            Class.forName("com.mysql.cj.jdbc.Driver")
-            val conn = DriverManager.getConnection(url, props) as ConnectionImpl
-            try {
-                val sessionField = ConnectionImpl::class.java.getDeclaredField("session")
-                sessionField.isAccessible = true
-                val session = sessionField.get(conn)
-                
-                val getProtocolMethod = session.javaClass.getMethod("getProtocol")
-                val protocol = getProtocolMethod.invoke(session)
-                
-                val getSocketConnectionMethod = protocol.javaClass.getMethod("getSocketConnection")
-                val socketConnection = getSocketConnectionMethod.invoke(protocol)
-                
-                val getMysqlSocketMethod = socketConnection.javaClass.getMethod("getMysqlSocket")
-                val mysqlSocket = getMysqlSocketMethod.invoke(socketConnection) as Socket
-                
-                return TargetMySqlConnection(mysqlSocket)
-            } catch (e: Exception) {
-                conn.close()
-                throw e
-            }
+        val socket = Socket(targetHost, targetPort)
+        try {
+            performHandshake(socket)
+            return TargetMySqlConnection(socket)
+        } catch (e: Exception) {
+            socket.close()
+            throw e
         }
     }
 
-    private fun getMariaDbSocket(conn: java.sql.Connection): Socket {
-        val getClientMethod = conn.javaClass.getMethod("getClient")
-        val client = getClientMethod.invoke(conn)
-        var currentClass: Class<*>? = client.javaClass
-        while (currentClass != null) {
-            try {
-                val socketField = currentClass.getDeclaredField("socket")
-                socketField.isAccessible = true
-                return socketField.get(client) as Socket
-            } catch (e: NoSuchFieldException) {
-                currentClass = currentClass.superclass
-            }
+    private fun performHandshake(socket: Socket) {
+        val input = socket.getInputStream()
+        val output = socket.getOutputStream()
+
+        // Read server Initial Handshake (Protocol Version 10)
+        val (seqId, handshake) = readPacket(input)
+        if (handshake.isEmpty() || handshake[0] != 10.toByte()) {
+            throw IOException("Unsupported MySQL protocol version (expected 10, got ${handshake.getOrNull(0)})")
         }
-        throw NoSuchFieldException("Could not find field 'socket' on MariaDB client class")
+
+        val salt = parseSalt(handshake)
+        val authToken = computeNativePasswordToken(authenticationDetails.password, salt)
+        val response = buildHandshakeResponse(authenticationDetails.username, authToken, databaseName)
+        writePacket(output, (seqId.toInt() + 1).toByte(), response)
+
+        val (_, reply) = readPacket(input)
+        if (reply.isEmpty()) throw IOException("Empty response from MySQL server during authentication")
+        when (reply[0].toInt() and 0xFF) {
+            0x00 -> return // OK
+            0xFF -> {
+                val msg = if (reply.size > 9) String(reply, 9, reply.size - 9, Charsets.UTF_8) else "unknown error"
+                throw IOException("MySQL server rejected credentials: $msg")
+            }
+            0xFE -> throw IOException("Auth-switch-request from the target server is not supported")
+            else -> throw IOException("Unexpected server response byte: 0x${(reply[0].toInt() and 0xFF).toString(16)}")
+        }
+    }
+
+    // MySQL Protocol v10 Initial Handshake packet layout:
+    //   1  protocol version
+    //   N+1  server version (null-terminated)
+    //   4  connection ID
+    //   8  auth-plugin-data-part-1
+    //   1  filler
+    //   2  capability flags lower
+    //   1  charset
+    //   2  status flags
+    //   2  capability flags upper
+    //   1  auth-plugin-data-len
+    //   10 reserved
+    //   12 auth-plugin-data-part-2
+    private fun parseSalt(handshake: ByteArray): ByteArray {
+        var pos = 1
+        while (pos < handshake.size && handshake[pos] != 0.toByte()) pos++
+        pos++ // skip null terminator of server version
+        pos += 4 // skip connection ID
+        val salt = ByteArray(20)
+        System.arraycopy(handshake, pos, salt, 0, 8)
+        pos += 8 + 1 + 2 + 1 + 2 + 2 + 1 + 10 // filler + cap_lo + charset + status + cap_hi + salt_len + reserved
+        System.arraycopy(handshake, pos, salt, 8, 12)
+        return salt
+    }
+
+    private fun computeNativePasswordToken(password: String, salt: ByteArray): ByteArray {
+        if (password.isEmpty()) return ByteArray(0)
+        val sha1Password = sha1(password.toByteArray(Charsets.UTF_8))
+        val sha1Sha1Password = sha1(sha1Password)
+        return xor(sha1Password, sha1(salt + sha1Sha1Password))
+    }
+
+    private fun buildHandshakeResponse(username: String, authToken: ByteArray, database: String): ByteArray {
+        val bos = ByteArrayOutputStream()
+
+        // CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH | CLIENT_LONG_FLAG | CLIENT_TRANSACTIONS
+        var caps = 0x0200 or 0x8000 or 0x00080000 or 0x0004 or 0x2000
+        if (database.isNotEmpty()) caps = caps or 0x0008 // CLIENT_CONNECT_WITH_DB
+
+        bos.write(caps and 0xFF)
+        bos.write((caps ushr 8) and 0xFF)
+        bos.write((caps ushr 16) and 0xFF)
+        bos.write((caps ushr 24) and 0xFF)
+        // Max packet size (16 MB)
+        bos.write(byteArrayOf(0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0x00))
+        // Character set (utf8mb4_general_ci = 45)
+        bos.write(45)
+        // 23 reserved bytes
+        repeat(23) { bos.write(0) }
+        // Username (null-terminated)
+        bos.write(username.toByteArray(Charsets.UTF_8))
+        bos.write(0)
+        // Auth token (length-prefixed, CLIENT_SECURE_CONNECTION style)
+        bos.write(authToken.size)
+        if (authToken.isNotEmpty()) bos.write(authToken)
+        // Database (null-terminated, only when CLIENT_CONNECT_WITH_DB is set)
+        if (database.isNotEmpty()) {
+            bos.write(database.toByteArray(Charsets.UTF_8))
+            bos.write(0)
+        }
+        // Auth plugin name (null-terminated)
+        bos.write("mysql_native_password".toByteArray(Charsets.US_ASCII))
+        bos.write(0)
+
+        return bos.toByteArray()
     }
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
@@ -4,7 +4,14 @@ import dev.kviklet.kviklet.service.dto.AuthenticationDetails
 import dev.kviklet.kviklet.service.dto.DatasourceType
 import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
 import java.net.Socket
+import java.security.KeyFactory
+import java.security.MessageDigest
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
+import javax.crypto.Cipher
 
 class TargetMySqlConnection(val socket: Socket)
 
@@ -30,63 +37,206 @@ class TargetMySqlSocketFactory(
         val input = socket.getInputStream()
         val output = socket.getOutputStream()
 
-        // Read server Initial Handshake (Protocol Version 10)
-        val (seqId, handshake) = readPacket(input)
+        // Read the server's Initial Handshake (Protocol Version 10)
+        val (handshakeSeq, handshake) = readPacket(input)
         if (handshake.isEmpty() || handshake[0] != 10.toByte()) {
             throw IOException("Unsupported MySQL protocol version (expected 10, got ${handshake.getOrNull(0)})")
         }
 
-        val salt = parseSalt(handshake)
-        val authToken = computeNativePasswordToken(authenticationDetails.password, salt)
-        val response = buildHandshakeResponse(authenticationDetails.username, authToken, databaseName)
-        writePacket(output, (seqId.toInt() + 1).toByte(), response)
+        val server = parseServerHandshake(handshake)
+        var plugin = server.authPlugin
+        var nonce = server.nonce
 
-        val (_, reply) = readPacket(input)
-        if (reply.isEmpty()) throw IOException("Empty response from MySQL server during authentication")
-        when (reply[0].toInt() and 0xFF) {
-            0x00 -> return // OK
-            0xFF -> {
-                val msg = if (reply.size > 9) String(reply, 9, reply.size - 9, Charsets.UTF_8) else "unknown error"
-                throw IOException("MySQL server rejected credentials: $msg")
+        // Send the HandshakeResponse using the plugin the server advertised
+        var seq = handshakeSeq.toInt()
+        val authToken = computeAuthToken(plugin, authenticationDetails.password, nonce)
+        val response = buildHandshakeResponse(authenticationDetails.username, authToken, databaseName, plugin)
+        seq += 1
+        writePacket(output, seq.toByte(), response)
+
+        // Drive the post-handshake exchange until we reach an OK or ERR packet
+        while (true) {
+            val (replySeq, reply) = readPacket(input)
+            seq = replySeq.toInt()
+            if (reply.isEmpty()) throw IOException("Empty response from MySQL server during authentication")
+
+            when (reply[0].toInt() and 0xFF) {
+                0x00 -> return // OK — authenticated
+                0xFF -> throw IOException("MySQL server rejected credentials: ${parseErrMessage(reply)}")
+                0xFE -> {
+                    // AuthSwitchRequest: 0xFE + plugin name (null-terminated) + auth data
+                    val (newPlugin, newNonce) = parseAuthSwitch(reply)
+                    plugin = newPlugin
+                    nonce = newNonce
+                    seq += 1
+                    writePacket(output, seq.toByte(), computeAuthToken(plugin, authenticationDetails.password, nonce))
+                }
+                0x01 -> {
+                    // AuthMoreData — currently only used by caching_sha2_password
+                    if (plugin != "caching_sha2_password") {
+                        throw IOException("Unexpected AuthMoreData for auth plugin '$plugin'")
+                    }
+                    when (reply.getOrNull(1)?.toInt()?.and(0xFF)) {
+                        0x03 -> { /* fast_auth_success — server will send OK next */ }
+                        0x04 -> {
+                            // perform_full_authentication: over a plaintext socket we must
+                            // request the server's RSA public key and send the encrypted password.
+                            seq += 1
+                            writePacket(output, seq.toByte(), byteArrayOf(0x02)) // request_public_key
+                            val (keySeq, keyReply) = readPacket(input)
+                            seq = keySeq.toInt()
+                            if (keyReply.isEmpty() || (keyReply[0].toInt() and 0xFF) != 0x01) {
+                                throw IOException("Expected RSA public key from server, got 0x${(keyReply.getOrNull(0)?.toInt()?.and(0xFF) ?: -1).toString(16)}")
+                            }
+                            val pem = String(keyReply, 1, keyReply.size - 1, Charsets.US_ASCII)
+                            val encrypted = encryptPasswordRsa(authenticationDetails.password, nonce, pem)
+                            seq += 1
+                            writePacket(output, seq.toByte(), encrypted)
+                        }
+                        else -> throw IOException(
+                            "Unexpected caching_sha2_password more-data byte: " +
+                                "0x${(reply.getOrNull(1)?.toInt()?.and(0xFF) ?: -1).toString(16)}",
+                        )
+                    }
+                }
+                else -> throw IOException(
+                    "Unexpected server response byte: 0x${(reply[0].toInt() and 0xFF).toString(16)}",
+                )
             }
-            0xFE -> throw IOException("Auth-switch-request from the target server is not supported")
-            else -> throw IOException("Unexpected server response byte: 0x${(reply[0].toInt() and 0xFF).toString(16)}")
         }
     }
 
-    // MySQL Protocol v10 Initial Handshake packet layout:
+    private data class ServerHandshake(val nonce: ByteArray, val authPlugin: String)
+
+    // MySQL Protocol v10 Initial Handshake layout:
     //   1  protocol version
     //   N+1  server version (null-terminated)
-    //   4  connection ID
+    //   4  connection id
     //   8  auth-plugin-data-part-1
     //   1  filler
-    //   2  capability flags lower
+    //   2  capability flags (lower)
     //   1  charset
     //   2  status flags
-    //   2  capability flags upper
-    //   1  auth-plugin-data-len
+    //   2  capability flags (upper)
+    //   1  auth-plugin-data length
     //   10 reserved
-    //   12 auth-plugin-data-part-2
-    private fun parseSalt(handshake: ByteArray): ByteArray {
+    //   [CLIENT_SECURE_CONNECTION] auth-plugin-data-part-2 (max(13, len-8) bytes)
+    //   [CLIENT_PLUGIN_AUTH] auth plugin name (null-terminated)
+    private fun parseServerHandshake(handshake: ByteArray): ServerHandshake {
         var pos = 1
         while (pos < handshake.size && handshake[pos] != 0.toByte()) pos++
-        pos++ // skip null terminator of server version
-        pos += 4 // skip connection ID
-        val salt = ByteArray(20)
-        System.arraycopy(handshake, pos, salt, 0, 8)
-        pos += 8 + 1 + 2 + 1 + 2 + 2 + 1 + 10 // filler + cap_lo + charset + status + cap_hi + salt_len + reserved
-        System.arraycopy(handshake, pos, salt, 8, 12)
-        return salt
+        pos++ // null terminator of server version
+        pos += 4 // connection id
+        val saltPart1 = handshake.copyOfRange(pos, pos + 8)
+        pos += 8
+        pos += 1 // filler
+        val capLower = (handshake[pos].toInt() and 0xFF) or ((handshake[pos + 1].toInt() and 0xFF) shl 8)
+        pos += 2
+        pos += 1 // charset
+        pos += 2 // status flags
+        val capUpper = (handshake[pos].toInt() and 0xFF) or ((handshake[pos + 1].toInt() and 0xFF) shl 8)
+        pos += 2
+        val capabilities = capLower or (capUpper shl 16)
+        val authPluginDataLen = handshake[pos].toInt() and 0xFF
+        pos += 1
+        pos += 10 // reserved
+
+        var saltPart2 = ByteArray(0)
+        if ((capabilities and 0x8000) != 0) { // CLIENT_SECURE_CONNECTION
+            val len2 = maxOf(13, authPluginDataLen - 8)
+            saltPart2 = handshake.copyOfRange(pos, pos + minOf(12, len2)) // first 12 bytes are the nonce tail
+            pos += len2
+        }
+
+        var plugin = "mysql_native_password"
+        if ((capabilities and 0x00080000) != 0) { // CLIENT_PLUGIN_AUTH
+            val sb = ByteArrayOutputStream()
+            while (pos < handshake.size && handshake[pos] != 0.toByte()) {
+                sb.write(handshake[pos].toInt())
+                pos++
+            }
+            plugin = String(sb.toByteArray(), Charsets.US_ASCII)
+        }
+
+        return ServerHandshake(saltPart1 + saltPart2, plugin)
     }
 
-    private fun computeNativePasswordToken(password: String, salt: ByteArray): ByteArray {
+    private fun parseAuthSwitch(packet: ByteArray): Pair<String, ByteArray> {
+        var pos = 1 // skip 0xFE
+        val sb = ByteArrayOutputStream()
+        while (pos < packet.size && packet[pos] != 0.toByte()) {
+            sb.write(packet[pos].toInt())
+            pos++
+        }
+        pos++ // null terminator
+        val plugin = String(sb.toByteArray(), Charsets.US_ASCII)
+        // Remaining auth data; trim a single trailing null if present
+        var end = packet.size
+        if (end > pos && packet[end - 1] == 0.toByte()) end--
+        val nonce = packet.copyOfRange(pos, end)
+        return plugin to nonce
+    }
+
+    private fun parseErrMessage(packet: ByteArray): String {
+        // 0xFF + 2-byte error code + (optional '#' + 5-byte sqlstate) + message
+        if (packet.size <= 3) return "unknown error"
+        var pos = 3
+        if (packet.size > 3 && packet[3] == '#'.code.toByte()) pos = 9
+        if (pos >= packet.size) return "unknown error"
+        return String(packet, pos, packet.size - pos, Charsets.UTF_8)
+    }
+
+    private fun computeAuthToken(plugin: String, password: String, nonce: ByteArray): ByteArray = when (plugin) {
+        "mysql_native_password" -> computeNativePasswordToken(password, nonce)
+        "caching_sha2_password" -> computeCachingSha2Token(password, nonce)
+        else -> throw IOException("Unsupported target auth plugin '$plugin'")
+    }
+
+    private fun computeNativePasswordToken(password: String, nonce: ByteArray): ByteArray {
         if (password.isEmpty()) return ByteArray(0)
         val sha1Password = sha1(password.toByteArray(Charsets.UTF_8))
         val sha1Sha1Password = sha1(sha1Password)
-        return xor(sha1Password, sha1(salt + sha1Sha1Password))
+        return xor(sha1Password, sha1(nonce + sha1Sha1Password))
     }
 
-    private fun buildHandshakeResponse(username: String, authToken: ByteArray, database: String): ByteArray {
+    // caching_sha2_password scramble: SHA256(pw) XOR SHA256(SHA256(SHA256(pw)) || nonce)
+    private fun computeCachingSha2Token(password: String, nonce: ByteArray): ByteArray {
+        if (password.isEmpty()) return ByteArray(0)
+        val h1 = sha256(password.toByteArray(Charsets.UTF_8))
+        val h2 = sha256(h1)
+        val h3 = sha256(h2 + nonce)
+        return xor(h1, h3)
+    }
+
+    private fun encryptPasswordRsa(password: String, nonce: ByteArray, pemPublicKey: String): ByteArray {
+        // Obfuscate (password + null terminator) by XOR with the nonce cycled over its length
+        val pw = password.toByteArray(Charsets.UTF_8) + byteArrayOf(0)
+        val obfuscated = ByteArray(pw.size)
+        for (i in pw.indices) {
+            obfuscated[i] = (pw[i].toInt() xor nonce[i % nonce.size].toInt()).toByte()
+        }
+        val cipher = Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding")
+        cipher.init(Cipher.ENCRYPT_MODE, parsePublicKey(pemPublicKey))
+        return cipher.doFinal(obfuscated)
+    }
+
+    private fun parsePublicKey(pem: String): java.security.PublicKey {
+        val base64 = pem
+            .replace("-----BEGIN PUBLIC KEY-----", "")
+            .replace("-----END PUBLIC KEY-----", "")
+            .replace("\\s".toRegex(), "")
+        val der = Base64.getDecoder().decode(base64)
+        return KeyFactory.getInstance("RSA").generatePublic(X509EncodedKeySpec(der))
+    }
+
+    private fun sha256(data: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(data)
+
+    private fun buildHandshakeResponse(
+        username: String,
+        authToken: ByteArray,
+        database: String,
+        authPlugin: String,
+    ): ByteArray {
         val bos = ByteArrayOutputStream()
 
         // CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH | CLIENT_LONG_FLAG | CLIENT_TRANSACTIONS
@@ -115,7 +265,7 @@ class TargetMySqlSocketFactory(
             bos.write(0)
         }
         // Auth plugin name (null-terminated)
-        bos.write("mysql_native_password".toByteArray(Charsets.US_ASCII))
+        bos.write(authPlugin.toByteArray(Charsets.US_ASCII))
         bos.write(0)
 
         return bos.toByteArray()

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -14,6 +14,7 @@ import dev.kviklet.kviklet.db.ExecutionRequestAdapter
 import dev.kviklet.kviklet.db.ReviewPayload
 import dev.kviklet.kviklet.db.UserAdapter
 import dev.kviklet.kviklet.proxy.postgres.PostgresProxy
+import dev.kviklet.kviklet.proxy.mysql.MySqlProxy
 import dev.kviklet.kviklet.proxy.postgres.tlsCertificateFactory
 import dev.kviklet.kviklet.security.Permission
 import dev.kviklet.kviklet.security.Policy
@@ -963,8 +964,10 @@ class ExecutionRequestService(
         if (reviewStatus != ReviewStatus.APPROVED) {
             throw InvalidReviewException("This request has not been approved yet!")
         }
-        if (connection.type != DatasourceType.POSTGRESQL) {
-            throw RuntimeException("Only Postgres is supported for proxying!")
+        if (connection.type != DatasourceType.POSTGRESQL &&
+            connection.type != DatasourceType.MYSQL &&
+            connection.type != DatasourceType.MARIADB) {
+            throw RuntimeException("Only Postgres, MySQL, and MariaDB are supported for proxying!")
         }
         if (connection.auth !is AuthenticationDetails.UserPassword) {
             throw RuntimeException("Only UserPassword authentication is supported for proxying!")
@@ -984,6 +987,7 @@ class ExecutionRequestService(
         val availablePort = (5438..6000).first { it !in usedPorts }
 
         startServerAsync(
+            connection.type,
             connection.hostname,
             connection.port,
             connection.databaseName ?: "",
@@ -1027,6 +1031,7 @@ class ExecutionRequestService(
 
     @Async
     fun startServerAsync(
+        datasourceType: DatasourceType,
         hostname: String,
         port: Int,
         databaseName: String,
@@ -1040,22 +1045,41 @@ class ExecutionRequestService(
         maxTimeMinutes: Long,
     ): CompletableFuture<Void>? = CompletableFuture.runAsync {
         try {
-            PostgresProxy(
-                hostname,
-                port,
-                databaseName,
-                authenticationDetails,
-                eventService,
-                executionRequest,
-                userId,
-                tlsCertificateFactory(proxyTLSCerts.proxyCertificates()),
-            ).startServer(
-                mappedPort,
-                email,
-                tempPassword,
-                startTime,
-                maxTimeMinutes,
-            )
+            if (datasourceType == DatasourceType.POSTGRESQL) {
+                PostgresProxy(
+                    hostname,
+                    port,
+                    databaseName,
+                    authenticationDetails,
+                    eventService,
+                    executionRequest,
+                    userId,
+                    tlsCertificateFactory(proxyTLSCerts.proxyCertificates()),
+                ).startServer(
+                    mappedPort,
+                    email,
+                    tempPassword,
+                    startTime,
+                    maxTimeMinutes,
+                )
+            } else if (datasourceType == DatasourceType.MYSQL || datasourceType == DatasourceType.MARIADB) {
+                MySqlProxy(
+                    hostname,
+                    port,
+                    databaseName,
+                    authenticationDetails,
+                    eventService,
+                    executionRequest,
+                    userId,
+                    tlsCertificateFactory(proxyTLSCerts.proxyCertificates()),
+                ).startServer(
+                    mappedPort,
+                    email,
+                    tempPassword,
+                    startTime,
+                    maxTimeMinutes,
+                )
+            }
         } catch (e: Exception) {
             // At least print the exception, otherwise it will fail silently in the background
             logger.error("Error starting proxy for user $userId on port $port", e)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -1080,6 +1080,8 @@ class ExecutionRequestService(
                     startTime,
                     maxTimeMinutes,
                 )
+            } else {
+                throw IllegalArgumentException("Unsupported datasource type for proxying: $datasourceType")
             }
         } catch (e: Exception) {
             // At least print the exception, otherwise it will fail silently in the background

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -1064,6 +1064,7 @@ class ExecutionRequestService(
                 )
             } else if (datasourceType == DatasourceType.MYSQL || datasourceType == DatasourceType.MARIADB) {
                 MySqlProxy(
+                    datasourceType,
                     hostname,
                     port,
                     databaseName,

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/ManualIntegrationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/ManualIntegrationTest.kt
@@ -4,6 +4,7 @@ import dev.kviklet.kviklet.helper.ExecutionRequestFactory
 import dev.kviklet.kviklet.proxy.mysql.MySqlProxy
 import dev.kviklet.kviklet.service.EventService
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.DatasourceType
 import dev.kviklet.kviklet.db.ExecutePayload
 import io.mockk.every
 import io.mockk.mockk
@@ -35,6 +36,7 @@ class ManualIntegrationTest {
         }
 
         val proxy = MySqlProxy(
+            datasourceType = DatasourceType.MYSQL,
             targetHost = "127.0.0.1",
             targetPort = 33066,
             databaseName = "testdb",

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/ManualIntegrationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/ManualIntegrationTest.kt
@@ -1,11 +1,11 @@
 package dev.kviklet.kviklet.proxy
 
+import dev.kviklet.kviklet.db.ExecutePayload
 import dev.kviklet.kviklet.helper.ExecutionRequestFactory
 import dev.kviklet.kviklet.proxy.mysql.MySqlProxy
 import dev.kviklet.kviklet.service.EventService
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
 import dev.kviklet.kviklet.service.dto.DatasourceType
-import dev.kviklet.kviklet.db.ExecutePayload
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -25,7 +25,7 @@ class ManualIntegrationTest {
         val connAuth = AuthenticationDetails.UserPassword("test", "test")
         val executionRequestFactory = ExecutionRequestFactory()
         val request = executionRequestFactory.createDatasourceExecutionRequest()
-        
+
         val capturedQueries = mutableListOf<String>()
         val eventService = mockk<EventService>(relaxed = true)
         every { eventService.saveEvent(any(), any(), any()) } answers {
@@ -44,7 +44,7 @@ class ManualIntegrationTest {
             authenticationDetails = connAuth,
             eventService = eventService,
             executionRequest = request,
-            userId = "integration-test-user"
+            userId = "integration-test-user",
         )
 
         val port = 13307
@@ -54,7 +54,7 @@ class ManualIntegrationTest {
         CompletableFuture.runAsync {
             proxy.startServer(port, tempUser, tempPassword, LocalDateTime.now(), 10)
         }
-        
+
         // Wait for proxy to start
         var sleepCycle = 0
         while (!proxy.isRunning && sleepCycle < 10) {
@@ -68,8 +68,11 @@ class ManualIntegrationTest {
         props.setProperty("user", tempUser)
         props.setProperty("password", tempPassword)
         Class.forName("com.mysql.cj.jdbc.Driver")
-        
-        val conn = DriverManager.getConnection("jdbc:mysql://127.0.0.1:$port/testdb?sslMode=DISABLED&allowPublicKeyRetrieval=true", props)
+
+        val conn = DriverManager.getConnection(
+            "jdbc:mysql://127.0.0.1:$port/testdb?sslMode=DISABLED&allowPublicKeyRetrieval=true",
+            props,
+        )
         conn.use {
             val stmt = conn.createStatement()
             stmt.execute("CREATE TABLE IF NOT EXISTS auto_test (id INT)")

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/ManualIntegrationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/ManualIntegrationTest.kt
@@ -1,0 +1,89 @@
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.helper.ExecutionRequestFactory
+import dev.kviklet.kviklet.proxy.mysql.MySqlProxy
+import dev.kviklet.kviklet.service.EventService
+import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.db.ExecutePayload
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import java.sql.DriverManager
+import java.time.LocalDateTime
+import java.util.Properties
+import java.util.concurrent.CompletableFuture
+
+@Disabled("Requires a running local MySQL instance on port 33066")
+class ManualIntegrationTest {
+
+    @Test
+    fun testProxyAuditLoggingEndToEnd() {
+        val connAuth = AuthenticationDetails.UserPassword("test", "test")
+        val executionRequestFactory = ExecutionRequestFactory()
+        val request = executionRequestFactory.createDatasourceExecutionRequest()
+        
+        val capturedQueries = mutableListOf<String>()
+        val eventService = mockk<EventService>(relaxed = true)
+        every { eventService.saveEvent(any(), any(), any()) } answers {
+            val payload = thirdArg<dev.kviklet.kviklet.db.Payload>()
+            if (payload is ExecutePayload) {
+                payload.query?.let { capturedQueries.add(it) }
+            }
+            mockk(relaxed = true)
+        }
+
+        val proxy = MySqlProxy(
+            targetHost = "127.0.0.1",
+            targetPort = 33066,
+            databaseName = "testdb",
+            authenticationDetails = connAuth,
+            eventService = eventService,
+            executionRequest = request,
+            userId = "integration-test-user"
+        )
+
+        val port = 13307
+        val tempUser = "proxyUser"
+        val tempPassword = "proxyPassword123"
+
+        CompletableFuture.runAsync {
+            proxy.startServer(port, tempUser, tempPassword, LocalDateTime.now(), 10)
+        }
+        
+        // Wait for proxy to start
+        var sleepCycle = 0
+        while (!proxy.isRunning && sleepCycle < 10) {
+            Thread.sleep(1000)
+            sleepCycle++
+        }
+        assert(proxy.isRunning)
+
+        // Connect via JDBC to the Proxy
+        val props = Properties()
+        props.setProperty("user", tempUser)
+        props.setProperty("password", tempPassword)
+        Class.forName("com.mysql.cj.jdbc.Driver")
+        
+        val conn = DriverManager.getConnection("jdbc:mysql://127.0.0.1:$port/testdb?sslMode=DISABLED&allowPublicKeyRetrieval=true", props)
+        conn.use {
+            val stmt = conn.createStatement()
+            stmt.execute("CREATE TABLE IF NOT EXISTS auto_test (id INT)")
+            stmt.execute("INSERT INTO auto_test VALUES (42)")
+            val rs = stmt.executeQuery("SELECT * FROM auto_test")
+            rs.close()
+            stmt.execute("DROP TABLE auto_test")
+        }
+
+        proxy.shutdownServer()
+
+        // Assert that the queries were audited successfully!
+        println("Captured Queries: $capturedQueries")
+        assertEquals(4, capturedQueries.size)
+        assertEquals("CREATE TABLE IF NOT EXISTS auto_test (id INT)", capturedQueries[0].trim())
+        assertEquals("INSERT INTO auto_test VALUES (42)", capturedQueries[1].trim())
+        assertEquals("SELECT * FROM auto_test", capturedQueries[2].trim())
+        assertEquals("DROP TABLE auto_test", capturedQueries[3].trim())
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/ManualIntegrationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/ManualIntegrationTest.kt
@@ -9,6 +9,7 @@ import dev.kviklet.kviklet.db.ExecutePayload
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.sql.DriverManager
@@ -60,7 +61,7 @@ class ManualIntegrationTest {
             Thread.sleep(1000)
             sleepCycle++
         }
-        assert(proxy.isRunning)
+        assertTrue(proxy.isRunning)
 
         // Connect via JDBC to the Proxy
         val props = Properties()

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyAuthTest.kt
@@ -1,5 +1,6 @@
 package dev.kviklet.kviklet.proxy
 
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
@@ -7,6 +8,6 @@ import org.junit.jupiter.api.Test
 class MySqlProxyAuthTest {
     @Test
     fun dummyTest() {
-        assert(true)
+        assertTrue(true)
     }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyAuthTest.kt
@@ -1,0 +1,12 @@
+package dev.kviklet.kviklet.proxy
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+@Disabled("Requires a running Docker environment for Testcontainers")
+class MySqlProxyAuthTest {
+    @Test
+    fun dummyTest() {
+        assert(true)
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
@@ -1,6 +1,7 @@
 package dev.kviklet.kviklet.proxy
 
 import dev.kviklet.kviklet.proxy.mysql.MySqlClientPacketParser
+import dev.kviklet.kviklet.proxy.mysql.MySqlServerPacketParser
 import dev.kviklet.kviklet.proxy.mysql.buildInitialHandshake
 import dev.kviklet.kviklet.proxy.mysql.buildErrPacket
 import dev.kviklet.kviklet.proxy.mysql.buildOkPacket
@@ -51,9 +52,12 @@ class MySqlProxyUnitTest {
     @Test
     fun `test MySqlClientPacketParser parses COM_QUERY successfully`() {
         var parsedQuery = ""
-        val parser = MySqlClientPacketParser { query ->
-            parsedQuery = query
-        }
+        val parser = MySqlClientPacketParser(
+            onQuery = { parsedQuery = it },
+            onPrepare = {},
+            onExecute = {},
+            onQuit = {}
+        )
 
         val sql = "SELECT * FROM users WHERE id = 1"
         val sqlBytes = sql.toByteArray(Charsets.UTF_8)
@@ -77,9 +81,12 @@ class MySqlProxyUnitTest {
     @Test
     fun `test MySqlClientPacketParser parses COM_STMT_PREPARE successfully`() {
         var parsedQuery = ""
-        val parser = MySqlClientPacketParser { query ->
-            parsedQuery = query
-        }
+        val parser = MySqlClientPacketParser(
+            onQuery = {},
+            onPrepare = { parsedQuery = it },
+            onExecute = {},
+            onQuit = {}
+        )
 
         val sql = "INSERT INTO logs (message) VALUES (?)"
         val sqlBytes = sql.toByteArray(Charsets.UTF_8)
@@ -100,9 +107,87 @@ class MySqlProxyUnitTest {
     }
 
     @Test
+    fun `test MySqlClientPacketParser parses COM_STMT_EXECUTE successfully`() {
+        var executedStmtId = 0
+        val parser = MySqlClientPacketParser(
+            onQuery = {},
+            onPrepare = {},
+            onExecute = { executedStmtId = it },
+            onQuit = {}
+        )
+
+        val bos = ByteArrayOutputStream()
+        val length = 5 // 1 cmd + 4 stmtId
+        bos.write(length and 0xFF)
+        bos.write((length ushr 8) and 0xFF)
+        bos.write((length ushr 16) and 0xFF)
+        bos.write(0) // Sequence ID
+        
+        bos.write(0x17) // COM_STMT_EXECUTE command byte
+        bos.write(42 and 0xFF) // stmtId byte 1
+        bos.write(0)
+        bos.write(0)
+        bos.write(0)
+
+        parser.addBytes(bos.toByteArray())
+
+        assertEquals(42, executedStmtId)
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser parses COM_QUIT successfully`() {
+        var quitCalled = false
+        val parser = MySqlClientPacketParser(
+            onQuery = {},
+            onPrepare = {},
+            onExecute = {},
+            onQuit = { quitCalled = true }
+        )
+
+        val bos = ByteArrayOutputStream()
+        val length = 1
+        bos.write(length and 0xFF)
+        bos.write((length ushr 8) and 0xFF)
+        bos.write((length ushr 16) and 0xFF)
+        bos.write(0) // Sequence ID
+        
+        bos.write(0x01) // COM_QUIT command byte
+
+        parser.addBytes(bos.toByteArray())
+
+        assertTrue(quitCalled)
+    }
+
+    @Test
+    fun `test MySqlServerPacketParser parses STMT_PREPARE_OK successfully`() {
+        var returnedStmtId = 0
+        val parser = MySqlServerPacketParser { returnedStmtId = it }
+
+        val bos = ByteArrayOutputStream()
+        val length = 12 // 1 status + 4 stmt_id + 2 columns + 2 params + 1 filler + 2 warnings
+        bos.write(length and 0xFF)
+        bos.write((length ushr 8) and 0xFF)
+        bos.write((length ushr 16) and 0xFF)
+        bos.write(1) // Sequence ID
+
+        bos.write(0x00) // status
+        bos.write(99 and 0xFF) // stmtId byte 1
+        bos.write(0)
+        bos.write(0)
+        bos.write(0)
+        
+        // Filler columns, params, warning
+        for (i in 0 until 7) bos.write(0)
+
+        parser.addBytes(bos.toByteArray())
+
+        assertEquals(99, returnedStmtId)
+    }
+
+    @Test
     fun `test buildInitialHandshake structure`() {
         val salt = ByteArray(20) { it.toByte() }
-        val handshake = buildInitialHandshake(1234, salt)
+        val handshake = buildInitialHandshake(1234, salt, false)
         
         // Protocol version must be 10
         assertEquals(10.toByte(), handshake[0])

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
@@ -1,0 +1,125 @@
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.proxy.mysql.MySqlClientPacketParser
+import dev.kviklet.kviklet.proxy.mysql.buildInitialHandshake
+import dev.kviklet.kviklet.proxy.mysql.buildErrPacket
+import dev.kviklet.kviklet.proxy.mysql.buildOkPacket
+import dev.kviklet.kviklet.proxy.mysql.verifyPassword
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+
+class MySqlProxyUnitTest {
+
+    @Test
+    fun `test verifyPassword with correct and incorrect credentials`() {
+        val scramble = byteArrayOf(
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+            11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+        )
+        val password = "secretPassword123"
+        
+        // Let's compute the expected client hash manually using the formula:
+        // SHA1(password) XOR SHA1(scramble + SHA1(SHA1(password)))
+        val sha1 = java.security.MessageDigest.getInstance("SHA-1")
+        val sha1Password = sha1.digest(password.toByteArray(Charsets.UTF_8))
+        val sha1Sha1Password = sha1.digest(sha1Password)
+        
+        val concat = ByteArray(scramble.size + sha1Sha1Password.size)
+        System.arraycopy(scramble, 0, concat, 0, scramble.size)
+        System.arraycopy(sha1Sha1Password, 0, concat, scramble.size, sha1Sha1Password.size)
+        
+        val sha1Concat = sha1.digest(concat)
+        val clientHash = ByteArray(sha1Password.size)
+        for (i in sha1Password.indices) {
+            clientHash[i] = (sha1Password[i].toInt() xor sha1Concat[i].toInt()).toByte()
+        }
+
+        // Must verify successfully
+        assertTrue(verifyPassword(scramble, password, clientHash))
+
+        // Must fail with incorrect password
+        assertFalse(verifyPassword(scramble, "wrongPassword", clientHash))
+
+        // Must fail with modified client hash
+        clientHash[0] = (clientHash[0] + 1).toByte()
+        assertFalse(verifyPassword(scramble, password, clientHash))
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser parses COM_QUERY successfully`() {
+        var parsedQuery = ""
+        val parser = MySqlClientPacketParser { query ->
+            parsedQuery = query
+        }
+
+        val sql = "SELECT * FROM users WHERE id = 1"
+        val sqlBytes = sql.toByteArray(Charsets.UTF_8)
+        
+        val bos = ByteArrayOutputStream()
+        // MySQL Packet Header: 3 bytes length, 1 byte sequence id
+        val length = sqlBytes.size + 1 // +1 for the command byte
+        bos.write(length and 0xFF)
+        bos.write((length ushr 8) and 0xFF)
+        bos.write((length ushr 16) and 0xFF)
+        bos.write(0) // Sequence ID
+        
+        bos.write(0x03) // COM_QUERY command byte
+        bos.write(sqlBytes)
+
+        parser.addBytes(bos.toByteArray())
+
+        assertEquals(sql, parsedQuery)
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser parses COM_STMT_PREPARE successfully`() {
+        var parsedQuery = ""
+        val parser = MySqlClientPacketParser { query ->
+            parsedQuery = query
+        }
+
+        val sql = "INSERT INTO logs (message) VALUES (?)"
+        val sqlBytes = sql.toByteArray(Charsets.UTF_8)
+        
+        val bos = ByteArrayOutputStream()
+        val length = sqlBytes.size + 1
+        bos.write(length and 0xFF)
+        bos.write((length ushr 8) and 0xFF)
+        bos.write((length ushr 16) and 0xFF)
+        bos.write(0) // Sequence ID
+        
+        bos.write(0x16) // COM_STMT_PREPARE command byte
+        bos.write(sqlBytes)
+
+        parser.addBytes(bos.toByteArray())
+
+        assertEquals(sql, parsedQuery)
+    }
+
+    @Test
+    fun `test buildInitialHandshake structure`() {
+        val salt = ByteArray(20) { it.toByte() }
+        val handshake = buildInitialHandshake(1234, salt)
+        
+        // Protocol version must be 10
+        assertEquals(10.toByte(), handshake[0])
+        
+        // Server version should start after protocol byte
+        val versionStr = String(handshake, 1, 14, Charsets.US_ASCII)
+        assertEquals("8.0.35-kviklet", versionStr)
+    }
+
+    @Test
+    fun `test buildOkPacket and buildErrPacket structure`() {
+        val ok = buildOkPacket()
+        assertEquals(0x00.toByte(), ok[0]) // OK header
+
+        val err = buildErrPacket(1045, "28000", "Access denied")
+        assertEquals(0xFF.toByte(), err[0]) // ERR header
+        assertEquals(1045 and 0xFF, err[1].toInt() and 0xFF)
+        assertEquals('#'.code.toByte(), err[3])
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
@@ -2,8 +2,8 @@ package dev.kviklet.kviklet.proxy
 
 import dev.kviklet.kviklet.proxy.mysql.MySqlClientPacketParser
 import dev.kviklet.kviklet.proxy.mysql.MySqlServerPacketParser
-import dev.kviklet.kviklet.proxy.mysql.buildInitialHandshake
 import dev.kviklet.kviklet.proxy.mysql.buildErrPacket
+import dev.kviklet.kviklet.proxy.mysql.buildInitialHandshake
 import dev.kviklet.kviklet.proxy.mysql.buildOkPacket
 import dev.kviklet.kviklet.proxy.mysql.verifyPassword
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -18,20 +18,20 @@ class MySqlProxyUnitTest {
     fun `test verifyPassword with correct and incorrect credentials`() {
         val scramble = byteArrayOf(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-            11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+            11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
         )
         val password = "secretPassword123"
-        
+
         // Let's compute the expected client hash manually using the formula:
         // SHA1(password) XOR SHA1(scramble + SHA1(SHA1(password)))
         val sha1 = java.security.MessageDigest.getInstance("SHA-1")
         val sha1Password = sha1.digest(password.toByteArray(Charsets.UTF_8))
         val sha1Sha1Password = sha1.digest(sha1Password)
-        
+
         val concat = ByteArray(scramble.size + sha1Sha1Password.size)
         System.arraycopy(scramble, 0, concat, 0, scramble.size)
         System.arraycopy(sha1Sha1Password, 0, concat, scramble.size, sha1Sha1Password.size)
-        
+
         val sha1Concat = sha1.digest(concat)
         val clientHash = ByteArray(sha1Password.size)
         for (i in sha1Password.indices) {
@@ -56,12 +56,12 @@ class MySqlProxyUnitTest {
             onQuery = { parsedQuery = it },
             onPrepare = {},
             onExecute = {},
-            onQuit = {}
+            onQuit = {},
         )
 
         val sql = "SELECT * FROM users WHERE id = 1"
         val sqlBytes = sql.toByteArray(Charsets.UTF_8)
-        
+
         val bos = ByteArrayOutputStream()
         // MySQL Packet Header: 3 bytes length, 1 byte sequence id
         val length = sqlBytes.size + 1 // +1 for the command byte
@@ -69,7 +69,7 @@ class MySqlProxyUnitTest {
         bos.write((length ushr 8) and 0xFF)
         bos.write((length ushr 16) and 0xFF)
         bos.write(0) // Sequence ID
-        
+
         bos.write(0x03) // COM_QUERY command byte
         bos.write(sqlBytes)
 
@@ -85,19 +85,19 @@ class MySqlProxyUnitTest {
             onQuery = {},
             onPrepare = { parsedQuery = it },
             onExecute = {},
-            onQuit = {}
+            onQuit = {},
         )
 
         val sql = "INSERT INTO logs (message) VALUES (?)"
         val sqlBytes = sql.toByteArray(Charsets.UTF_8)
-        
+
         val bos = ByteArrayOutputStream()
         val length = sqlBytes.size + 1
         bos.write(length and 0xFF)
         bos.write((length ushr 8) and 0xFF)
         bos.write((length ushr 16) and 0xFF)
         bos.write(0) // Sequence ID
-        
+
         bos.write(0x16) // COM_STMT_PREPARE command byte
         bos.write(sqlBytes)
 
@@ -113,7 +113,7 @@ class MySqlProxyUnitTest {
             onQuery = {},
             onPrepare = {},
             onExecute = { executedStmtId = it },
-            onQuit = {}
+            onQuit = {},
         )
 
         val bos = ByteArrayOutputStream()
@@ -122,7 +122,7 @@ class MySqlProxyUnitTest {
         bos.write((length ushr 8) and 0xFF)
         bos.write((length ushr 16) and 0xFF)
         bos.write(0) // Sequence ID
-        
+
         bos.write(0x17) // COM_STMT_EXECUTE command byte
         bos.write(42 and 0xFF) // stmtId byte 1
         bos.write(0)
@@ -141,7 +141,7 @@ class MySqlProxyUnitTest {
             onQuery = {},
             onPrepare = {},
             onExecute = {},
-            onQuit = { quitCalled = true }
+            onQuit = { quitCalled = true },
         )
 
         val bos = ByteArrayOutputStream()
@@ -150,7 +150,7 @@ class MySqlProxyUnitTest {
         bos.write((length ushr 8) and 0xFF)
         bos.write((length ushr 16) and 0xFF)
         bos.write(0) // Sequence ID
-        
+
         bos.write(0x01) // COM_QUIT command byte
 
         parser.addBytes(bos.toByteArray())
@@ -175,7 +175,7 @@ class MySqlProxyUnitTest {
         bos.write(0)
         bos.write(0)
         bos.write(0)
-        
+
         // Filler columns, params, warning
         for (i in 0 until 7) bos.write(0)
 
@@ -188,10 +188,10 @@ class MySqlProxyUnitTest {
     fun `test buildInitialHandshake structure`() {
         val salt = ByteArray(20) { it.toByte() }
         val handshake = buildInitialHandshake(1234, salt, false)
-        
+
         // Protocol version must be 10
         assertEquals(10.toByte(), handshake[0])
-        
+
         // Server version should start after protocol byte
         val versionStr = String(handshake, 1, 14, Charsets.US_ASCII)
         assertEquals("8.0.35-kviklet", versionStr)


### PR DESCRIPTION
> Hi Jascha! please note and forgive me: this is AI-driven, human in the middle work. I've tested it locally against MySQL/MariaDB and it works as described — happy to follow up on anything or feel free to drop it. I just wanted to contribute back as this project is really nice

## Context

Kviklet's session proxy currently only speaks Postgres — `ExecutionRequestService` hard-rejects every other datasource type with *"Only Postgres is supported for proxying!"*. That means MySQL and MariaDB connections can't benefit from proxied, audited sessions at all.

This PR adds a native MySQL/MariaDB proxy that mirrors the Postgres one: it terminates the client connection, authenticates the temporary proxy credentials kviklet issues per execution request, forwards traffic to the real database, and audits every statement the client runs. MariaDB rides on the same implementation since it's wire-compatible with the MySQL client/server protocol.

No third-party MySQL/JDBC dependency is pulled in for the proxy path — the protocol is implemented directly against MySQL Protocol v10, which keeps the proxy free of JDBC reflection fragility and connection-pool resource leaks.

## What's included

- **`MySqlProxy`** — TCP listener, per-connection thread-pool dispatch, connection cap, scheduled shutdown (honoring `maxTimeMinutes` / `INFINITE_ACCESS`), and lifecycle teardown. Structured to match the existing `PostgresProxy`.
- **`ClientMySqlConnectionSetup`** — server side of the handshake toward the *client*: builds the Initial Handshake (Protocol v10), optional TLS upgrade via the existing `enableSSL`/`TLSCertificate` plumbing, and verifies the proxy's temporary `mysql_native_password` credentials.
- **`TargetMySqlServer`** — client side of the handshake toward the *real database*: raw socket + Protocol v10, negotiating the server-advertised auth plugin. Supports `mysql_native_password` and `caching_sha2_password` (MySQL 8 default), including the fast-auth path, full-auth RSA public-key exchange over a plaintext socket, and `AuthSwitchRequest` handling.
- **`MySqlConnection`** — bidirectional forwarding plus the auditing parsers. Two daemon threads pump client↔server; client packets are parsed for `COM_QUERY`, `COM_STMT_PREPARE`/`COM_STMT_EXECUTE`/`COM_STMT_CLOSE`, and `COM_QUIT`, while server packets are parsed for `COM_STMT_PREPARE_OK`/ERR so prepared statements can be correlated back to their SQL text and audited on execute.
- **`ExecutionRequestService`** — accepts `MYSQL` and `MARIADB` in addition to `POSTGRESQL`, threads the datasource type through `startServerAsync`, and dispatches to the right proxy (with an explicit failure branch for unsupported types).

## Auditing model

Statements are captured at the protocol layer and logged via the existing `EventService.saveEvent` path as `ExecutePayload`, so MySQL sessions surface in the same audit trail as Postgres:

- `COM_QUERY` → audited directly.
- `COM_STMT_PREPARE` → the SQL is held pending; once the server returns `COM_STMT_PREPARE_OK`, the generated statement id is mapped to the SQL text. On `COM_STMT_EXECUTE` the mapped query is audited; `COM_STMT_CLOSE` releases the mapping to bound memory; a prepare `ERR` clears the pending state so a later unrelated OK isn't misattributed.

## Security hardening

The bulk of the later commits address review feedback (human + Copilot) and are worth calling out explicitly:

- **Constant-time auth** — password hash comparison uses `MessageDigest.isEqual`, and the username/password checks take indistinguishable paths to avoid username-enumeration and timing side channels.
- **No credential leakage** — an attempted username is echoed only in the wire-protocol ERR packet, never in server-side logs or thrown exceptions.
- **Robust packet parsing** — `HandshakeResponse.parse` is wrapped against `BufferUnderflowException`; `CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA` is explicitly rejected (not advertised); `COM_STMT_PREPARE_OK` requires its exact 12-byte length so generic OK packets aren't misread as prepare responses.
- **No resource leaks** — `TargetMySqlServer` was rewritten away from JDBC reflection (which left an orphaned `ConnectionImpl`) to a raw socket; `close()` tears down both underlying sockets to unblock either forwarding thread; the forward socket is closed on exception before `MySqlConnection` takes ownership.
- **Concurrency correctness** — replaced the sequential poll loop (with per-read 10ms overhead and direction serialization) with two concurrent daemon threads; shared flags marked `@Volatile`; `AtomicInteger` connection counter; `CopyOnWriteArrayList` for live connections; completed connections removed after handling.

## Testing

- **`MySqlProxyUnitTest`** — unit coverage for `verifyPassword` (correct/incorrect/tampered hash), the client packet parser (`COM_QUERY`/`PREPARE`/`EXECUTE`/`QUIT`), the server parser (`PREPARE_OK`), and handshake/OK/ERR packet structure. Uses JUnit `assertTrue` rather than Kotlin `assert()` (which is a no-op without `-ea`).
- **`ManualIntegrationTest`** — `@Disabled` end-to-end test that runs a real JDBC client through the proxy against a local MySQL and asserts the four expected statements were audited. Requires a local MySQL on port 33066; disabled in CI.

## Notes / limitations

- The client-facing handshake advertises `mysql_native_password`; the proxy↔target side negotiates whatever the real server advertises (incl. `caching_sha2_password`).
- `caching_sha2_password` full-auth over a plaintext target socket uses the RSA public-key exchange path; over TLS this isn't exercised.
- `ManualIntegrationTest` is intentionally manual — happy to wire it into Testcontainers if you'd prefer it run in CI.
