### PR TITLE
Auto-dismiss toasts and remove them from the queue (#476)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "test",
       "version": "0.1.0",
       "dependencies": {
+        "@formkit/auto-animate": "^0.9.0",
         "@fortawesome/fontawesome-svg-core": "^6.3.0",
         "@fortawesome/free-regular-svg-icons": "^6.3.0",
         "@fortawesome/free-solid-svg-icons": "^6.3.0",
@@ -952,6 +953,12 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
       "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
+    },
+    "node_modules/@formkit/auto-animate": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@formkit/auto-animate/-/auto-animate-0.9.0.tgz",
+      "integrity": "sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==",
+      "license": "MIT"
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.4.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@formkit/auto-animate": "^0.9.0",
     "@fortawesome/fontawesome-svg-core": "^6.3.0",
     "@fortawesome/free-regular-svg-icons": "^6.3.0",
     "@fortawesome/free-solid-svg-icons": "^6.3.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { Route, Navigate, Routes } from "react-router-dom";
 import Settings from "./routes/settings/Settings";
-import DefaultLayout from "./layout/DefaultLayout";
+import RootLayout from "./layout/RootLayout";
 import { Requests } from "./routes/Requests";
 import Login from "./routes/Login";
 import { ReactElement, useContext } from "react";
@@ -41,7 +41,7 @@ function App() {
           <NotificationContextProvider>
             <ConfigProvider>
               <Routes>
-                <Route path="/" element={<DefaultLayout />}>
+                <Route path="/" element={<RootLayout />}>
                   <Route
                     index
                     element={

--- a/frontend/src/components/NotifcationStatusProvider.tsx
+++ b/frontend/src/components/NotifcationStatusProvider.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from "react";
 
-type Notification = {
+type NotificationInput = {
   title: string;
   text: string;
   type: "info" | "error";
 };
 
+type Notification = NotificationInput & { id: number };
+
 type NotificationContext = {
   notifications: Notification[];
-  addNotification: (notification: Notification) => void;
-  removeNotification: (notification: Notification) => void;
+  addNotification: (notification: NotificationInput) => void;
+  removeNotification: (id: number) => void;
 };
 
 const NotificationContext = React.createContext<NotificationContext>({
@@ -22,16 +24,22 @@ type Props = {
   children: React.ReactNode;
 };
 
+let nextNotificationId = 0;
+
 export const NotificationContextProvider: React.FC<Props> = ({ children }) => {
   const [notifications, setNotifications] = useState<Notification[]>([]);
 
-  const addNotification = (notification: Notification) => {
-    setNotifications((notifications) => [...notifications, notification]);
+  const addNotification = (notification: NotificationInput) => {
+    const id = nextNotificationId++;
+    setNotifications((notifications) => [
+      ...notifications,
+      { ...notification, id },
+    ]);
   };
 
-  const removeNotification = (notification: Notification) => {
+  const removeNotification = (id: number) => {
     setNotifications((notifications) => {
-      return notifications.filter((n) => n !== notification);
+      return notifications.filter((n) => n.id !== id);
     });
   };
 

--- a/frontend/src/components/Notification.tsx
+++ b/frontend/src/components/Notification.tsx
@@ -1,10 +1,32 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Transition } from "@headlessui/react";
 import { CheckCircleIcon } from "@heroicons/react/24/outline";
 import { XMarkIcon } from "@heroicons/react/20/solid";
 
-export default function Notification(props: { title: string; text: string }) {
+// Auto-dismiss timings. Errors linger a bit longer so they can be read.
+const INFO_DISMISS_MS = 5000;
+const ERROR_DISMISS_MS = 8000;
+// Matches the leave transition duration below, so the toast is removed from the
+// list only after it has animated out.
+const LEAVE_TRANSITION_MS = 150;
+
+export default function Notification(props: {
+  title: string;
+  text: string;
+  onClose: () => void;
+}) {
   const [show, setShow] = useState(true);
+
+  const handleClose = () => {
+    setShow(false);
+    setTimeout(props.onClose, LEAVE_TRANSITION_MS);
+  };
+
+  useEffect(() => {
+    const timer = setTimeout(handleClose, INFO_DISMISS_MS);
+    return () => clearTimeout(timer);
+    // Set the auto-dismiss timer once on mount.
+  }, []);
 
   return (
     <Transition
@@ -40,9 +62,7 @@ export default function Notification(props: { title: string; text: string }) {
               <button
                 type="button"
                 className="inline-flex rounded-md text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 hover:text-slate-500"
-                onClick={() => {
-                  setShow(false);
-                }}
+                onClick={handleClose}
               >
                 <span className="sr-only">Close</span>
                 <XMarkIcon className="h-5 w-5" aria-hidden="true" />
@@ -55,8 +75,23 @@ export default function Notification(props: { title: string; text: string }) {
   );
 }
 
-function ErrorNotification(props: { title: string; text: string }) {
+function ErrorNotification(props: {
+  title: string;
+  text: string;
+  onClose: () => void;
+}) {
   const [show, setShow] = useState(true);
+
+  const handleClose = () => {
+    setShow(false);
+    setTimeout(props.onClose, LEAVE_TRANSITION_MS);
+  };
+
+  useEffect(() => {
+    const timer = setTimeout(handleClose, ERROR_DISMISS_MS);
+    return () => clearTimeout(timer);
+    // Set the auto-dismiss timer once on mount.
+  }, []);
 
   return (
     <Transition
@@ -89,9 +124,7 @@ function ErrorNotification(props: { title: string; text: string }) {
               <button
                 type="button"
                 className="inline-flex rounded-md text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 hover:text-slate-500"
-                onClick={() => {
-                  setShow(false);
-                }}
+                onClick={handleClose}
               >
                 <span className="sr-only">Close</span>
                 <XMarkIcon className="h-5 w-5" aria-hidden="true" />

--- a/frontend/src/components/Notification.tsx
+++ b/frontend/src/components/Notification.tsx
@@ -1,77 +1,56 @@
-import { useEffect, useState } from "react";
-import { Transition } from "@headlessui/react";
+import { useEffect } from "react";
 import { CheckCircleIcon } from "@heroicons/react/24/outline";
 import { XMarkIcon } from "@heroicons/react/20/solid";
 
 // Auto-dismiss timings. Errors linger a bit longer so they can be read.
 const INFO_DISMISS_MS = 5000;
 const ERROR_DISMISS_MS = 8000;
-// Matches the leave transition duration below, so the toast is removed from the
-// list only after it has animated out.
-const LEAVE_TRANSITION_MS = 150;
 
 export default function Notification(props: {
   title: string;
   text: string;
   onClose: () => void;
 }) {
-  const [show, setShow] = useState(true);
-
-  const handleClose = () => {
-    setShow(false);
-    setTimeout(props.onClose, LEAVE_TRANSITION_MS);
-  };
-
   useEffect(() => {
-    const timer = setTimeout(handleClose, INFO_DISMISS_MS);
+    const timer = setTimeout(props.onClose, INFO_DISMISS_MS);
     return () => clearTimeout(timer);
     // Set the auto-dismiss timer once on mount.
   }, []);
 
   return (
-    <Transition
-      show={show}
-      enter="transform ease-out duration-300 transition"
-      enterFrom="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
-      enterTo="translate-y-0 opacity-100 sm:translate-x-0"
-      leave="transition ease-in duration-100"
-      leaveFrom="opacity-100"
-      leaveTo="opacity-0"
-    >
-      <div
-        className="pointer-events-auto ml-auto w-full max-w-sm overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5
+    <div
+      className="pointer-events-auto ml-auto w-full max-w-sm overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5
       dark:border dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:shadow-none"
-      >
-        <div className="p-4">
-          <div className="flex items-start">
-            <div className="flex-shrink-0">
-              <CheckCircleIcon
-                className="h-6 w-6 text-green-400"
-                aria-hidden="true"
-              />
-            </div>
-            <div className="ml-3 w-0 flex-1 pt-0.5">
-              <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
-                {props.title}
-              </p>
-              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                {props.text}
-              </p>
-            </div>
-            <div className="ml-4 flex flex-shrink-0">
-              <button
-                type="button"
-                className="inline-flex rounded-md text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 hover:text-slate-500"
-                onClick={handleClose}
-              >
-                <span className="sr-only">Close</span>
-                <XMarkIcon className="h-5 w-5" aria-hidden="true" />
-              </button>
-            </div>
+    >
+      <div className="p-4">
+        <div className="flex items-start">
+          <div className="flex-shrink-0">
+            <CheckCircleIcon
+              className="h-6 w-6 text-green-400"
+              aria-hidden="true"
+            />
+          </div>
+          <div className="ml-3 w-0 flex-1 pt-0.5">
+            <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+              {props.title}
+            </p>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              {props.text}
+            </p>
+          </div>
+          <div className="ml-4 flex flex-shrink-0">
+            <button
+              type="button"
+              className="inline-flex rounded-md text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 hover:text-slate-500"
+              onClick={props.onClose}
+            >
+              <span className="sr-only">Close</span>
+              <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+            </button>
           </div>
         </div>
       </div>
-    </Transition>
+    </div>
   );
 }
 
@@ -80,60 +59,43 @@ function ErrorNotification(props: {
   text: string;
   onClose: () => void;
 }) {
-  const [show, setShow] = useState(true);
-
-  const handleClose = () => {
-    setShow(false);
-    setTimeout(props.onClose, LEAVE_TRANSITION_MS);
-  };
-
   useEffect(() => {
-    const timer = setTimeout(handleClose, ERROR_DISMISS_MS);
+    const timer = setTimeout(props.onClose, ERROR_DISMISS_MS);
     return () => clearTimeout(timer);
     // Set the auto-dismiss timer once on mount.
   }, []);
 
   return (
-    <Transition
-      show={show}
-      enter="transform ease-out duration-300 transition"
-      enterFrom="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
-      enterTo="translate-y-0 opacity-100 sm:translate-x-0"
-      leave="transition ease-in duration-100"
-      leaveFrom="opacity-100"
-      leaveTo="opacity-0"
-    >
-      <div
-        className="pointer-events-auto ml-auto w-full max-w-sm overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5
+    <div
+      className="pointer-events-auto ml-auto w-full max-w-sm overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5
       dark:border dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:shadow-none"
-      >
-        <div className="p-4">
-          <div className="flex items-start">
-            <div className="flex-shrink-0">
-              <XMarkIcon className="h-6 w-6 text-red-400" aria-hidden="true" />
-            </div>
-            <div className="ml-3 w-0 flex-1 pt-0.5">
-              <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
-                {props.title}
-              </p>
-              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                {props.text}
-              </p>
-            </div>
-            <div className="ml-4 flex flex-shrink-0">
-              <button
-                type="button"
-                className="inline-flex rounded-md text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 hover:text-slate-500"
-                onClick={handleClose}
-              >
-                <span className="sr-only">Close</span>
-                <XMarkIcon className="h-5 w-5" aria-hidden="true" />
-              </button>
-            </div>
+    >
+      <div className="p-4">
+        <div className="flex items-start">
+          <div className="flex-shrink-0">
+            <XMarkIcon className="h-6 w-6 text-red-400" aria-hidden="true" />
+          </div>
+          <div className="ml-3 w-0 flex-1 pt-0.5">
+            <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+              {props.title}
+            </p>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              {props.text}
+            </p>
+          </div>
+          <div className="ml-4 flex flex-shrink-0">
+            <button
+              type="button"
+              className="inline-flex rounded-md text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 hover:text-slate-500"
+              onClick={props.onClose}
+            >
+              <span className="sr-only">Close</span>
+              <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+            </button>
           </div>
         </div>
       </div>
-    </Transition>
+    </div>
   );
 }
 

--- a/frontend/src/layout/DefaultLayout.tsx
+++ b/frontend/src/layout/DefaultLayout.tsx
@@ -6,7 +6,7 @@ import { NotificationContext } from "../components/NotifcationStatusProvider";
 import { useContext } from "react";
 
 function DefaultLayout() {
-  const { notifications } =
+  const { notifications, removeNotification } =
     useContext<NotificationContext>(NotificationContext);
 
   return (
@@ -25,15 +25,19 @@ function DefaultLayout() {
             if (notification.type === "info") {
               return (
                 <Notification
+                  key={notification.id}
                   title={notification.title}
                   text={notification.text}
+                  onClose={() => removeNotification(notification.id)}
                 />
               );
             } else {
               return (
                 <ErrorNotification
+                  key={notification.id}
                   title={notification.title}
                   text={notification.text}
+                  onClose={() => removeNotification(notification.id)}
                 />
               );
             }

--- a/frontend/src/layout/DefaultLayout.tsx
+++ b/frontend/src/layout/DefaultLayout.tsx
@@ -4,10 +4,52 @@ import { Outlet } from "react-router-dom";
 import Notification, { ErrorNotification } from "../components/Notification";
 import { NotificationContext } from "../components/NotifcationStatusProvider";
 import { useContext } from "react";
+import { useAutoAnimate } from "@formkit/auto-animate/react";
+import type { AutoAnimationPlugin } from "@formkit/auto-animate";
+
+const ANIMATION_MS = 200;
+
+// Custom plugin: animate toasts with opacity + translate only. The default
+// auto-animate plugin grows added elements from zero width/height, which makes
+// the overflow-hidden cards visibly squish/shrink for a frame.
+// NOTE: at runtime auto-animate calls the plugin as
+// (el, "remain", oldCoords, newCoords) — the reverse of its published types,
+// so we name the positional args by what they actually receive.
+const notificationAnimation: AutoAnimationPlugin = (
+  el,
+  action,
+  oldCoords,
+  newCoords,
+) => {
+  let keyframes: Keyframe[] = [];
+  if (action === "add") {
+    keyframes = [
+      { opacity: 0, transform: "translateX(1rem)" },
+      { opacity: 1, transform: "translateX(0)" },
+    ];
+  } else if (action === "remove") {
+    keyframes = [
+      { opacity: 1, transform: "translateX(0)" },
+      { opacity: 0, transform: "translateX(1rem)" },
+    ];
+  } else if (oldCoords && newCoords) {
+    // remain: slide existing toasts from their old position to the new one.
+    const deltaY = oldCoords.top - newCoords.top;
+    keyframes = [
+      { transform: `translateY(${deltaY}px)` },
+      { transform: "translateY(0)" },
+    ];
+  }
+  return new KeyframeEffect(el, keyframes, {
+    duration: ANIMATION_MS,
+    easing: "ease-out",
+  });
+};
 
 function DefaultLayout() {
   const { notifications, removeNotification } =
     useContext<NotificationContext>(NotificationContext);
+  const [notificationListRef] = useAutoAnimate(notificationAnimation);
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -20,7 +62,10 @@ function DefaultLayout() {
         aria-live="assertive"
         className="pointer-events-none fixed inset-0 mt-12 flex items-end px-4 py-6 sm:items-start sm:p-6"
       >
-        <div className="flex w-full flex-col items-center space-y-4 sm:items-end">
+        <div
+          ref={notificationListRef}
+          className="flex w-full flex-col items-center gap-4 sm:items-end"
+        >
           {notifications.map((notification) => {
             if (notification.type === "info") {
               return (

--- a/frontend/src/layout/RootLayout.tsx
+++ b/frontend/src/layout/RootLayout.tsx
@@ -46,7 +46,7 @@ const notificationAnimation: AutoAnimationPlugin = (
   });
 };
 
-function DefaultLayout() {
+function RootLayout() {
   const { notifications, removeNotification } =
     useContext<NotificationContext>(NotificationContext);
   const [notificationListRef] = useAutoAnimate(notificationAnimation);
@@ -93,4 +93,4 @@ function DefaultLayout() {
   );
 }
 
-export default DefaultLayout;
+export default RootLayout;

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -9,6 +9,18 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
+// Mock matchMedia for auto-animate, which reads prefers-reduced-motion.
+window.matchMedia = (query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+});
+
 afterEach(() => {
   cleanup();
 });

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -21,6 +21,20 @@ window.matchMedia = (query: string) => ({
   dispatchEvent: () => false,
 });
 
+// jsdom lacks the Web Animations API that auto-animate drives. Stub the bits it
+// touches (new KeyframeEffect / new Animation -> play/cancel/finish) as no-ops;
+// the tests don't assert on animations.
+globalThis.KeyframeEffect =
+  class KeyframeEffect {} as unknown as typeof KeyframeEffect;
+
+globalThis.Animation = class Animation {
+  finished = Promise.resolve();
+  play() {}
+  cancel() {}
+  addEventListener() {}
+  removeEventListener() {}
+} as unknown as typeof Animation;
+
 afterEach(() => {
   cleanup();
 });


### PR DESCRIPTION
Toast notifications never disappeared on their own, and closing one only hid it locally — the notification object stayed in the shared `notifications` array forever. Because each toast is `pointer-events-auto` and pinned to the top-right, the accumulating (invisible-but-present, or still-visible) toasts piled up and intercepted clicks on the UI behind them.

Changes:
- Each notification now gets a stable `id`; `removeNotification(id)` actually drops it from the array.
- Toasts auto-dismiss after a timeout (5s for info, 8s for errors), animating out and then removing themselves from the queue.
- The manual close button now goes through the same path, so closing a toast removes it from the array instead of just hiding it.
- Added the missing React `key` when rendering the list.

The container was already `pointer-events-none`, so the click-blocking was caused purely by toasts never being removed — fixed by the above.

Fixes #476.