### PR TITLE
Fix false JSON error when deleting a role-sync mapping (#466)

### DIFF
--- a/frontend/src/api/RoleSyncConfigApi.ts
+++ b/frontend/src/api/RoleSyncConfigApi.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import baseUrl from "./base";
-import { ApiResponse, fetchWithErrorHandling } from "./Errors";
+import {
+  ApiErrorResponse,
+  ApiResponse,
+  fetchEmptyWithErrorHandling,
+  fetchWithErrorHandling,
+} from "./Errors";
 
 // Zod schemas
 const RoleSyncMappingSchema = z.object({
@@ -91,13 +96,14 @@ export async function addRoleSyncMapping(
 
 export async function deleteRoleSyncMapping(
   id: string,
-): Promise<ApiResponse<void>> {
-  return fetchWithErrorHandling(
+): Promise<ApiErrorResponse | null> {
+  // DELETE returns 204 No Content, so use the empty-body aware helper to avoid
+  // a spurious JSON parse error on the empty response.
+  return fetchEmptyWithErrorHandling(
     `${baseUrl}/config/role-sync/mappings/${id}`,
     {
       method: "DELETE",
       credentials: "include",
     },
-    z.undefined(),
   );
 }


### PR DESCRIPTION
Deleting a role-sync mapping returned a `204 No Content`, but the frontend `deleteRoleSyncMapping` used `fetchWithErrorHandling`, which unconditionally calls `response.json()` on the empty body. That parse threw and surfaced a misleading error toast even though the delete succeeded.

Switches the call to the existing `fetchEmptyWithErrorHandling` helper, which short-circuits on `204` / `Content-Length: 0` and returns `null` on success.

Fixes #466.