### PR TITLE
Populate Kubernetes request fields once pods load (#472)

### DIFF
--- a/frontend/src/routes/NewRequest.tsx
+++ b/frontend/src/routes/NewRequest.tsx
@@ -695,8 +695,30 @@ const KubernetesExecutionRequestForm = ({
       setChosenPod(selectedPod);
       setValue("podName", selectedPod.name);
       setValue("namespace", selectedPod.namespace);
+      setValue("containerName", selectedPod.containerNames[0] ?? "");
     }
   };
+
+  // The pod dropdown's first option is shown as selected by the browser, but that
+  // never fires onChange, so the derived namespace/pod/container fields would stay
+  // blank until the user re-picks a pod. Once the pods load, commit a selection to
+  // form state. A pod pre-filled from a "re-run" link takes precedence.
+  useEffect(() => {
+    if (pods.length === 0 || chosenPod) {
+      return;
+    }
+    const state = location.state as PreConfiguredStateKubernetes | null;
+    if (state?.podName) {
+      const preselected = pods.find(
+        (p) => p.name === state.podName && p.namespace === state.namespace,
+      );
+      if (preselected) {
+        setChosenPod(preselected);
+      }
+      return;
+    }
+    choosePod(pods[0].id);
+  }, [pods, chosenPod, location.state]);
 
   const onSubmit: SubmitHandler<KubernetesExecutionRequest> = async (
     data: KubernetesExecutionRequest,
@@ -799,6 +821,7 @@ const KubernetesExecutionRequestForm = ({
             </label>
             <select
               className="mt-2 block w-full rounded-md border-0 pr-10 text-slate-900 focus:ring-0 focus-visible:outline-none dark:bg-slate-950 dark:text-slate-300 sm:text-sm sm:leading-6"
+              value={chosenPod?.id ?? ""}
               onChange={(e: ChangeEvent<HTMLSelectElement>) => {
                 choosePod(e.target.value);
               }}


### PR DESCRIPTION
When creating a request against a Kubernetes connection, the pod dropdown populated correctly but the derived **Namespace**, **Pod Name**, and **Container Name** fields stayed blank on first load. The user had to manually re-pick the pod before those fields filled in.

Cause: the pod `<select>` was uncontrolled. The browser shows the first option as selected, but that never fires `onChange`, so `choosePod()` was never called and the form state for the dependent fields was never set. `choosePod()` also never seeded the container field.

Changes:
- Add an effect that commits a pod selection to form state once the pod list loads. A pod pre-filled from a "re-run" link takes precedence (it isn't overwritten).
- `choosePod()` now also sets `containerName` to the pod's first container.
- Make the pod `<select>` controlled (`value={chosenPod?.id}`) so it always reflects the actual selection.

Note: a loading indicator already exists — the whole form is gated behind a `<Spinner>` while the pods are being fetched — so no change was needed there.

Fixes #472.