### PR TITLE
Allow clearing a connection category once set (#470)

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConnectionController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConnectionController.kt
@@ -172,6 +172,10 @@ data class UpdateDatasourceConnectionRequest(
 
     val category: String? = null,
 
+    // Using an extra clear flag because the patch requests don't differentiate between
+    // null and not present.
+    val clearCategory: Boolean = false,
+
     val dryRunEnabled: Boolean? = null,
 
     val dryRunRequiresApproval: Boolean? = null,
@@ -191,6 +195,10 @@ data class UpdateKubernetesConnectionRequest(
     val storeResults: Boolean? = null,
 
     val category: String? = null,
+
+    // Using an extra clear flag because the patch requests don't differentiate between
+    // null and not present.
+    val clearCategory: Boolean = false,
 
     @field:Min(1)
     val kubernetesExecInitialWaitTimeoutSeconds: Long? = null,

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ConnectionService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ConnectionService.kt
@@ -91,7 +91,7 @@ class ConnectionService(
             } else {
                 (request.maxTemporaryAccessDuration ?: connection.maxTemporaryAccessDuration)
             },
-            category = request.category ?: connection.category,
+            category = if (request.clearCategory) null else (request.category ?: connection.category),
             dryRunEnabled = request.dryRunEnabled ?: connection.dryRunEnabled,
             dryRunRequiresApproval = request.dryRunRequiresApproval ?: connection.dryRunRequiresApproval,
         )
@@ -166,7 +166,7 @@ class ConnectionService(
             newReviewConfig,
             newMaxExecutions,
             request.storeResults ?: connection.storeResults,
-            category = request.category ?: connection.category,
+            category = if (request.clearCategory) null else (request.category ?: connection.category),
             kubernetesExecInitialWaitTimeoutSeconds = newInitialWaitTimeoutSeconds,
             kubernetesExecTimeoutMinutes = newTimeoutMinutes,
         )

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ConnectionCategoryTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ConnectionCategoryTest.kt
@@ -2,6 +2,7 @@ package dev.kviklet.kviklet
 
 import dev.kviklet.kviklet.db.ConnectionRepository
 import dev.kviklet.kviklet.helper.UserHelper
+import org.hamcrest.CoreMatchers.nullValue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -120,6 +121,64 @@ class ConnectionCategoryTest(
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.category").value("Production"))
+    }
+
+    @Test
+    fun `clear connection category via PATCH with clearCategory flag`() {
+        userHelper.createUser(listOf("*"))
+        val cookie = userHelper.login(mockMvc = mockMvc)
+
+        // Create connection with a category
+        val createJson = """
+            {
+                "connectionType": "DATASOURCE",
+                "id": "clear-category-conn",
+                "displayName": "Clear Category Test",
+                "username": "root",
+                "password": "root",
+                "type": "MYSQL",
+                "hostname": "localhost",
+                "port": 3306,
+                "category": "Production",
+                "reviewConfig": {
+                    "numTotalRequired": 1
+                }
+            }
+        """.trimIndent()
+
+        mockMvc.perform(
+            post("/connections/")
+                .cookie(cookie)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createJson),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.category").value("Production"))
+
+        // Clear the category via the clearCategory flag
+        val clearJson = """
+            {
+                "connectionType": "DATASOURCE",
+                "clearCategory": true
+            }
+        """.trimIndent()
+
+        mockMvc.perform(
+            patch("/connections/clear-category-conn")
+                .cookie(cookie)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(clearJson),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.category", nullValue()))
+
+        // Verify the cleared category is persisted
+        mockMvc.perform(
+            get("/connections/clear-category-conn")
+                .cookie(cookie),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.category", nullValue()))
     }
 
     @Test

--- a/frontend/src/api/DatasourceApi.ts
+++ b/frontend/src/api/DatasourceApi.ts
@@ -159,6 +159,7 @@ type PatchDatabaseConnectionPayload = DatabaseConnection extends infer T
         "id"
       > & {
         clearMaxTempDuration?: boolean;
+        clearCategory?: boolean;
       }
     : never
   : never;
@@ -166,7 +167,9 @@ type PatchDatabaseConnectionPayload = DatabaseConnection extends infer T
 type PatchKubernetesConnectionPayload = Omit<
   AllNullableExcept<KubernetesConnection, "connectionType">,
   "id"
->;
+> & {
+  clearCategory?: boolean;
+};
 
 type PatchConnectionPayload =
   | PatchDatabaseConnectionPayload

--- a/frontend/src/hooks/connections.ts
+++ b/frontend/src/hooks/connections.ts
@@ -130,6 +130,9 @@ const useConnection = (id: string) => {
     }
     const normalizedConnection =
       normalizeMaxTemporaryAccessDuration(patchedConnection);
+    // The PATCH endpoint can't distinguish null from "not provided", so signal an
+    // explicit clear when the category has been removed.
+    normalizedConnection.clearCategory = !patchedConnection.category;
     const response = await patchConnection(normalizedConnection, connection.id);
     if (isApiErrorResponse(response)) {
       addNotification({


### PR DESCRIPTION
Once a connection had a category, it couldn't be removed: the PATCH endpoint coalesced the incoming value with `request.category ?: connection.category`, so a cleared `null` always fell back to the previously stored category.

This mirrors the existing `clearMaxTempDuration` pattern (the patch DTOs can't distinguish `null` from "not provided"):

- Backend: add a `clearCategory` flag to the datasource and Kubernetes patch requests; when set, the service stores `null` instead of falling back to the existing value.
- Frontend: the connection edit hook sends `clearCategory: true` whenever the category field has been emptied.

Adds a backend test covering clearing a category via PATCH.

Fixes #470.