### PR TITLE
Reflect connection type in the new-request header

### DIFF
--- a/frontend/src/routes/NewRequest.test.tsx
+++ b/frontend/src/routes/NewRequest.test.tsx
@@ -76,10 +76,8 @@ describe("NewRequest - Basic functionality", () => {
       </MemoryRouter>,
     );
 
-    // Check that the page title is rendered
-    expect(
-      screen.getByText("Request Access to a Database"),
-    ).toBeInTheDocument();
+    // Check that the page title is rendered (generic, since no connection is chosen yet)
+    expect(screen.getByText("Request Access")).toBeInTheDocument();
 
     // Wait for loading to complete and connections section to appear
     await waitFor(() => {

--- a/frontend/src/routes/NewRequest.tsx
+++ b/frontend/src/routes/NewRequest.tsx
@@ -230,7 +230,11 @@ export default function ConnectionChooser() {
       <div className=" border-b border-slate-300 bg-slate-50 dark:border-slate-700 dark:bg-slate-950">
         <h1 className=" m-5 mx-auto max-w-5xl pl-1.5 text-xl">
           {" "}
-          Request Access to a Database
+          {chosenConnection?._type === "KUBERNETES"
+            ? "Request Access to a Kubernetes Pod"
+            : chosenConnection?._type === "DATASOURCE"
+            ? "Request Access to a Database"
+            : "Request Access"}
         </h1>
       </div>
       <div className="mx-auto mt-5 flex max-w-5xl">


### PR DESCRIPTION
The create-request screen's header was hard-coded to "Request Access to a Database", so it showed the database wording even when requesting access to a Kubernetes connection.

The header now reflects the chosen connection: "Request Access to a Kubernetes Pod" for Kubernetes connections, "Request Access to a Database" for datasources, and a generic "Request Access" before a connection is selected.