### PR TITLE
Surface Kubernetes pod-listing failures, upgrade Kotlin 2.2 + client-java 26

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,18 +1,19 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
     id("org.springframework.boot") version "3.4.2"
     id("io.spring.dependency-management") version "1.1.7"
-    kotlin("jvm") version "1.9.24"
-    kotlin("plugin.spring") version "1.9.24"
-    kotlin("plugin.jpa") version "1.9.24"
-    kotlin("kapt") version "1.9.24" // needed for query-dsl
+    kotlin("jvm") version "2.2.0"
+    kotlin("plugin.spring") version "2.2.0"
+    kotlin("plugin.jpa") version "2.2.0"
+    kotlin("kapt") version "2.2.0" // needed for query-dsl
 }
 
 kapt {
     javacOptions {
-        option("querydsl.entityAccessors", true)
+        option("querydsl.entityAccessors", "true")
     }
     arguments {
         arg("plugin", "com.querydsl.apt.jpa.JPAAnnotationProcessor")
@@ -57,7 +58,7 @@ dependencies {
     implementation("org.springframework.security:spring-security-config")
     implementation("org.springframework:spring-context-support")
     implementation("com.github.jsqlparser:jsqlparser:4.9")
-    implementation("io.kubernetes:client-java:24.0.0")
+    implementation("io.kubernetes:client-java:26.0.0")
     implementation("software.amazon.awssdk:rds:2.30.37")
     implementation("software.amazon.awssdk:sts:2.30.37")
 
@@ -111,9 +112,9 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs = listOf("-Xjsr305=strict")
-        jvmTarget = "21"
+    compilerOptions {
+        freeCompilerArgs.add("-Xjsr305=strict")
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/shell/KubernetesApi.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/shell/KubernetesApi.kt
@@ -5,6 +5,7 @@ import io.kubernetes.client.openapi.apis.CoreV1Api
 import io.kubernetes.client.openapi.models.V1Pod
 import io.kubernetes.client.openapi.models.V1PodList
 import io.kubernetes.client.util.Config
+import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Service
@@ -13,14 +14,25 @@ import java.util.concurrent.TimeUnit
 
 @Service
 class KubernetesApi(private val coreV1Api: CoreV1Api) {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(KubernetesApi::class.java)
+    }
+
     fun getActivePods(): List<V1Pod> {
-        try {
-            val pods: V1PodList = coreV1Api.listPodForAllNamespaces().execute()
-            return pods.items.filter { it.status?.phase == "Running" }
+        val pods: V1PodList = try {
+            coreV1Api.listPodForAllNamespaces().execute()
         } catch (e: Exception) {
-            e.printStackTrace()
-            return emptyList()
+            // Log the underlying cause (cluster unreachable, auth failure, client/server
+            // version mismatch, ...) and surface a user-friendly error instead of silently
+            // returning an empty list, which previously made failures look like "no pods".
+            logger.error("Failed to list pods from the Kubernetes cluster", e)
+            throw IllegalArgumentException(
+                "Could not list pods from the Kubernetes cluster. " +
+                    "Please check the cluster connection and the server logs for details.",
+            )
         }
+        return pods.items.orEmpty().filter { it.status?.phase == "Running" }
     }
 
     fun executeCommandOnPod(

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/KubernetesApiTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/KubernetesApiTest.kt
@@ -15,6 +15,7 @@ import io.mockk.mockkStatic
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.io.ByteArrayInputStream
 import java.util.concurrent.TimeUnit
 
@@ -62,6 +63,38 @@ class KubernetesApiTest {
         assertEquals("pod2", activePods[1].metadata?.name)
         assertEquals("default", activePods[1].metadata?.namespace)
         assertEquals("Running", activePods[1].status?.phase)
+    }
+
+    @Test
+    fun testGetActivePodsThrowsWhenApiCallFails() {
+        val mockCoreV1Api = mockk<CoreV1Api>()
+
+        every {
+            mockCoreV1Api.listPodForAllNamespaces().execute()
+        } throws RuntimeException("connection refused")
+
+        val kubernetesApi = KubernetesApi(mockCoreV1Api)
+
+        // The failure must surface instead of being swallowed into an empty list.
+        assertThrows<IllegalArgumentException> {
+            kubernetesApi.getActivePods()
+        }
+    }
+
+    @Test
+    fun testGetActivePodsReturnsEmptyWhenItemsNull() {
+        val mockCoreV1Api = mockk<CoreV1Api>()
+        val podList = mockk<V1PodList>()
+        every { podList.items } returns null
+
+        every {
+            mockCoreV1Api.listPodForAllNamespaces().execute()
+        } returns podList
+
+        val kubernetesApi = KubernetesApi(mockCoreV1Api)
+
+        // A successful call with no items is a genuinely empty cluster, not an error.
+        assertEquals(0, kubernetesApi.getActivePods().size)
     }
 
     @Test

--- a/frontend/src/routes/NewRequest.tsx
+++ b/frontend/src/routes/NewRequest.tsx
@@ -799,9 +799,17 @@ const KubernetesExecutionRequestForm = ({
                 choosePod(e.target.value);
               }}
             >
-              {pods.map((pod) => (
-                <option value={pod.id}>{pod.name}</option>
-              ))}
+              {pods.length === 0 ? (
+                <option value="" disabled>
+                  No running pods found
+                </option>
+              ) : (
+                pods.map((pod) => (
+                  <option key={pod.id} value={pod.id}>
+                    {pod.name}
+                  </option>
+                ))
+              )}
             </select>
           </div>
           <input type="hidden" id="type" {...register("type")}></input>


### PR DESCRIPTION
`getActivePods()` wrapped the Kubernetes API call in a `try/catch` that printed the exception to stdout and returned an empty list. As a result a failed pod listing was indistinguishable from a cluster with genuinely no running pods — the dropdown rendered empty with no error, and the stacktrace only ever reached stdout (never the logs).

Changes:
- Log the underlying exception (cluster unreachable, auth failure, client/server version mismatch, ...) through the logging framework instead of `printStackTrace()`.
- Raise a user-friendly error on failure, which the existing exception handler turns into a `{message}` response — the frontend already surfaces this as an error toast via the standard error pipeline.
- Treat a successful call with no items as a genuinely empty cluster (no error).
- Show a "No running pods found" placeholder in the pod dropdown when the list is empty, so the control never looks broken.

Dependency upgrade (enables newer cluster compatibility):
- Upgrade Kotlin 1.9.24 -> 2.2.0. `client-java` versions past 24.0.0 pull okhttp 5.x, which ships Kotlin 2.x metadata the 1.9 compiler cannot read, so the compiler upgrade was a prerequisite.
- Bump `io.kubernetes:client-java` 24.0.0 -> 26.0.0.
- Build-script migrations for Kotlin 2.2: `kotlinOptions` -> `compilerOptions` DSL, kapt `option()` value as a String. kapt/QueryDSL, mockk, and archunit all verified working under K2.