### PR TITLE
Refetch config after login so webhook URL field isn't stale

### DIFF
--- a/frontend/src/components/ConfigProvider.tsx
+++ b/frontend/src/components/ConfigProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext, useRef } from "react";
 import {
   ConfigPayload,
   ConfigResponse,
@@ -7,11 +7,12 @@ import {
 } from "../api/ConfigApi";
 import { isApiErrorResponse } from "../api/Errors";
 import useNotification from "../hooks/useNotification";
+import { UserStatusContext } from "./UserStatusProvider";
 
 type ConfigContextType = {
   config: ConfigResponse | null;
   loading: boolean;
-  refreshConfig: () => Promise<void>;
+  refreshConfig: (background?: boolean) => Promise<void>;
   updateConfig: (config: ConfigPayload) => Promise<void>;
 };
 
@@ -31,8 +32,10 @@ export const ConfigProvider: React.FC<Props> = ({ children }) => {
   const [loading, setLoading] = useState(true);
   const { addNotification } = useNotification();
 
-  const refreshConfig = async () => {
-    setLoading(true);
+  const refreshConfig = async (background = false) => {
+    // Background refreshes (e.g. after login, or when opening settings) keep the
+    // existing UI visible instead of flashing the global loading spinner.
+    if (!background) setLoading(true);
     const response = await getConfig();
     if (isApiErrorResponse(response)) {
       addNotification({
@@ -43,7 +46,7 @@ export const ConfigProvider: React.FC<Props> = ({ children }) => {
     } else {
       setConfig(response);
     }
-    setLoading(false);
+    if (!background) setLoading(false);
   };
 
   const updateConfig = async (newConfig: ConfigPayload) => {
@@ -61,9 +64,19 @@ export const ConfigProvider: React.FC<Props> = ({ children }) => {
     setLoading(false);
   };
 
+  // The config endpoint returns the webhook URLs only to authenticated users; a
+  // logged-out fetch comes back without them. Refetch whenever the logged-in user
+  // changes (login, logout, user switch) so the config never stays stale after an
+  // initial unauthenticated load. The first fetch shows the spinner; later ones
+  // (auth transitions) refresh silently in the background.
+  const { userStatus } = useContext(UserStatusContext);
+  const userId = userStatus ? userStatus.id : null;
+  const hasLoadedOnce = useRef(false);
+
   useEffect(() => {
-    void refreshConfig();
-  }, []);
+    void refreshConfig(hasLoadedOnce.current);
+    hasLoadedOnce.current = true;
+  }, [userId]);
 
   return (
     <ConfigContext.Provider

--- a/frontend/src/routes/settings/GeneralSettings.tsx
+++ b/frontend/src/routes/settings/GeneralSettings.tsx
@@ -100,7 +100,6 @@ const ConfigForm = ({
         slackUrl: config?.slackUrl ?? "",
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [config?.teamsUrl, config?.slackUrl]);
 
   return (

--- a/frontend/src/routes/settings/GeneralSettings.tsx
+++ b/frontend/src/routes/settings/GeneralSettings.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import {
   ConfigPayload,
@@ -17,7 +18,13 @@ import {
 import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
 
 export default function GeneralSettings() {
-  const { config, loading, updateConfig } = useConfig();
+  const { config, loading, updateConfig, refreshConfig } = useConfig();
+
+  // Refresh in the background when the page opens so the webhook URLs reflect the
+  // latest server state even if the initial app-load fetch happened while logged out.
+  useEffect(() => {
+    void refreshConfig(true);
+  }, []);
 
   const onSubmit = async (data: ConfigPayload) => {
     await updateConfig(data);
@@ -74,7 +81,8 @@ const ConfigForm = ({
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    reset,
+    formState: { errors, isDirty },
   } = useForm<ConfigPayload>({
     resolver: zodResolver(ConfigPayloadSchema),
     defaultValues: {
@@ -82,6 +90,18 @@ const ConfigForm = ({
       slackUrl: config?.slackUrl,
     },
   });
+
+  // When a background refresh brings in newer config, sync it into the form — but
+  // never overwrite edits the user has already started (isDirty guard).
+  useEffect(() => {
+    if (!isDirty) {
+      reset({
+        teamsUrl: config?.teamsUrl ?? "",
+        slackUrl: config?.slackUrl ?? "",
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [config?.teamsUrl, config?.slackUrl]);
 
   return (
     <form


### PR DESCRIPTION
The config endpoint only returns the Teams/Slack webhook URLs to authenticated users — a logged-out fetch comes back without them. `ConfigProvider` sits above the auth gate and previously fetched the config only once on mount, so if that fetch happened while logged out (e.g. on the login page), the webhook URL fields stayed blank for the rest of the session even after logging in. Saving from that blank state would overwrite the stored URL with an empty value.

This refetches the config whenever the logged-in user changes (login, logout, user switch), and again in the background when opening General Settings:

- `refreshConfig` now takes a `background` flag that skips the global loading spinner.
- The provider's load effect is keyed on the logged-in user id, so any auth transition triggers a silent refetch; the initial app-load fetch still shows the spinner.
- General Settings triggers a background refresh on open and resets the form to the latest config only when it isn't dirty, so in-progress edits are never clobbered.