### PR TITLE
Simplify result download

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExceptionHandlerController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExceptionHandlerController.kt
@@ -2,6 +2,7 @@ package dev.kviklet.kviklet.controller
 
 import dev.kviklet.kviklet.security.EnterpriseFeatureException
 import dev.kviklet.kviklet.service.AlreadyExecutedException
+import dev.kviklet.kviklet.service.DownloadException
 import dev.kviklet.kviklet.service.EmailAlreadyExistsException
 import dev.kviklet.kviklet.service.EntityNotFound
 import dev.kviklet.kviklet.service.InvalidLicenseException
@@ -91,6 +92,12 @@ class ExceptionHandlerController {
     fun handleAccessDeniedException(ex: AccessDeniedException, request: HttpServletRequest): ResponseEntity<Any> {
         logger.warn("Access denied at ${request.requestURI}: ${ex.message}")
         return ResponseEntity(ErrorResponse("Access denied"), HttpStatus.FORBIDDEN)
+    }
+
+    @ExceptionHandler(DownloadException::class)
+    fun handleDownloadException(ex: DownloadException, request: HttpServletRequest): ResponseEntity<Any> {
+        logger.warn("Download failed at ${request.requestURI}: ${ex.message}")
+        return ResponseEntity(ErrorResponse(ex.message ?: "Download failed"), HttpStatus.BAD_REQUEST)
     }
 
     @ExceptionHandler(AlreadyExecutedException::class)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
@@ -775,27 +775,16 @@ class ExecutionRequestController(val executionRequestService: ExecutionRequestSe
         response: HttpServletResponse,
         @RequestParam query: String?,
     ) {
-        try {
-            val download = executionRequestService.downloadResults(executionRequestId, userDetails.id, query)
-            response.contentType = download.contentType
-            response.setHeader(
-                HttpHeaders.CONTENT_DISPOSITION,
-                "attachment; filename=\"${download.fileName}\"",
-            )
-            response.setContentLength(download.bytes.size)
-            response.outputStream.use { it.write(download.bytes) }
-        } catch (e: RuntimeException) {
-            // Business/database errors (e.g. a failing query) are surfaced to the user as plain text.
-            response.reset()
-            response.contentType = "text/plain"
-            response.status = HttpServletResponse.SC_BAD_REQUEST
-            response.outputStream.use { it.write((e.message ?: "Unknown error").toByteArray()) }
-        } catch (e: Exception) {
-            response.reset()
-            response.contentType = "text/plain"
-            response.status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR
-            response.outputStream.use { it.write("An error occurred: ${e.message}".toByteArray()) }
-        }
+        // Errors (failed query, missing approval, access denied) propagate to the
+        // ExceptionHandlerController before anything is written to the response.
+        val download = executionRequestService.downloadResults(executionRequestId, userDetails.id, query)
+        response.contentType = download.contentType
+        response.setHeader(
+            HttpHeaders.CONTENT_DISPOSITION,
+            "attachment; filename=\"${download.fileName}\"",
+        )
+        response.setContentLength(download.bytes.size)
+        response.outputStream.use { it.write(download.bytes) }
     }
 
     @Operation(

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
@@ -222,10 +222,6 @@ sealed class ExecutionRequestDetailResponse(open val id: ExecutionRequestId, ope
                     createdAt = request.createdAt,
                     events = dto.events.sortedBy { it.createdAt }.map { EventResponse.fromEvent(it) },
                     connection = ConnectionResponse.fromDto(request.connection),
-                    csvDownload = CSVDownloadableResponse(
-                        allowed = dto.csvDownloadAllowed().first,
-                        reason = dto.csvDownloadAllowed().second,
-                    ),
                     temporaryAccessDuration = request.temporaryAccessDuration?.toMinutes(),
                     approvalProgress = ApprovalProgressResponse.fromDto(
                         dto.getApprovalProgress(),
@@ -270,7 +266,6 @@ data class DatasourceExecutionRequestDetailResponse(
     val reviewStatus: ReviewStatus,
     val executionStatus: ExecutionStatus,
     val createdAt: LocalDateTime = utcTimeNow(),
-    val csvDownload: CSVDownloadableResponse,
     override val events: List<EventResponse>,
     val temporaryAccessDuration: Long? = null,
     val approvalProgress: ApprovalProgressResponse,
@@ -278,8 +273,6 @@ data class DatasourceExecutionRequestDetailResponse(
     id = id,
     events = events,
 )
-
-data class CSVDownloadableResponse(val allowed: Boolean, val reason: String)
 
 data class RoleApprovalProgressResponse(
     val role: RoleResponse,

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
@@ -772,33 +772,32 @@ class ExecutionRequestController(val executionRequestService: ExecutionRequestSe
     )
 
     @Operation(
-        summary = "Execute Execution Request and Download as CSV",
-        description = "Run the query and download results as CSV after the Execution Request has been approved.",
+        summary = "Execute Execution Request and Download Results",
+        description = "Run the query and download the results as a file (or ZIP for multiple results).",
     )
     @GetMapping("/{executionRequestId}/download")
-    fun downloadCsv(
+    fun download(
         @PathVariable executionRequestId: ExecutionRequestId,
         @CurrentUser userDetails: UserDetailsWithId,
         response: HttpServletResponse,
         @RequestParam query: String?,
     ) {
         try {
-            // Set CSV headers ONLY if we know the query will succeed
-            response.contentType = "text/csv; charset=UTF-8"
-            val csvName = executionRequestService.getCSVFileName(executionRequestId)
-            response.setHeader("Content-Disposition", "attachment; filename=\"$csvName\"")
-
-            // Use output stream to write CSV data
-            val outputStream = response.outputStream
-            executionRequestService.streamResultsAsCsv(executionRequestId, userDetails.id, outputStream, query)
-        } catch (e: IllegalStateException) {
-            // For exceptions, reset content type to plain text and use the same output method consistently
-            response.reset() // Clear previous response settings
+            val download = executionRequestService.downloadResults(executionRequestId, userDetails.id, query)
+            response.contentType = download.contentType
+            response.setHeader(
+                HttpHeaders.CONTENT_DISPOSITION,
+                "attachment; filename=\"${download.fileName}\"",
+            )
+            response.setContentLength(download.bytes.size)
+            response.outputStream.use { it.write(download.bytes) }
+        } catch (e: RuntimeException) {
+            // Business/database errors (e.g. a failing query) are surfaced to the user as plain text.
+            response.reset()
             response.contentType = "text/plain"
             response.status = HttpServletResponse.SC_BAD_REQUEST
-            response.outputStream.use { it.write(e.message?.toByteArray() ?: "Unknown error".toByteArray()) }
+            response.outputStream.use { it.write((e.message ?: "Unknown error").toByteArray()) }
         } catch (e: Exception) {
-            // Handle any other exceptions
             response.reset()
             response.contentType = "text/plain"
             response.status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -762,6 +762,11 @@ class ExecutionRequestService(
         if (connection.type == DatasourceType.MONGODB) {
             throw IllegalArgumentException("MongoDB requests can't be downloaded")
         }
+        if (executionRequest.request.type == RequestType.Dump) {
+            throw IllegalArgumentException(
+                "Result download is not available for dump requests, use the SQL dump endpoint instead",
+            )
+        }
         if (executionRequest.resolveReviewStatus() != ReviewStatus.APPROVED) {
             throw InvalidReviewException("This request has not been approved yet!")
         }
@@ -781,7 +786,11 @@ class ExecutionRequestService(
             throw DownloadException(it.message)
         }
 
-        val baseName = executionRequest.request.title.replace(" ", "_")
+        // The name ends up in a quoted Content-Disposition header and on the user's filesystem,
+        // so anything outside a conservative ASCII set is replaced.
+        val baseName = executionRequest.request.title
+            .replace(Regex("[^A-Za-z0-9._-]"), "_")
+            .ifBlank { "results" }
         val files = results.map { resultToFile(it) }
 
         if (files.size == 1) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -752,16 +752,15 @@ class ExecutionRequestService(
      */
     // Intentionally not @Transactional: mirrors execute(), so the audited execute event is committed
     // independently and survives even when a database error fails the download.
-    // checkIsPresentOnly: the return value is a plain file DTO, not a SecuredDomainObject to filter.
-    @Policy(Permission.EXECUTION_REQUEST_EXECUTE, checkIsPresentOnly = true)
+    @Policy(Permission.EXECUTION_REQUEST_EXECUTE)
     fun downloadResults(id: ExecutionRequestId, userId: String, query: String? = null): DownloadResult {
         val executionRequest = executionRequestAdapter.getExecutionRequestDetails(id)
         val connection = executionRequest.request.connection
         if (connection !is DatasourceConnection || executionRequest.request !is DatasourceExecutionRequest) {
-            throw RuntimeException("Only Datasource requests can be downloaded")
+            throw IllegalArgumentException("Only Datasource requests can be downloaded")
         }
         if (connection.type == DatasourceType.MONGODB) {
-            throw RuntimeException("MongoDB requests can't be downloaded")
+            throw IllegalArgumentException("MongoDB requests can't be downloaded")
         }
         if (executionRequest.resolveReviewStatus() != ReviewStatus.APPROVED) {
             throw InvalidReviewException("This request has not been approved yet!")
@@ -770,16 +769,19 @@ class ExecutionRequestService(
 
         val result = executeDatasourceRequest(id, executionRequest, connection, query, userId, isDownload = true)
 
-        return buildDownloadResult(executionRequest.request.title, result.results)
+        return buildDownloadResult(executionRequest, result.results)
     }
 
-    private fun buildDownloadResult(title: String, results: List<QueryResult>): DownloadResult {
+    private fun buildDownloadResult(
+        executionRequest: ExecutionRequestDetails,
+        results: List<QueryResult>,
+    ): DownloadResult {
         // A database error fails the whole download; the error is already audited via the execute event.
         results.filterIsInstance<ErrorQueryResult>().firstOrNull()?.let {
             throw DownloadException(it.message)
         }
 
-        val baseName = title.replace(" ", "_")
+        val baseName = executionRequest.request.title.replace(" ", "_")
         val files = results.map { resultToFile(it) }
 
         if (files.size == 1) {
@@ -788,6 +790,7 @@ class ExecutionRequestService(
                 fileName = "$baseName.${file.extension}",
                 contentType = file.contentType,
                 bytes = file.bytes,
+                executionRequest = executionRequest,
             )
         }
 
@@ -801,7 +804,12 @@ class ExecutionRequestService(
             }
             byteStream.toByteArray()
         }
-        return DownloadResult(fileName = "$baseName.zip", contentType = "application/zip", bytes = zipBytes)
+        return DownloadResult(
+            fileName = "$baseName.zip",
+            contentType = "application/zip",
+            bytes = zipBytes,
+            executionRequest = executionRequest,
+        )
     }
 
     private data class DownloadFile(val extension: String, val contentType: String, val bytes: ByteArray)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -24,7 +24,9 @@ import dev.kviklet.kviklet.service.dto.DBExecutionResult
 import dev.kviklet.kviklet.service.dto.DatasourceConnection
 import dev.kviklet.kviklet.service.dto.DatasourceExecutionRequest
 import dev.kviklet.kviklet.service.dto.DatasourceType
+import dev.kviklet.kviklet.service.dto.DownloadResult
 import dev.kviklet.kviklet.service.dto.DumpResultLog
+import dev.kviklet.kviklet.service.dto.ErrorQueryResult
 import dev.kviklet.kviklet.service.dto.ErrorResultLog
 import dev.kviklet.kviklet.service.dto.Event
 import dev.kviklet.kviklet.service.dto.EventType
@@ -41,13 +43,15 @@ import dev.kviklet.kviklet.service.dto.KubernetesConnection
 import dev.kviklet.kviklet.service.dto.KubernetesExecutionRequest
 import dev.kviklet.kviklet.service.dto.KubernetesExecutionResult
 import dev.kviklet.kviklet.service.dto.KubernetesOutputResultLog
-import dev.kviklet.kviklet.service.dto.QueryResultLog
+import dev.kviklet.kviklet.service.dto.MongoRecordsQueryResult
+import dev.kviklet.kviklet.service.dto.QueryResult
+import dev.kviklet.kviklet.service.dto.RecordsQueryResult
 import dev.kviklet.kviklet.service.dto.RequestType
 import dev.kviklet.kviklet.service.dto.ReviewAction
 import dev.kviklet.kviklet.service.dto.ReviewStatus
+import dev.kviklet.kviklet.service.dto.UpdateQueryResult
 import dev.kviklet.kviklet.service.dto.utcTimeNow
 import dev.kviklet.kviklet.shell.KubernetesApi
-import jakarta.servlet.ServletOutputStream
 import jakarta.transaction.Transactional
 import net.sf.jsqlparser.parser.CCJSqlParserUtil
 import org.slf4j.LoggerFactory
@@ -55,12 +59,15 @@ import org.springframework.context.ApplicationEventPublisher
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import java.io.BufferedInputStream
+import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.OutputStream
 import java.security.SecureRandom
 import java.time.Duration
 import java.time.LocalDateTime
 import java.util.concurrent.CompletableFuture
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 @Service
 class ExecutionRequestService(
@@ -488,6 +495,7 @@ class ExecutionRequestService(
         connection: DatasourceConnection,
         query: String?,
         userId: String,
+        isDownload: Boolean = false,
     ): DBExecutionResult {
         if (executionRequest.request !is DatasourceExecutionRequest) {
             throw RuntimeException("This should never happen! Probably there is a way to refactor this code")
@@ -507,6 +515,7 @@ class ExecutionRequestService(
             userId,
             ExecutePayload(
                 query = queryToExecute,
+                isDownload = isDownload,
             ),
         )
 
@@ -735,97 +744,88 @@ class ExecutionRequestService(
         }
     }
 
-    @Policy(Permission.EXECUTION_REQUEST_GET, checkIsPresentOnly = true)
-    fun getCSVFileName(id: ExecutionRequestId): String {
-        val executionRequest = executionRequestAdapter.getExecutionRequestDetails(id)
-        val csvName = executionRequest.request.title.replace(" ", "_")
-        return "$csvName.csv"
-    }
-
-    @Policy(Permission.EXECUTION_REQUEST_EXECUTE)
-    fun streamResultsAsCsv(
-        id: ExecutionRequestId,
-        userId: String,
-        outputStream: ServletOutputStream,
-        query: String? = null,
-    ) {
+    /**
+     * Executes the request through the normal datasource execution path (so the run is audited and
+     * results are stored just like a regular execution) and formats the results into a downloadable
+     * file. A single result yields one file; multiple results are bundled into a ZIP. A database
+     * error fails the whole download via [DownloadException].
+     */
+    // Intentionally not @Transactional: mirrors execute(), so the audited execute event is committed
+    // independently and survives even when a database error fails the download.
+    // checkIsPresentOnly: the return value is a plain file DTO, not a SecuredDomainObject to filter.
+    @Policy(Permission.EXECUTION_REQUEST_EXECUTE, checkIsPresentOnly = true)
+    fun downloadResults(id: ExecutionRequestId, userId: String, query: String? = null): DownloadResult {
         val executionRequest = executionRequestAdapter.getExecutionRequestDetails(id)
         val connection = executionRequest.request.connection
-        if (connection !is DatasourceConnection ||
-            executionRequest.request !is DatasourceExecutionRequest
-        ) {
-            throw RuntimeException("Only Datasource requests can be downloaded as CSV")
+        if (connection !is DatasourceConnection || executionRequest.request !is DatasourceExecutionRequest) {
+            throw RuntimeException("Only Datasource requests can be downloaded")
         }
         if (connection.type == DatasourceType.MONGODB) {
-            throw RuntimeException("MongoDB requests can't be downloaded as CSV")
+            throw RuntimeException("MongoDB requests can't be downloaded")
         }
-        val downloadAllowedAndReason = executionRequest.csvDownloadAllowed(query)
-        val queryToExecute = when (executionRequest.request.type) {
-            RequestType.SingleExecution ->
-                executionRequest.request.statement!!
-                    .trim()
-                    .removeSuffix(";")
-
-            RequestType.TemporaryAccess ->
-                query?.trim()?.removeSuffix(";")
-                    ?: throw MissingQueryException("For temporary access requests a query to execute is required")
-
-            RequestType.Dump -> throw RuntimeException("Dump requests can't be downloaded as CSV")
+        if (executionRequest.resolveReviewStatus() != ReviewStatus.APPROVED) {
+            throw InvalidReviewException("This request has not been approved yet!")
         }
-        if (!downloadAllowedAndReason.first) {
-            throw RuntimeException(downloadAllowedAndReason.second)
+        executionRequest.raiseIfAlreadyExecuted()
+
+        val result = executeDatasourceRequest(id, executionRequest, connection, query, userId, isDownload = true)
+
+        return buildDownloadResult(executionRequest.request.title, result.results)
+    }
+
+    private fun buildDownloadResult(title: String, results: List<QueryResult>): DownloadResult {
+        // A database error fails the whole download; the error is already audited via the execute event.
+        results.filterIsInstance<ErrorQueryResult>().firstOrNull()?.let {
+            throw DownloadException(it.message)
         }
 
-        val eventId = eventService.saveEvent(
-            id,
-            userId,
-            ExecutePayload(
-                query = queryToExecute,
-                isDownload = true,
-            ),
-        ).eventId!!
+        val baseName = title.replace(" ", "_")
+        val files = results.map { resultToFile(it) }
 
-        val maxRowsToStore = if (connection.storeResults) MAX_STORED_ROWS else 0
-
-        try {
-            val writer = outputStream.writer(Charsets.UTF_8)
-            val streamResult = JDBCExecutor.executeAndStreamDbResponse(
-                connectionString = connection.getConnectionString(),
-                authenticationDetails = connection.auth,
-                query = queryToExecute,
-                maxRowsToStore = maxRowsToStore,
-            ) { row ->
-                writer.write(
-                    row.joinToString(",") { field ->
-                        escapeCsvField(field)
-                    } + "\n",
-                )
-                writer.flush()
-            }
-
-            // Store results on success if storeResults is enabled
-            if (connection.storeResults) {
-                val resultLog = QueryResultLog(
-                    columnCount = streamResult.columns.size,
-                    rowCount = streamResult.rowCount,
-                    columns = streamResult.columns,
-                    storedRows = streamResult.storedRows,
-                    storedRowCount = streamResult.storedRows.size,
-                )
-                eventService.addResultLogs(eventId, listOf(resultLog))
-            }
-        } catch (e: Exception) {
-            eventService.addResultLogs(
-                eventId,
-                listOf(
-                    ErrorResultLog(
-                        errorCode = 0,
-                        message = e.message ?: "An error occurred while streaming the database response",
-                    ),
-                ),
+        if (files.size == 1) {
+            val file = files.first()
+            return DownloadResult(
+                fileName = "$baseName.${file.extension}",
+                contentType = file.contentType,
+                bytes = file.bytes,
             )
-            throw e
         }
+
+        val zipBytes = ByteArrayOutputStream().use { byteStream ->
+            ZipOutputStream(byteStream).use { zip ->
+                files.forEachIndexed { index, file ->
+                    zip.putNextEntry(ZipEntry("${baseName}_${index + 1}.${file.extension}"))
+                    zip.write(file.bytes)
+                    zip.closeEntry()
+                }
+            }
+            byteStream.toByteArray()
+        }
+        return DownloadResult(fileName = "$baseName.zip", contentType = "application/zip", bytes = zipBytes)
+    }
+
+    private data class DownloadFile(val extension: String, val contentType: String, val bytes: ByteArray)
+
+    private fun resultToFile(result: QueryResult): DownloadFile = when (result) {
+        is RecordsQueryResult -> {
+            val csv = buildString {
+                append(result.columns.joinToString(",") { escapeCsvField(it.label) }).append("\n")
+                result.data.forEach { row ->
+                    append(result.columns.joinToString(",") { escapeCsvField(row[it.label] ?: "") }).append("\n")
+                }
+            }
+            DownloadFile("csv", "text/csv; charset=UTF-8", csv.toByteArray(Charsets.UTF_8))
+        }
+
+        is UpdateQueryResult -> DownloadFile(
+            "txt",
+            "text/plain; charset=UTF-8",
+            "${result.rowsUpdated} rows updated\n".toByteArray(Charsets.UTF_8),
+        )
+
+        is ErrorQueryResult -> throw DownloadException(result.message)
+
+        is MongoRecordsQueryResult -> throw RuntimeException("MongoDB requests can't be downloaded")
     }
 
     private fun escapeCsvField(field: String): String {
@@ -1081,6 +1081,8 @@ fun ExecutionRequestDetails.raiseIfAlreadyExecuted() {
 }
 
 class InvalidReviewException(message: String) : RuntimeException(message)
+
+class DownloadException(message: String) : RuntimeException(message)
 
 class MissingQueryException(message: String) : RuntimeException(message)
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -218,12 +218,7 @@ class ExecutionRequestService(
 
         val connection = connectionService.getDatasourceConnection(executionRequest.request.connection.id)
 
-        val reviewStatus = executionRequest.resolveReviewStatus()
-        if (reviewStatus != ReviewStatus.APPROVED) {
-            throw InvalidReviewException("This request has not been approved yet!")
-        }
-
-        executionRequest.raiseIfAlreadyExecuted()
+        executionRequest.raiseIfNotExecutable()
 
         if (connection !is DatasourceConnection) {
             throw IllegalArgumentException("Only Datasource connections can be dumped")
@@ -726,12 +721,7 @@ class ExecutionRequestService(
             )
         } else {
             // Normal execution - always requires approval
-            val reviewStatus = executionRequest.resolveReviewStatus()
-            if (reviewStatus != ReviewStatus.APPROVED) {
-                throw InvalidReviewException("This request has not been approved yet!")
-            }
-
-            executionRequest.raiseIfAlreadyExecuted()
+            executionRequest.raiseIfNotExecutable()
             return when (connection) {
                 is DatasourceConnection -> {
                     executeDatasourceRequest(id, executionRequest, connection, query, userId)
@@ -767,10 +757,7 @@ class ExecutionRequestService(
                 "Result download is not available for dump requests, use the SQL dump endpoint instead",
             )
         }
-        if (executionRequest.resolveReviewStatus() != ReviewStatus.APPROVED) {
-            throw InvalidReviewException("This request has not been approved yet!")
-        }
-        executionRequest.raiseIfAlreadyExecuted()
+        executionRequest.raiseIfNotExecutable()
 
         val result = executeDatasourceRequest(id, executionRequest, connection, query, userId, isDownload = true)
 
@@ -781,11 +768,6 @@ class ExecutionRequestService(
         executionRequest: ExecutionRequestDetails,
         results: List<QueryResult>,
     ): DownloadResult {
-        // A database error fails the whole download; the error is already audited via the execute event.
-        results.filterIsInstance<ErrorQueryResult>().firstOrNull()?.let {
-            throw DownloadException(it.message)
-        }
-
         // The name ends up in a quoted Content-Disposition header and on the user's filesystem,
         // so anything outside a conservative ASCII set is replaced.
         val baseName = executionRequest.request.title
@@ -840,6 +822,7 @@ class ExecutionRequestService(
             "${result.rowsUpdated} rows updated\n".toByteArray(Charsets.UTF_8),
         )
 
+        // A database error fails the whole download; the error is already audited via the execute event.
         is ErrorQueryResult -> throw DownloadException(result.message)
 
         is MongoRecordsQueryResult -> throw RuntimeException("MongoDB requests can't be downloaded")
@@ -1079,6 +1062,17 @@ class ExecutionRequestService(
             throw e
         }
     }
+}
+
+/**
+ * The shared gate for every path that runs a request against the database (execute, download,
+ * SQL dump): the request must be approved and must not have used up its executions.
+ */
+fun ExecutionRequestDetails.raiseIfNotExecutable() {
+    if (resolveReviewStatus() != ReviewStatus.APPROVED) {
+        throw InvalidReviewException("This request has not been approved yet!")
+    }
+    raiseIfAlreadyExecuted()
 }
 
 fun ExecutionRequestDetails.raiseIfAlreadyExecuted() {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/JDBCExecutor.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/JDBCExecutor.kt
@@ -33,12 +33,6 @@ data class ColumnInfo(
     val typeClass: String,
 )
 
-data class StreamingQueryResult(
-    val columns: List<ColumnInfo>,
-    val rowCount: Int,
-    val storedRows: List<Map<String, String>> = emptyList(),
-)
-
 @Service
 class JDBCExecutor {
 
@@ -205,67 +199,6 @@ class JDBCExecutor {
                 return emptyList()
             }
         }
-    }
-
-    fun executeAndStreamDbResponse(
-        connectionString: String,
-        authenticationDetails: AuthenticationDetails,
-        query: String,
-        maxRowsToStore: Int = 0,
-        callback: (List<String>) -> Unit,
-    ): StreamingQueryResult {
-        createConnection(connectionString, authenticationDetails).use { dataSource: HikariDataSource ->
-            try {
-                dataSource.connection.createStatement().use { statement ->
-                    val hasResults = statement.execute(query)
-                    if (hasResults) {
-                        statement.resultSet?.use { resultSet ->
-                            return streamResultSet(resultSet, maxRowsToStore, callback)
-                        } ?: throw IllegalStateException("Can't stream a non-Select statement")
-                    } else {
-                        throw IllegalStateException("Can't stream a non-Select statement")
-                    }
-                }
-            } catch (e: SQLException) {
-                throw IllegalStateException("Error executing query: ${e.message}", e)
-            }
-        }
-    }
-
-    private fun streamResultSet(
-        resultSet: ResultSet,
-        maxRowsToStore: Int,
-        callback: (List<String>) -> Unit,
-    ): StreamingQueryResult {
-        val metadata = resultSet.metaData
-        val columns = (1..metadata.columnCount).map { i ->
-            ColumnInfo(
-                label = metadata.getColumnLabel(i),
-                typeName = metadata.getColumnTypeName(i),
-                typeClass = metadata.getColumnClassName(i),
-            )
-        }
-
-        callback(columns.map { it.label })
-
-        val storedRows = mutableListOf<Map<String, String>>()
-        var rowCount = 0
-
-        iterateResultSet(resultSet, columns, forEachRow = { resultMap ->
-            callback(columns.map { resultMap[it.label] ?: "" })
-
-            // Only store first N rows for result storage
-            if (storedRows.size < maxRowsToStore) {
-                storedRows.add(resultMap)
-            }
-            rowCount++
-        })
-
-        return StreamingQueryResult(
-            columns = columns,
-            rowCount = rowCount,
-            storedRows = storedRows,
-        )
     }
 
     private fun createRecordsQueryResult(resultSet: ResultSet, maxRowsToStore: Int? = null): RecordsQueryResult {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/JDBCExecutor.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/JDBCExecutor.kt
@@ -205,9 +205,18 @@ class JDBCExecutor {
         val results: MutableList<Map<String, String>> = mutableListOf()
 
         val metadata = resultSet.metaData
+        // Labels are de-duplicated ("id", "id (2)") because rows are keyed by label — duplicate
+        // labels (e.g. SELECT a.id, b.id) would otherwise collapse into one column.
+        val usedLabels = mutableSetOf<String>()
         val columns = (1..metadata.columnCount).map { i ->
+            var label = metadata.getColumnLabel(i)
+            var suffix = 2
+            while (!usedLabels.add(label)) {
+                label = "${metadata.getColumnLabel(i)} ($suffix)"
+                suffix++
+            }
             ColumnInfo(
-                label = metadata.getColumnLabel(i),
+                label = label,
                 typeName = metadata.getColumnTypeName(i),
                 typeClass = metadata.getColumnClassName(i),
             )
@@ -246,12 +255,15 @@ class JDBCExecutor {
     ) {
         while (resultSet.next()) {
             forEachRow.invoke(
-                columns.associate {
-                    if (it.typeClass == "[B") {
-                        Pair(it.label, resultSet.getBytes(it.label)?.let { "0x" + HexFormat.of().formatHex(it) } ?: "")
+                columns.withIndex().associate { (index, column) ->
+                    // Read by position: with duplicate labels in the query, label-based access
+                    // returns the first matching column's value for all of them.
+                    val value = if (column.typeClass == "[B") {
+                        resultSet.getBytes(index + 1)?.let { "0x" + HexFormat.of().formatHex(it) } ?: ""
                     } else {
-                        Pair(it.label, resultSet.getString(it.label))
+                        resultSet.getString(index + 1)
                     }
+                    Pair(column.label, value)
                 },
             )
         }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/Execution.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/Execution.kt
@@ -56,9 +56,19 @@ data class MongoRecordsQueryResult(
 
 /**
  * The fully built file a download produces. The service assembles the bytes (single file or a ZIP)
- * so the controller only needs to set the matching headers and write them out.
+ * so the controller only needs to set the matching headers and write them out. Carries the
+ * execution request so the @Policy check runs object-scoped, like ExecutionResult.
  */
-data class DownloadResult(val fileName: String, val contentType: String, val bytes: ByteArray)
+data class DownloadResult(
+    val fileName: String,
+    val contentType: String,
+    val bytes: ByteArray,
+    val executionRequest: ExecutionRequestDetails,
+) : SecuredDomainObject {
+    override fun getSecuredObjectId() = executionRequest.getSecuredObjectId()
+    override fun getDomainObjectType() = executionRequest.getDomainObjectType()
+    override fun getRelated(resource: Resource) = executionRequest.getRelated(resource)
+}
 
 sealed class ExecutionResponse : SecuredDomainObject {
     data class Stream(val connectionId: ConnectionId, val stream: (OutputStream) -> Unit) : ExecutionResponse() {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/Execution.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/Execution.kt
@@ -54,6 +54,12 @@ data class MongoRecordsQueryResult(
     )
 }
 
+/**
+ * The fully built file a download produces. The service assembles the bytes (single file or a ZIP)
+ * so the controller only needs to set the matching headers and write them out.
+ */
+data class DownloadResult(val fileName: String, val contentType: String, val bytes: ByteArray)
+
 sealed class ExecutionResponse : SecuredDomainObject {
     data class Stream(val connectionId: ConnectionId, val stream: (OutputStream) -> Unit) : ExecutionResponse() {
         override fun getSecuredObjectId(): String = connectionId.toString()

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
@@ -334,34 +334,6 @@ data class ExecutionRequestDetails(val request: ExecutionRequest, val events: Mu
         }
         return false
     }
-
-    fun csvDownloadAllowed(query: String? = null): Pair<Boolean, String> {
-        if (request.type === RequestType.Dump) {
-            return Pair(false, "CSV download is not available for SQLDump")
-        }
-
-        if (request.connection !is DatasourceConnection || request !is DatasourceExecutionRequest) {
-            return Pair(false, "Only Datasource Requests can be downloaded as CSV")
-        }
-
-        if (request.connection.type == DatasourceType.MONGODB) {
-            return Pair(false, "MongoDB requests can't be downloaded as CSV")
-        }
-
-        if (resolveReviewStatus() != ReviewStatus.APPROVED) {
-            return Pair(false, "This request has not been approved yet!")
-        }
-
-        if (resolveExecutionStatus() == ExecutionStatus.EXECUTED) {
-            return Pair(false, "This request has already been executed the maximum amount of times!")
-        }
-
-        if (request.type == RequestType.TemporaryAccess && query == null) {
-            return Pair(false, "Query can't be empty")
-        }
-
-        return Pair(true, "")
-    }
 }
 
 data class ExecutionRequestDetailsWithRoles(
@@ -372,7 +344,6 @@ data class ExecutionRequestDetailsWithRoles(
     val events get() = details.events
     fun resolveReviewStatus() = details.resolveReviewStatus()
     fun resolveExecutionStatus() = details.resolveExecutionStatus()
-    fun csvDownloadAllowed(query: String? = null) = details.csvDownloadAllowed(query)
     fun getApprovalProgress() = details.getApprovalProgress()
 }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
@@ -10,8 +10,6 @@ import dev.kviklet.kviklet.security.SecuredCollectionWrapper
 import dev.kviklet.kviklet.security.SecuredDomainId
 import dev.kviklet.kviklet.security.SecuredDomainObject
 import dev.kviklet.kviklet.security.UserDetailsWithId
-import net.sf.jsqlparser.JSQLParserException
-import net.sf.jsqlparser.parser.CCJSqlParserUtil
 import java.io.Serializable
 import java.time.Duration
 import java.time.LocalDateTime
@@ -358,30 +356,11 @@ data class ExecutionRequestDetails(val request: ExecutionRequest, val events: Mu
             return Pair(false, "This request has already been executed the maximum amount of times!")
         }
 
-        val queryToExecute = when (request.type) {
-            RequestType.SingleExecution -> request.statement!!.trim().removeSuffix(";")
-
-            RequestType.TemporaryAccess -> query?.trim()?.removeSuffix(
-                ";",
-            ) ?: return Pair(false, "Query can't be empty")
-
-            else -> return Pair(false, "Can't download results for this request type")
+        if (request.type == RequestType.TemporaryAccess && query == null) {
+            return Pair(false, "Query can't be empty")
         }
-        try {
-            val statementCount = CCJSqlParserUtil.parseStatements(queryToExecute)?.size ?: 0
-            if (statementCount > 1) {
-                return Pair(false, "This request contains more than one statement!")
-            }
-            if (CCJSqlParserUtil.parseStatements(
-                    queryToExecute,
-                )?.first() !is net.sf.jsqlparser.statement.select.Select
-            ) {
-                return Pair(false, "Can only download results for select queries!")
-            }
-            return Pair(true, "")
-        } catch (e: JSQLParserException) {
-            return Pair(false, "Error parsing query: ${e.message}")
-        }
+
+        return Pair(true, "")
     }
 }
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
@@ -450,7 +450,7 @@ class ExecutionTest {
         )
         val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
 
-        val contentResponse = downloadCSV(csvRequest.getId(), userCookie).andExpect(status().isOk).andReturn()
+        val contentResponse = downloadResults(csvRequest.getId(), userCookie).andExpect(status().isOk).andReturn()
         val content = contentResponse.response.contentAsString
         verifyCSVContent(content)
         verifyExecutionsList(csvRequest.getId(), userCookie)
@@ -466,7 +466,7 @@ class ExecutionTest {
         )
         val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
 
-        val response = downloadCSV(csvRequest.getId(), userCookie).andExpect(status().is4xxClientError)
+        val response = downloadResults(csvRequest.getId(), userCookie).andExpect(status().is4xxClientError)
         response.andExpect(
             jsonPath("$.message").value(containsString("relation \"foo.inexistent_table\" does not exist")),
         )
@@ -496,7 +496,7 @@ class ExecutionTest {
         )
         val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
 
-        val response = downloadCSV(duplicateColumnsRequest.getId(), userCookie)
+        val response = downloadResults(duplicateColumnsRequest.getId(), userCookie)
             .andExpect(status().isOk)
             .andReturn()
 
@@ -516,7 +516,7 @@ class ExecutionTest {
         )
         val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
 
-        val response = downloadCSV(updateRequest.getId(), userCookie)
+        val response = downloadResults(updateRequest.getId(), userCookie)
             .andExpect(status().isOk)
             .andExpect(header().string("Content-Disposition", "attachment; filename=\"Test_Execution.txt\""))
             .andReturn()
@@ -534,7 +534,7 @@ class ExecutionTest {
         )
         val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
 
-        val response = downloadCSV(multiRequest.getId(), userCookie)
+        val response = downloadResults(multiRequest.getId(), userCookie)
             .andExpect(status().isOk)
             .andExpect(header().string("Content-Disposition", "attachment; filename=\"Test_Execution.zip\""))
             .andReturn()
@@ -716,7 +716,7 @@ class ExecutionTest {
             .andExpect(jsonPath("$.events[1].results[0].type").value("ERROR"))
     }
 
-    private fun downloadCSV(executionRequestId: String, cookie: Cookie): ResultActions = mockMvc.perform(
+    private fun downloadResults(executionRequestId: String, cookie: Cookie): ResultActions = mockMvc.perform(
         get("/execution-requests/$executionRequestId/download")
             .cookie(cookie)
             .contentType("application/json"),

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
@@ -30,7 +30,6 @@ import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -468,7 +467,9 @@ class ExecutionTest {
         val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
 
         val response = downloadCSV(csvRequest.getId(), userCookie).andExpect(status().is4xxClientError)
-        response.andExpect(content().string(containsString("relation \"foo.inexistent_table\" does not exist")))
+        response.andExpect(
+            jsonPath("$.message").value(containsString("relation \"foo.inexistent_table\" does not exist")),
+        )
 
         // Verify the request has exactly one event of type EXECUTE and it's an error
         mockMvc.perform(

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
@@ -487,6 +487,26 @@ class ExecutionTest {
     }
 
     @Test
+    fun `when downloading a query with duplicate column labels then each column keeps its own values`() {
+        val duplicateColumnsRequest = executionRequestHelper.createApprovedRequest(
+            author = testUser,
+            approver = testReviewer,
+            connection = testConnection,
+            sql = "SELECT col1 AS id, col2 AS id FROM foo.simple_table",
+        )
+        val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+        val response = downloadCSV(duplicateColumnsRequest.getId(), userCookie)
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val content = response.response.contentAsString
+        assert(content.contains("id,id (2)"))
+        assert(content.contains("1,foo"))
+        assert(content.contains("2,bar"))
+    }
+
+    @Test
     fun `when downloading an update statement then return a text file`() {
         val updateRequest = executionRequestHelper.createApprovedRequest(
             author = testUser,

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
@@ -31,10 +31,12 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
+import java.util.zip.ZipInputStream
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -481,6 +483,51 @@ class ExecutionTest {
                     "$.events[1].results[0].message",
                 ).value(containsString("relation \"foo.inexistent_table\" does not exist")),
             )
+    }
+
+    @Test
+    fun `when downloading an update statement then return a text file`() {
+        val updateRequest = executionRequestHelper.createApprovedRequest(
+            author = testUser,
+            approver = testReviewer,
+            connection = testConnection,
+            sql = "UPDATE foo.simple_table SET col2 = 'baz' WHERE col1 = 1",
+        )
+        val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+        val response = downloadCSV(updateRequest.getId(), userCookie)
+            .andExpect(status().isOk)
+            .andExpect(header().string("Content-Disposition", "attachment; filename=\"Test_Execution.txt\""))
+            .andReturn()
+
+        assert(response.response.contentAsString.contains("1 rows updated"))
+    }
+
+    @Test
+    fun `when downloading multiple statements then return a zip with one entry per result`() {
+        val multiRequest = executionRequestHelper.createApprovedRequest(
+            author = testUser,
+            approver = testReviewer,
+            connection = testConnection,
+            sql = "SELECT * FROM foo.simple_table; UPDATE foo.simple_table SET col2 = 'baz' WHERE col1 = 1",
+        )
+        val userCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+        val response = downloadCSV(multiRequest.getId(), userCookie)
+            .andExpect(status().isOk)
+            .andExpect(header().string("Content-Disposition", "attachment; filename=\"Test_Execution.zip\""))
+            .andReturn()
+
+        val entryNames = mutableListOf<String>()
+        ZipInputStream(response.response.contentAsByteArray.inputStream()).use { zip ->
+            var entry = zip.nextEntry
+            while (entry != null) {
+                entryNames.add(entry.name)
+                entry = zip.nextEntry
+            }
+        }
+        assert(entryNames.contains("Test_Execution_1.csv"))
+        assert(entryNames.contains("Test_Execution_2.txt"))
     }
 
     @Test

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/StoreExecutionResultsTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/StoreExecutionResultsTest.kt
@@ -392,10 +392,10 @@ class StoreExecutionResultsTest {
     }
 
     @Nested
-    inner class CSVDownloadResultStorageTests {
+    inner class DownloadResultStorageTests {
 
         @Test
-        fun `CSV download on connection with storeResults=true stores results`() {
+        fun `Result download on connection with storeResults=true stores results`() {
             val connectionWithStorage = connectionHelper.createPostgresConnection(db, storeResults = true)
             val executionRequest = executionRequestHelper.createApprovedRequest(
                 author = testUser,
@@ -426,7 +426,7 @@ class StoreExecutionResultsTest {
         }
 
         @Test
-        fun `CSV download on connection with storeResults=false does not store results`() {
+        fun `Result download on connection with storeResults=false does not store results`() {
             val connectionWithoutStorage = connectionHelper.createPostgresConnection(db, storeResults = false)
             val executionRequest = executionRequestHelper.createApprovedRequest(
                 author = testUser,

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/StoreExecutionResultsTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/StoreExecutionResultsTest.kt
@@ -444,14 +444,15 @@ class StoreExecutionResultsTest {
                     .contentType("application/json"),
             ).andExpect(status().isOk)
 
-            // Verify no stored results in execution request details
-            // When storeResults=false, the results array is empty
+            // Verify the query is still audited but no rows are stored when storeResults=false
             mockMvc.perform(
                 get("/execution-requests/${executionRequest.getId()}").cookie(userCookie),
             ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.events[-1].type").value("EXECUTE"))
                 .andExpect(jsonPath("$.events[-1].isDownload").value(true))
-                .andExpect(jsonPath("$.events[-1].results", hasSize<Collection<*>>(0)))
+                .andExpect(jsonPath("$.events[-1].results[0].type").value("QUERY"))
+                .andExpect(jsonPath("$.events[-1].results[0].storedRows").doesNotExist())
+                .andExpect(jsonPath("$.events[-1].results[0].columns").doesNotExist())
         }
     }
 }

--- a/frontend/src/api/ExecutionRequestApi.ts
+++ b/frontend/src/api/ExecutionRequestApi.ts
@@ -116,11 +116,6 @@ const ExecuteEvent = withType(
   "EXECUTE",
 );
 
-const CSVDownloadSchema = z.object({
-  allowed: z.boolean(),
-  reason: z.string(),
-});
-
 const RoleApprovalProgressSchema = z.object({
   role: roleResponseSchema,
   numRequired: z.number(),
@@ -147,7 +142,6 @@ const RawDatasourceRequestSchema = z.object({
   reviewStatus: z.string(),
   createdAt: z.coerce.date(),
   connectionName: z.string().optional(),
-  csvDownload: CSVDownloadSchema.optional(),
   temporaryAccessDuration: z.number().nullable(),
   approvalProgress: ApprovalProgressSchema.optional(),
 });

--- a/frontend/src/routes/LiveSessionWebsockets.tsx
+++ b/frontend/src/routes/LiveSessionWebsockets.tsx
@@ -175,7 +175,7 @@ const LiveSessionWebsockets: React.FC<LiveSessionWebsocketsProps> = ({
         <div className="mb-4 flex flex-row items-center justify-end gap-2">
           {request?._type === "DATASOURCE" && isRelationalDatabase(request) && (
             <a href="#" onClick={handleCsvDownload}>
-              <Button>Download as CSV</Button>
+              <Button>Execute and Download Results</Button>
             </a>
           )}
           <LoadingCancelButton

--- a/frontend/src/routes/LiveSessionWebsockets.tsx
+++ b/frontend/src/routes/LiveSessionWebsockets.tsx
@@ -137,7 +137,7 @@ const LiveSessionWebsockets: React.FC<LiveSessionWebsocketsProps> = ({
     await executeQuery(text);
   };
 
-  const handleCsvDownload = (event: MouseEvent<HTMLAnchorElement>) => {
+  const handleResultDownload = (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
     const selection = editor?.getSelection();
     const query =
@@ -174,7 +174,7 @@ const LiveSessionWebsockets: React.FC<LiveSessionWebsocketsProps> = ({
         </div>
         <div className="mb-4 flex flex-row items-center justify-end gap-2">
           {request?._type === "DATASOURCE" && isRelationalDatabase(request) && (
-            <a href="#" onClick={handleCsvDownload}>
+            <a href="#" onClick={handleResultDownload}>
               <Button>Execute and Download Results</Button>
             </a>
           )}

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -64,15 +64,29 @@ function DatasourceRequestBox({
     });
   };
 
+  const getDisabledReason = () => {
+    if (request?.reviewStatus !== "APPROVED") {
+      return "Request needs to be approved before execution";
+    } else if (request?.executionStatus === "EXECUTED") {
+      return "Request has already been executed";
+    }
+    return undefined;
+  };
+
   // Downloading executes the stored statement, so it's only available for relational
   // (non-Mongo) single-execution requests. Temporary access downloads run from the live
   // session, which sends the editor's query along.
-  const downloadEnabled =
+  const downloadPossible =
     isRelationalDatabase(request) && request?.type === "SingleExecution";
+  const downloadEnabled =
+    downloadPossible &&
+    request?.reviewStatus === "APPROVED" &&
+    request?.executionStatus !== "EXECUTED";
   const menuDropDownItems = [
     {
       onClick: () => {},
       enabled: downloadEnabled,
+      tooltip: downloadPossible ? getDisabledReason() : undefined,
       content: downloadEnabled ? (
         <a href={`${baseUrl}/execution-requests/${request?.id}/download`}>
           Execute and Download Results
@@ -222,15 +236,6 @@ function DatasourceRequestBox({
     } else {
       await runQuery();
     }
-  };
-
-  const getDisabledReason = () => {
-    if (request?.reviewStatus !== "APPROVED") {
-      return "Request needs to be approved before execution";
-    } else if (request?.executionStatus === "EXECUTED") {
-      return "Request has already been executed";
-    }
-    return undefined;
   };
 
   return (

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -64,19 +64,21 @@ function DatasourceRequestBox({
     });
   };
 
+  // Downloading executes the stored statement, so it's only available for relational
+  // (non-Mongo) single-execution requests. Temporary access downloads run from the live
+  // session, which sends the editor's query along.
+  const downloadEnabled =
+    isRelationalDatabase(request) && request?.type === "SingleExecution";
   const menuDropDownItems = [
     {
       onClick: () => {},
-      enabled: request?.csvDownload?.allowed || false,
-      tooltip:
-        (!request?.csvDownload?.allowed && request?.csvDownload?.reason) ||
-        undefined,
-      content: request?.csvDownload?.allowed ? (
+      enabled: downloadEnabled,
+      content: downloadEnabled ? (
         <a href={`${baseUrl}/execution-requests/${request?.id}/download`}>
-          Download as CSV
+          Execute and Download Results
         </a>
       ) : (
-        <span>Download as CSV</span>
+        <span>Execute and Download Results</span>
       ),
     },
     {


### PR DESCRIPTION
Replaces the streaming CSV download with a simpler non-streaming download that reuses the normal datasource execution logic, and moves the "is download available" decision to the frontend.

## Backend

- The download endpoint runs through `executeDatasourceRequest` (the same path normal executions use), so the run is audited (execute event flagged `isDownload = true`) and results are stored just like a regular execution.
- **File formatting (in the service)**:
  - Records result → CSV (header + escaped values).
  - Update result → a small text file stating the number of rows updated.
  - A database error fails the whole download with a 400 carrying the DB message (no file produced).
  - A single result is returned as one file; multiple results are bundled into a `.zip` with one entry per result.
- The service builds the full bytes and returns a small `DownloadResult` DTO (filename, content type, bytes). The controller stays stupid: it only sets headers (including `Content-Length`) and writes the bytes.
- Removed the now-dead streaming code (`executeAndStreamDbResponse`, `streamResultSet`, `StreamingQueryResult`, `getCSVFileName`). The jsqlparser dependency stays (still used by `explain()`).
- Removed the computed `csvDownload {allowed, reason}` response field and the `csvDownloadAllowed()` helper — no longer needed now that the frontend decides visibility. The backend still enforces the real guards (datasource-only, not Mongo, approved, not already fully executed, query present for temporary access) inside `downloadResults`.

## Frontend

- The download button is shown based purely on the request being a relational (non-Mongo) datasource request (review box: relational + SingleExecution, since the stored statement is executed without a query; temporary-access downloads run from the live session, which sends the editor's query).
- Renamed the button to **Execute and Download Results** in both the review box and the live session.