### PR TITLE
Reject connection creation when the id is already taken

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExceptionHandlerController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExceptionHandlerController.kt
@@ -3,6 +3,7 @@ package dev.kviklet.kviklet.controller
 import dev.kviklet.kviklet.security.EnterpriseFeatureException
 import dev.kviklet.kviklet.service.AlreadyExecutedException
 import dev.kviklet.kviklet.service.EmailAlreadyExistsException
+import dev.kviklet.kviklet.service.EntityAlreadyExists
 import dev.kviklet.kviklet.service.EntityNotFound
 import dev.kviklet.kviklet.service.InvalidLicenseException
 import dev.kviklet.kviklet.service.InvalidReviewException
@@ -109,6 +110,12 @@ class ExceptionHandlerController {
     fun handleEntityNotFound(ex: EntityNotFound, request: HttpServletRequest): ResponseEntity<Any> {
         logger.warn("Entity not found at ${request.requestURI}: ${ex.message}")
         return ResponseEntity(ErrorResponse(ex.message), HttpStatus.NOT_FOUND)
+    }
+
+    @ExceptionHandler(EntityAlreadyExists::class)
+    fun handleEntityAlreadyExists(ex: EntityAlreadyExists, request: HttpServletRequest): ResponseEntity<Any> {
+        logger.warn("Entity already exists at ${request.requestURI}: ${ex.message}")
+        return ResponseEntity(ErrorResponse(ex.message), HttpStatus.CONFLICT)
     }
 
     @ExceptionHandler(Exception::class)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/Connection.kt
@@ -124,6 +124,8 @@ class ConnectionAdapter(
         return connectionEntity
     }
 
+    fun connectionExists(connectionId: ConnectionId): Boolean = connectionRepository.existsById(connectionId.toString())
+
     @Transactional
     fun getConnection(connectionId: ConnectionId): Connection {
         val entity = connectionRepository.findByIdOrNull(connectionId.toString())

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ConnectionService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ConnectionService.kt
@@ -21,6 +21,8 @@ import org.springframework.stereotype.Service
 
 class EntityNotFound(override val message: String, val detail: String) : Exception(message)
 
+class EntityAlreadyExists(override val message: String, val detail: String) : Exception(message)
+
 data class TestConnectionResult(
     val success: Boolean,
     val message: String,
@@ -225,6 +227,7 @@ class ConnectionService(
         if (authenticationType == AuthenticationType.USER_PASSWORD && password == null) {
             throw IllegalArgumentException("Password is required for USER_PASSWORD authentication")
         }
+        ensureConnectionIdIsAvailable(connectionId)
         // Validate: MongoDB cannot have dry run enabled
         if (type == DatasourceType.MONGODB && dryRunEnabled) {
             throw IllegalArgumentException("Dry run is not supported for MongoDB connections")
@@ -352,6 +355,7 @@ class ConnectionService(
         kubernetesExecInitialWaitTimeoutSeconds: Long?,
         kubernetesExecTimeoutMinutes: Long?,
     ): Connection {
+        ensureConnectionIdIsAvailable(connectionId)
         validateReviewConfig(reviewConfig, existingReviewConfig = null)
         return connectionAdapter.createKubernetesConnection(
             connectionId,
@@ -377,6 +381,15 @@ class ConnectionService(
     fun getDatasourceConnection(connectionId: ConnectionId): Connection = connectionAdapter.getConnection(
         connectionId = connectionId,
     )
+
+    private fun ensureConnectionIdIsAvailable(connectionId: ConnectionId) {
+        if (connectionAdapter.connectionExists(connectionId)) {
+            throw EntityAlreadyExists(
+                "Connection already exists",
+                "A connection with id $connectionId already exists.",
+            )
+        }
+    }
 
     private fun validateReviewConfig(newReviewConfig: ReviewConfig, existingReviewConfig: ReviewConfig?) {
         if (newReviewConfig.numTotalRequired < 0) {

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ConnectionTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ConnectionTest.kt
@@ -684,6 +684,64 @@ class ConnectionTest(
     }
 
     @Test
+    fun `creating a connection with an already used id is rejected and does not overwrite the existing one`() {
+        userHelper.createUser(permissions = listOf("*"))
+        val cookie = userHelper.login(mockMvc = mockMvc)
+
+        val datasourceJson = """
+            {
+                "connectionType": "DATASOURCE",
+                "id": "duplicate-id",
+                "displayName": "Original Datasource",
+                "username": "root",
+                "password": "root",
+                "type": "MYSQL",
+                "hostname": "localhost",
+                "port": 3306,
+                "reviewConfig": {
+                    "numTotalRequired": 1
+                }
+            }
+        """.trimIndent()
+
+        // First create succeeds
+        mockMvc.perform(
+            post("/connections/")
+                .cookie(cookie)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(datasourceJson),
+        )
+            .andExpect(status().isOk)
+
+        // Second create reuses the same id but a different connection type -> must be rejected
+        val kubernetesJson = """
+            {
+                "connectionType": "KUBERNETES",
+                "id": "duplicate-id",
+                "displayName": "Sneaky Kubernetes",
+                "description": "",
+                "reviewConfig": {
+                    "numTotalRequired": 1
+                }
+            }
+        """.trimIndent()
+
+        mockMvc.perform(
+            post("/connections/")
+                .cookie(cookie)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(kubernetesJson),
+        )
+            .andExpect(status().isConflict)
+
+        // The original datasource connection must still be intact and the only one
+        connectionRepository.count() shouldBe 1L
+        val remaining = datasourceConnectionController.getConnection("duplicate-id") as DatasourceConnectionResponse
+        remaining.displayName shouldBe "Original Datasource"
+        remaining.type shouldBe DatasourceType.MYSQL
+    }
+
+    @Test
     fun `kubernetes connection supports setting and updating exec timeout settings`() {
         val created = datasourceConnectionController.createConnection(
             CreateKubernetesConnectionRequest(


### PR DESCRIPTION
## Problem

Creating a connection went straight to `JpaRepository.save()`. Because `ConnectionEntity` uses an assigned (non-generated) string `@Id`, Spring Data treats every entity as "not new" and `save()` runs a `merge()` — an **upsert**. Posting a create request (`POST /connections/`) with an `id` that already belonged to an existing connection silently **overwrote** it, returning `200 OK` as if a new connection had been created.

Both connection types (Datasource and Kubernetes) share one table discriminated only by `connection_type`, so this also let a create of one type clobber and convert an existing connection of the other type, orphaning its execution-request history. The update (`PATCH`) path was already type-guarded; only create was affected.

## Fix

Guard both create paths in `ConnectionService` with an existence check (`ConnectionAdapter.connectionExists`) and reject duplicates with a new `EntityAlreadyExists` exception, mapped to HTTP `409 Conflict` in `ExceptionHandlerController`.

Added a request-level integration test in `ConnectionTest` that creates a connection, then attempts to create a second one of a different type reusing the same id, asserting the second request is rejected and the original connection stays intact.