### PR TITLE
Normalize default role names

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/init/InitialUserInitializer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/init/InitialUserInitializer.kt
@@ -20,7 +20,7 @@ class InitialUserInitializer(private val roleRepository: RoleRepository) {
 
     fun createAdminRole(savedUser: UserEntity) {
         val role = RoleEntity(
-            name = "Admin role",
+            name = "Admin",
             description = "This role gives admin permissions on everything",
             policies = mutableSetOf(
                 PolicyEntity(
@@ -37,7 +37,7 @@ class InitialUserInitializer(private val roleRepository: RoleRepository) {
 
     fun createDevRole() {
         val role = RoleEntity(
-            name = "Developer Role",
+            name = "Developer",
             description = "This role gives permission to create, review and execute requests",
             policies = mutableSetOf(
                 PolicyEntity(

--- a/backend/src/main/resources/changelog/000-changelog.yaml
+++ b/backend/src/main/resources/changelog/000-changelog.yaml
@@ -134,3 +134,6 @@ databaseChangeLog:
   - include:
       file: 046-role-sync-mapping-composite-unique.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 047-normalize-default-role-names.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/changelog/047-normalize-default-role-names.yaml
+++ b/backend/src/main/resources/changelog/047-normalize-default-role-names.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 047-normalize-default-role-names
+      author: jascha
+      changes:
+        # Normalize the factory-default role names by dropping the redundant "role"
+        # suffix. Guarded by the exact old name so operator-renamed roles are left
+        # untouched (these roles are seeded with random ids, so we cannot guard by id).
+        - sql:
+            sql: "UPDATE role SET name = 'Admin' WHERE name = 'Admin role'"
+        - sql:
+            sql: "UPDATE role SET name = 'Developer' WHERE name = 'Developer Role'"

--- a/e2e/tests/pages.ts
+++ b/e2e/tests/pages.ts
@@ -49,7 +49,7 @@ class SettingsPage {
     const userRow = this.page.getByTestId(`user-${email}`);
     const roleCombobox = userRow.getByTestId("role-combobox-button");
     await roleCombobox.click();
-    await this.page.getByTestId("role-combobox-option-Developer Role").click();
+    await this.page.getByTestId("role-combobox-option-Developer").click();
     await roleCombobox.click();
 
     await expect(roleCombobox).toContainText("Developer", { timeout: 5000 });

--- a/e2e/tests/pages.ts
+++ b/e2e/tests/pages.ts
@@ -50,9 +50,12 @@ class SettingsPage {
     const roleCombobox = userRow.getByTestId("role-combobox-button");
     await roleCombobox.click();
     await this.page.getByTestId("role-combobox-option-Developer").click();
-    await roleCombobox.click();
 
-    await expect(roleCombobox).toContainText("Developer", { timeout: 5000 });
+    // Selecting a role triggers an async save; wait for it to land (the button
+    // text reflects the saved roles) before closing the dropdown, otherwise the
+    // close click can race with the update and the selection is dropped.
+    await expect(roleCombobox).toContainText("Developer", { timeout: 10000 });
+    await roleCombobox.click();
   }
 
   async createConnection(


### PR DESCRIPTION
The factory-default roles shipped as `Default`, `Developer Role`, and `Admin role` — mixed capitalization on the `role` suffix, and one of the three had no suffix. Since these names render right next to the word "role" in dropdowns and audit entries, the suffix is also redundant.

This renames the production seed roles to `Developer` and `Admin` (matching `Default`), and adds a guarded migration that renames them on existing installs. The migration matches only the exact factory-default names, so any role an operator has renamed is left untouched.