### PR TITLE
Send Teams notifications as Adaptive Cards and widen webhook column

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -483,7 +483,7 @@ To configure Slack notifications you need to create a Slack App and enable webho
 
 #### Teams
 
-Microsoft retired the legacy "Incoming Webhook" Office 365 connectors in May 2026, so Teams notifications now use a Power Automate **Workflow** webhook. Kviklet sends an Adaptive Card, which the standard webhook template posts as-is.
+Teams notifications use a Power Automate **Workflow** webhook. Kviklet sends an Adaptive Card, which the webhook template posts to your channel.
 
 **Recommended: use the workflow template**
 
@@ -501,8 +501,6 @@ If you prefer to build the flow yourself (or the template is unavailable):
 2. Add the action **Microsoft Teams -> "Post card in a chat or channel"**.
 3. Set the action's **Adaptive Card** field to the expression `string(triggerBody())` so it posts the card Kviklet sends.
 4. Select the target Team and Channel, **Save**, then copy the **HTTP POST URL** from the trigger step.
-
-Teams adds a small "... used a Workflow template to send this card" footer to cards posted this way; this is added by Teams and cannot be removed from Kviklet's side.
 
 Currently there are notifications for:
 

--- a/Readme.md
+++ b/Readme.md
@@ -483,9 +483,26 @@ To configure Slack notifications you need to create a Slack App and enable webho
 
 #### Teams
 
-To configure Teams notifications you need to add a Webhook connector to your channel. The official microsoft docs on that are here: https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook
+Microsoft retired the legacy "Incoming Webhook" Office 365 connectors in May 2026, so Teams notifications now use a Power Automate **Workflow** webhook. Kviklet sends an Adaptive Card, which the standard webhook template posts as-is.
 
-To enable the notifications, simply set the Webhook URL in the Kviklet Notification Settings and click save.
+**Recommended: use the workflow template**
+
+1. In Teams, open the channel you want notifications in, click the **...** next to the channel name and choose **Workflows** (or add the **Workflows** app).
+2. Search for and create the **"Send webhook alerts to a channel"** template.
+3. Sign in when prompted, then select the target Team and Channel and create the workflow.
+4. Open the trigger step and copy the generated **HTTP POST URL**.
+5. Paste the URL into Kviklet under Settings -> General -> Notification Settings and click save.
+
+**Alternative: build the workflow manually**
+
+If you prefer to build the flow yourself (or the template is unavailable):
+
+1. Channel **...** -> **Workflows** -> create a flow with the trigger **"When a Teams webhook request is received"**.
+2. Add the action **Microsoft Teams -> "Post card in a chat or channel"**.
+3. Set the action's **Adaptive Card** field to the expression `string(triggerBody())` so it posts the card Kviklet sends.
+4. Select the target Team and Channel, **Save**, then copy the **HTTP POST URL** from the trigger step.
+
+Teams adds a small "... used a Workflow template to send this card" footer to cards posted this way; this is added by Teams and cannot be removed from Kviklet's side.
 
 Currently there are notifications for:
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/notifications/SlackApiClient.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/notifications/SlackApiClient.kt
@@ -5,6 +5,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
+import java.net.URI
 
 @Component
 class SlackApiClient(private val restTemplate: RestTemplate) {
@@ -15,7 +16,8 @@ class SlackApiClient(private val restTemplate: RestTemplate) {
         val payload = mapOf("text" to message)
         val request = HttpEntity(payload, headers)
 
-        restTemplate.exchange(webhookUrl, HttpMethod.POST, request, String::class.java)
+        // Pass a parsed URI (not a String) so RestTemplate does not treat the webhook URL as a URI template.
+        restTemplate.exchange(URI.create(webhookUrl), HttpMethod.POST, request, String::class.java)
         return
     }
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/notifications/TeamsApiClient.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/notifications/TeamsApiClient.kt
@@ -1,44 +1,68 @@
 package dev.kviklet.kviklet.service.notifications
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestTemplate
-import org.springframework.web.client.exchange
 
 @Service
 class TeamsApiClient(private val restTemplate: RestTemplate, private val objectMapper: ObjectMapper) {
 
     fun sendMessage(webhookUrl: String, title: String, message: String) {
-        val formattedMessage = formatMessageWithLinksAndLineBreaks(message)
-        val headers = HttpHeaders().apply {
-            add("Content-Type", "application/json")
-        }
-        val notification = TeamsNotification(
-            summary = title,
-            sections = listOf(
-                Section(title, formattedMessage),
-            ),
-        )
+        val headers = HttpHeaders().apply { contentType = MediaType.APPLICATION_JSON }
+        val card = buildAdaptiveCard(title, message)
+        val request = HttpEntity(objectMapper.writeValueAsString(card), headers)
 
-        val body = objectMapper.writeValueAsString(notification)
-        val request = HttpEntity(body, headers)
-
-        restTemplate.exchange<String>(webhookUrl, HttpMethod.POST, request)
-        return
+        restTemplate.exchange(webhookUrl, HttpMethod.POST, request, String::class.java)
     }
 
-    private fun formatMessageWithLinksAndLineBreaks(message: String): String {
-        val urlRegex = Regex("(http[s]?://[^\\s]+)")
-        val formattedMessage = urlRegex.replace(message) { matchResult ->
-            val url = matchResult.value
-            "[$url]($url)"
-        }
-        return formattedMessage.replace("\n", "  \n")
+    private fun buildAdaptiveCard(title: String, message: String): AdaptiveCard {
+        val body = mutableListOf(
+            AdaptiveCardTextBlock(text = title, weight = "Bolder", size = "Medium"),
+        )
+        message.split("\n")
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .forEach { line ->
+                body.add(AdaptiveCardTextBlock(text = linkify(line), spacing = "Small"))
+            }
+
+        val actions = urlRegex.find(message)?.value?.let { url ->
+            listOf(AdaptiveCardAction(title = "Open in Kviklet", url = url))
+        } ?: emptyList()
+
+        return AdaptiveCard(body = body, actions = actions)
+    }
+
+    private fun linkify(text: String): String = urlRegex.replace(text) { "[${it.value}](${it.value})" }
+
+    companion object {
+        private val urlRegex = Regex("https?://\\S+")
     }
 }
 
-data class TeamsNotification(val summary: String, val sections: List<Section>)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class AdaptiveCard(
+    val body: List<AdaptiveCardTextBlock>,
+    val actions: List<AdaptiveCardAction> = emptyList(),
+    val type: String = "AdaptiveCard",
+    @get:JsonProperty("\$schema")
+    val schema: String = "http://adaptivecards.io/schemas/adaptive-card.json",
+    val version: String = "1.4",
+)
 
-data class Section(val title: String, val text: String, val markdown: Boolean = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class AdaptiveCardTextBlock(
+    val text: String,
+    val type: String = "TextBlock",
+    val weight: String? = null,
+    val size: String? = null,
+    val spacing: String? = null,
+    val wrap: Boolean = true,
+)
+
+data class AdaptiveCardAction(val title: String, val url: String, val type: String = "Action.OpenUrl")

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/notifications/TeamsApiClient.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/notifications/TeamsApiClient.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestTemplate
+import java.net.URI
 
 @Service
 class TeamsApiClient(private val restTemplate: RestTemplate, private val objectMapper: ObjectMapper) {
@@ -17,7 +18,10 @@ class TeamsApiClient(private val restTemplate: RestTemplate, private val objectM
         val card = buildAdaptiveCard(title, message)
         val request = HttpEntity(objectMapper.writeValueAsString(card), headers)
 
-        restTemplate.exchange(webhookUrl, HttpMethod.POST, request, String::class.java)
+        // Pass a parsed URI (not a String) so RestTemplate does not treat the webhook URL as a URI
+        // template. Power Automate "Workflows" URLs carry percent-encoded query params (e.g. the SAS
+        // `sig`); template expansion would mangle or drop them and the request would fail to authenticate.
+        restTemplate.exchange(URI.create(webhookUrl), HttpMethod.POST, request, String::class.java)
     }
 
     private fun buildAdaptiveCard(title: String, message: String): AdaptiveCard {

--- a/backend/src/main/resources/changelog/000-changelog.yaml
+++ b/backend/src/main/resources/changelog/000-changelog.yaml
@@ -128,3 +128,6 @@ databaseChangeLog:
   - include:
       file: 044-add-github-id-column.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 045-widen-configuration-value.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/changelog/045-widen-configuration-value.yaml
+++ b/backend/src/main/resources/changelog/045-widen-configuration-value.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 045-widen-configuration-value
+      author: jascha
+      changes:
+        - modifyDataType:
+            tableName: configuration
+            columnName: value
+            newDataType: TEXT

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ConfigurationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ConfigurationTest.kt
@@ -39,4 +39,21 @@ class ConfigurationTest {
         assert(savedConfiguration == loadedConfiguration)
         assert(configuration == savedConfiguration)
     }
+
+    @Test
+    fun `stores webhook urls longer than 255 characters`() {
+        // Teams Power Automate "Workflows" webhook URLs routinely exceed 255 chars,
+        // which the original VARCHAR(255) column rejected.
+        val longUrl = "https://default.environment.api.powerplatform.com/powerautomate/automations/direct/" +
+            "workflows/${"a".repeat(700)}/triggers/manual/paths/invoke?api-version=1&sig=${"b".repeat(43)}"
+        assert(longUrl.length > 255)
+
+        val savedConfiguration = configurationAdapter.setConfiguration(
+            Configuration(teamsUrl = longUrl, slackUrl = "https://slack.com"),
+        )
+        val loadedConfiguration = configurationAdapter.getConfiguration()
+
+        assert(savedConfiguration.teamsUrl == longUrl)
+        assert(loadedConfiguration.teamsUrl == longUrl)
+    }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/service/notifications/TeamsApiClientTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/service/notifications/TeamsApiClientTest.kt
@@ -12,6 +12,7 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestTemplate
+import java.net.URI
 
 class TeamsApiClientTest {
 
@@ -21,16 +22,25 @@ class TeamsApiClientTest {
 
     @Test
     fun `sends a well-formed adaptive card to the webhook`() {
+        // A Power Automate "Workflows" style URL: percent-encoded path params plus a SAS `sig` query param.
+        val webhookUrl = "https://example.webhook/triggers/manual/paths/invoke" +
+            "?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sig=abc123signature"
+        val uriSlot = slot<URI>()
         val bodySlot = slot<HttpEntity<*>>()
         every {
-            restTemplate.exchange(any<String>(), HttpMethod.POST, capture(bodySlot), String::class.java)
+            restTemplate.exchange(capture(uriSlot), HttpMethod.POST, capture(bodySlot), String::class.java)
         } returns ResponseEntity.ok("")
 
         client.sendMessage(
-            webhookUrl = "https://example.webhook",
+            webhookUrl = webhookUrl,
             title = "New Request: \"Deploy\"",
             message = "Created by Alice.\nGo to https://kviklet.example.com/requests/42 to review it.",
         )
+
+        // The webhook URL must reach RestTemplate intact, query string (and SAS signature) included,
+        // otherwise the request fails to authenticate (HTTP 401).
+        assertEquals(webhookUrl, uriSlot.captured.toString())
+        assertTrue(uriSlot.captured.rawQuery.contains("sig=abc123signature"), "SAS signature must survive")
 
         val json = objectMapper.readTree(bodySlot.captured.body as String)
 
@@ -59,7 +69,7 @@ class TeamsApiClientTest {
 
         verify {
             restTemplate.exchange(
-                "https://example.webhook",
+                URI.create(webhookUrl),
                 HttpMethod.POST,
                 any<HttpEntity<*>>(),
                 String::class.java,

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/service/notifications/TeamsApiClientTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/service/notifications/TeamsApiClientTest.kt
@@ -1,0 +1,69 @@
+package dev.kviklet.kviklet.service.notifications
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.RestTemplate
+
+class TeamsApiClientTest {
+
+    private val restTemplate = mockk<RestTemplate>()
+    private val objectMapper = ObjectMapper()
+    private val client = TeamsApiClient(restTemplate, objectMapper)
+
+    @Test
+    fun `sends a well-formed adaptive card to the webhook`() {
+        val bodySlot = slot<HttpEntity<*>>()
+        every {
+            restTemplate.exchange(any<String>(), HttpMethod.POST, capture(bodySlot), String::class.java)
+        } returns ResponseEntity.ok("")
+
+        client.sendMessage(
+            webhookUrl = "https://example.webhook",
+            title = "New Request: \"Deploy\"",
+            message = "Created by Alice.\nGo to https://kviklet.example.com/requests/42 to review it.",
+        )
+
+        val json = objectMapper.readTree(bodySlot.captured.body as String)
+
+        // It's an Adaptive Card, not the legacy MessageCard.
+        assertEquals("AdaptiveCard", json["type"].asText())
+        assertEquals("http://adaptivecards.io/schemas/adaptive-card.json", json["\$schema"].asText())
+
+        // Title is the first block, rendered as a bold heading.
+        val titleBlock = json["body"][0]
+        assertEquals("New Request: \"Deploy\"", titleBlock["text"].asText())
+        assertEquals("Bolder", titleBlock["weight"].asText())
+
+        // Message lines are present and URLs are linkified.
+        val bodyText = json["body"].joinToString(" ") { it["text"].asText() }
+        assertTrue(bodyText.contains("Created by Alice."), "message lines should be present: $bodyText")
+        assertTrue(
+            bodyText.contains("[https://kviklet.example.com/requests/42](https://kviklet.example.com/requests/42)"),
+            "url should be linkified: $bodyText",
+        )
+
+        // A single "Open in Kviklet" button links to the request.
+        val action = json["actions"][0]
+        assertEquals("Action.OpenUrl", action["type"].asText())
+        assertEquals("Open in Kviklet", action["title"].asText())
+        assertEquals("https://kviklet.example.com/requests/42", action["url"].asText())
+
+        verify {
+            restTemplate.exchange(
+                "https://example.webhook",
+                HttpMethod.POST,
+                any<HttpEntity<*>>(),
+                String::class.java,
+            )
+        }
+    }
+}

--- a/frontend/src/routes/settings/GeneralSettings.tsx
+++ b/frontend/src/routes/settings/GeneralSettings.tsx
@@ -89,8 +89,17 @@ const ConfigForm = ({
       onSubmit={(event) => void handleSubmit(onSubmit)(event)}
     >
       <span className="text-sm dark:text-slate-300">
-        See the Readme section on Notifications to see how to add webhooks, to
-        get notified in a channel when reviews are necessary.
+        See the{" "}
+        <a
+          href="https://github.com/kviklet/kviklet/blob/main/Readme.md#notifications"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+        >
+          Readme section on Notifications
+        </a>{" "}
+        to see how to add webhooks, to get notified in a channel when reviews
+        are necessary.
       </span>
       <InputField
         label="Teams Webhook URL"


### PR DESCRIPTION
Microsoft has retired the legacy Office 365 connector webhooks and replaced them with Power Automate "Workflows" webhooks. Three things broke the existing Teams integration as a result:

1. The new webhook URLs routinely exceed 255 characters, but `configuration.value` was `VARCHAR(255)`, so saving one failed with a `DataIntegrityViolationException`.
2. The modern Workflows flow renders **Adaptive Cards**, not the legacy `MessageCard` format Kviklet was sending, so even once the URL is saved the notification does not render.
3. The webhook URLs carry percent-encoded path params and a SAS `sig` query parameter. `RestTemplate.exchange(String, ...)` treats the URL as a URI template, which dropped the query string — the request reached the bare endpoint without its signature and was rejected with `HTTP 401`.

## Changes

- **Migration:** widen `configuration.value` from `VARCHAR(255)` to `TEXT`.
- **TeamsApiClient:** drop the `MessageCard` payload and send a formatted Adaptive Card instead — bold title heading, one wrapped text block per line, linkified URLs, and an "Open in Kviklet" button to the request.
- **Teams + Slack clients:** pass a parsed `URI` to `RestTemplate` instead of a raw `String`, so webhook URLs (and their query params) are used verbatim.
- **Docs:** rewrite the Teams notification section in the Readme for the Power Automate Workflow setup (the "Send webhook alerts to a channel" template plus a manual alternative), and link to that section from the notification settings page.
- **Tests:** new `TeamsApiClient` unit test asserting the Adaptive Card structure and that the full URL (incl. query string / SAS signature) is forwarded unchanged, plus a configuration test that round-trips a webhook URL longer than 255 characters.

The `sendMessage(webhookUrl, title, message)` signature is unchanged, so `NotificationHandler` is untouched.

Verified end to end against a real Teams channel: the Adaptive Card renders through the "Send webhook alerts to a channel" template.