### PR TITLE
Validate create-user form fields client-side

### DIFF
--- a/frontend/src/api/UserApi.ts
+++ b/frontend/src/api/UserApi.ts
@@ -13,9 +13,18 @@ const userResponseSchema = z.object({
 type UserResponse = z.infer<typeof userResponseSchema>;
 
 const createUserRequestSchema = z.object({
-  email: z.string().min(3).max(50),
-  password: z.string().min(6).max(50),
-  fullName: z.string().min(1).max(50),
+  email: z
+    .string()
+    .min(3, "Email must be between 3 and 50 characters.")
+    .max(50, "Email must be between 3 and 50 characters."),
+  password: z
+    .string()
+    .min(6, "Password must be between 6 and 50 characters.")
+    .max(50, "Password must be between 6 and 50 characters."),
+  fullName: z
+    .string()
+    .min(1, "Full name is required.")
+    .max(50, "Full name must be at most 50 characters."),
 });
 
 const usersResponseSchema = z.object({
@@ -80,5 +89,11 @@ async function updateUser(
   );
 }
 
-export { fetchUsers, userResponseSchema, createUser, updateUser };
-export type { UserResponse };
+export {
+  fetchUsers,
+  userResponseSchema,
+  createUser,
+  createUserRequestSchema,
+  updateUser,
+};
+export type { UserResponse, CreateUserRequest };

--- a/frontend/src/routes/settings/UserSettings.tsx
+++ b/frontend/src/routes/settings/UserSettings.tsx
@@ -25,9 +25,45 @@ function UserForm(props: {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [fullName, setFullName] = useState("");
+  const [errors, setErrors] = useState<{
+    email?: string;
+    password?: string;
+    fullName?: string;
+  }>({});
+
+  // Mirrors the backend validation on CreateUserRequest so that missing or
+  // invalid fields surface as inline messages instead of an unhandled error.
+  const validate = () => {
+    const newErrors: {
+      email?: string;
+      password?: string;
+      fullName?: string;
+    } = {};
+    if (email.trim().length === 0) {
+      newErrors.email = "Email is required.";
+    } else if (email.length < 3 || email.length > 50) {
+      newErrors.email = "Email must be between 3 and 50 characters.";
+    }
+    if (password.length === 0) {
+      newErrors.password = "Password is required.";
+    } else if (password.length < 6 || password.length > 50) {
+      newErrors.password = "Password must be between 6 and 50 characters.";
+    }
+    if (fullName.trim().length === 0) {
+      newErrors.fullName = "Full name is required.";
+    } else if (fullName.length > 50) {
+      newErrors.fullName = "Full name must be at most 50 characters.";
+    }
+    return newErrors;
+  };
 
   const saveUser = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    const validationErrors = validate();
+    setErrors(validationErrors);
+    if (Object.keys(validationErrors).length > 0) {
+      return;
+    }
     props
       .createNewUser(email, password, fullName)
       .then(() => {
@@ -45,9 +81,11 @@ function UserForm(props: {
             id="email"
             label="Email"
             value={email}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setEmail(e.target.value)
-            }
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setEmail(e.target.value);
+              setErrors((prev) => ({ ...prev, email: undefined }));
+            }}
+            error={errors.email}
             data-testid="email-input"
           />
         </div>
@@ -57,9 +95,11 @@ function UserForm(props: {
             label="Password"
             type="passwordlike"
             value={password}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setPassword(e.target.value)
-            }
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setPassword(e.target.value);
+              setErrors((prev) => ({ ...prev, password: undefined }));
+            }}
+            error={errors.password}
             data-testid="password-input"
           />
         </div>
@@ -68,9 +108,11 @@ function UserForm(props: {
             id="fullName"
             label="Full Name"
             value={fullName}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setFullName(e.target.value)
-            }
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setFullName(e.target.value);
+              setErrors((prev) => ({ ...prev, fullName: undefined }));
+            }}
+            error={errors.fullName}
             data-testid="name-input"
           />
         </div>

--- a/frontend/src/routes/settings/UserSettings.tsx
+++ b/frontend/src/routes/settings/UserSettings.tsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import Button from "../../components/Button";
 import {
+  CreateUserRequest,
   UserResponse,
   createUser,
+  createUserRequestSchema,
   fetchUsers,
   updateUser,
 } from "../../api/UserApi";
@@ -22,71 +26,37 @@ function UserForm(props: {
     fullName: string,
   ) => Promise<void>;
 }) {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [fullName, setFullName] = useState("");
-  const [errors, setErrors] = useState<{
-    email?: string;
-    password?: string;
-    fullName?: string;
-  }>({});
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<CreateUserRequest>({
+    resolver: zodResolver(createUserRequestSchema),
+    defaultValues: { email: "", password: "", fullName: "" },
+  });
 
-  // Mirrors the backend validation on CreateUserRequest so that missing or
-  // invalid fields surface as inline messages instead of an unhandled error.
-  const validate = () => {
-    const newErrors: {
-      email?: string;
-      password?: string;
-      fullName?: string;
-    } = {};
-    if (email.trim().length === 0) {
-      newErrors.email = "Email is required.";
-    } else if (email.length < 3 || email.length > 50) {
-      newErrors.email = "Email must be between 3 and 50 characters.";
-    }
-    if (password.length === 0) {
-      newErrors.password = "Password is required.";
-    } else if (password.length < 6 || password.length > 50) {
-      newErrors.password = "Password must be between 6 and 50 characters.";
-    }
-    if (fullName.trim().length === 0) {
-      newErrors.fullName = "Full name is required.";
-    } else if (fullName.length > 50) {
-      newErrors.fullName = "Full name must be at most 50 characters.";
-    }
-    return newErrors;
-  };
-
-  const saveUser = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const validationErrors = validate();
-    setErrors(validationErrors);
-    if (Object.keys(validationErrors).length > 0) {
-      return;
-    }
-    props
-      .createNewUser(email, password, fullName)
-      .then(() => {
-        props.disableModal();
-      })
-      .catch((err) => console.log(err));
+  // Validation mirrors the backend CreateUserRequest constraints via the shared
+  // createUserRequestSchema, so missing or invalid fields surface as inline
+  // messages instead of an unhandled error.
+  const onSubmit = async (data: CreateUserRequest) => {
+    await props.createNewUser(data.email, data.password, data.fullName);
+    props.disableModal();
   };
 
   return (
-    <form method="post" onSubmit={saveUser}>
+    <form
+      method="post"
+      onSubmit={(event) => void handleSubmit(onSubmit)(event)}
+    >
       <div className="w-2xl rounded bg-slate-50 p-3 shadow dark:bg-slate-900">
         <h2 className="mb-4 text-lg font-semibold">Create New User</h2>
         <div className="mb-3 flex flex-col">
           <InputField
             id="email"
             label="Email"
-            value={email}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setEmail(e.target.value);
-              setErrors((prev) => ({ ...prev, email: undefined }));
-            }}
-            error={errors.email}
+            error={errors.email?.message}
             data-testid="email-input"
+            {...register("email")}
           />
         </div>
         <div className="mb-3 flex flex-col">
@@ -94,26 +64,18 @@ function UserForm(props: {
             id="password"
             label="Password"
             type="passwordlike"
-            value={password}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setPassword(e.target.value);
-              setErrors((prev) => ({ ...prev, password: undefined }));
-            }}
-            error={errors.password}
+            error={errors.password?.message}
             data-testid="password-input"
+            {...register("password")}
           />
         </div>
         <div className="mb-3 flex flex-col">
           <InputField
             id="fullName"
             label="Full Name"
-            value={fullName}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setFullName(e.target.value);
-              setErrors((prev) => ({ ...prev, fullName: undefined }));
-            }}
-            error={errors.fullName}
+            error={errors.fullName?.message}
             data-testid="name-input"
+            {...register("fullName")}
           />
         </div>
         <div className="mb-3 flex flex-row justify-end space-x-2">


### PR DESCRIPTION
Adds inline, field-level validation to the "Create New User" form in user settings.

Previously, submitting the form with a missing or invalid field (e.g. an empty full name) surfaced an unhandled error rather than a clear message. The form now validates email, password, and full name on submit, mirroring the backend `CreateUserRequest` constraints (`@NotBlank` / `@Size`):

- Email — required, 3–50 characters
- Password — required, 6–50 characters
- Full name — required, max 50 characters

Errors render under each field and clear as the user edits. Reported during an enterprise trial.