### PR TITLE
Allow non-authors to execute approved single execution requests

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/SessionWebsocketHandler.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/SessionWebsocketHandler.kt
@@ -151,12 +151,21 @@ class SessionWebsocketHandler(
                 }
 
                 is ExecuteMessage -> {
+                    val principal = securityContext.authentication.principal
+                    val userId = when (principal) {
+                        is UserDetailsWithId -> principal.id
+
+                        else -> throw IllegalStateException(
+                            "Expected UserDetailsWithId but got: ${principal.javaClass}",
+                        )
+                    }
                     // Run execution in background thread with SecurityContext propagation
                     queryExecutor.submit {
                         try {
                             val executionResult = sessionService.executeStatement(
                                 liveSessionId,
                                 webSocketMessage.statement,
+                                userId,
                             )
                             when (executionResult) {
                                 is DBExecutionResult -> {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/ExecutionRequest.kt
@@ -316,9 +316,15 @@ data class ExecutionRequestDetails(val request: ExecutionRequest, val events: Mu
         policies: List<PolicyGrantedAuthority>,
     ): Boolean = when (permission) {
         Permission.EXECUTION_REQUEST_EDIT -> request.author.getId() == userDetails.id
-        Permission.EXECUTION_REQUEST_EXECUTE -> request.author.getId() == userDetails.id && isExecutable()
+        Permission.EXECUTION_REQUEST_EXECUTE -> mayExecute(userDetails) && isExecutable()
         else -> true
     }
+
+    // Approvals on single executions attach to the reviewed statement, so anyone with execute
+    // permission may run them. Temporary access and dumps are grants to a person and stay
+    // author-only.
+    private fun mayExecute(userDetails: UserDetailsWithId): Boolean =
+        request.type == RequestType.SingleExecution || request.author.getId() == userDetails.id
 
     private fun isExecutable(): Boolean {
         // If approved, always executable

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/websocket/SessionService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/websocket/SessionService.kt
@@ -35,14 +35,14 @@ class SessionService(
     }
 
     @Policy(Permission.EXECUTION_REQUEST_EXECUTE)
-    fun executeStatement(sessionId: LiveSessionId, statement: String): ExecutionResult {
+    fun executeStatement(sessionId: LiveSessionId, statement: String, userId: String): ExecutionResult {
         // Atomically check and set executing flag - this will throw if already executing
         val session = sessionAdapter.checkAndSetExecuting(sessionId)
 
         return executionRequestService.execute(
             session.executionRequest.request.id!!,
             statement,
-            session.executionRequest.request.author.getId()!!,
+            userId,
         )
     }
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
@@ -9,6 +9,7 @@ import dev.kviklet.kviklet.service.dto.Connection
 import dev.kviklet.kviklet.service.dto.ExecutionRequestDetails
 import dev.kviklet.kviklet.service.dto.Policy
 import dev.kviklet.kviklet.service.dto.PolicyEffect
+import dev.kviklet.kviklet.service.dto.RequestType
 import jakarta.servlet.http.Cookie
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.hasSize
@@ -257,7 +258,7 @@ class ExecutionTest {
         }
 
         @Test
-        fun `only request creator can execute the request`() {
+        fun `non-author with execute permission can execute a single execution request`() {
             // Create and approve an execution request
             val executionRequest = executionRequestHelper.createExecutionRequest(
                 db,
@@ -267,11 +268,64 @@ class ExecutionTest {
             val reviewerCookie = userHelper.login(email = testReviewer.email, mockMvc = mockMvc)
             approveRequest(executionRequest.getId(), "Approved", reviewerCookie)
 
+            executeRequestAndAssert(executionRequest.getId(), reviewerCookie)
+
+            // The execute event is attributed to the actual executor, not the request author
+            mockMvc.perform(
+                get("/executions/").cookie(reviewerCookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.executions[0].requestId").value(executionRequest.getId()))
+                .andExpect(jsonPath("$.executions[0].name").value(testReviewer.fullName))
+        }
+
+        @Test
+        fun `non-author without execute permission cannot execute a single execution request`() {
+            val executionRequest = executionRequestHelper.createExecutionRequest(
+                db,
+                testUser,
+                connection = testConnection,
+            )
+            val reviewerCookie = userHelper.login(email = testReviewer.email, mockMvc = mockMvc)
+            approveRequest(executionRequest.getId(), "Approved", reviewerCookie)
+
+            val userWithoutExecutePermission = userHelper.createUser(
+                permissions = listOf("execution_request:get", "datasource_connection:get"),
+                resources = listOf("*", "*"),
+            )
+            val cookie = userHelper.login(email = userWithoutExecutePermission.email, mockMvc = mockMvc)
+
             mockMvc.perform(
                 post("/execution-requests/${executionRequest.getId()}/execute")
-                    .cookie(reviewerCookie)
+                    .cookie(cookie)
                     .contentType("application/json"),
             ).andExpect(status().isForbidden)
+        }
+
+        @Test
+        fun `only the author can execute a temporary access request`() {
+            val temporaryAccessRequest = executionRequestHelper.createApprovedRequest(
+                db,
+                testUser,
+                testReviewer,
+                connection = testConnection,
+                requestType = RequestType.TemporaryAccess,
+            )
+            val reviewerCookie = userHelper.login(email = testReviewer.email, mockMvc = mockMvc)
+
+            mockMvc.perform(
+                post("/execution-requests/${temporaryAccessRequest.getId()}/execute")
+                    .cookie(reviewerCookie)
+                    .content("""{"query": "SELECT 1;"}""")
+                    .contentType("application/json"),
+            ).andExpect(status().isForbidden)
+
+            val authorCookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+            mockMvc.perform(
+                post("/execution-requests/${temporaryAccessRequest.getId()}/execute")
+                    .cookie(authorCookie)
+                    .content("""{"query": "SELECT 1;"}""")
+                    .contentType("application/json"),
+            ).andExpect(status().isOk)
         }
 
         @Test

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/SessionServiceTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/SessionServiceTest.kt
@@ -76,7 +76,7 @@ class SessionServiceTest {
 
     @AfterEach
     fun cleanup() {
-        sessionService.executeStatement(testLiveSession, "DROP TABLE IF EXISTS test_table")
+        sessionService.executeStatement(testLiveSession, "DROP TABLE IF EXISTS test_table", testUser.getId()!!)
         liveSessionHelper.deleteAll()
         executionRequestHelper.deleteAll()
         connectionHelper.deleteAll()
@@ -85,7 +85,7 @@ class SessionServiceTest {
 
     @Test
     fun testExecuteStatementSimpleSelect() {
-        val result = sessionService.executeStatement(testLiveSession, "SELECT 1 as test")
+        val result = sessionService.executeStatement(testLiveSession, "SELECT 1 as test", testUser.getId()!!)
 
         assertTrue(result is DBExecutionResult)
         result as DBExecutionResult
@@ -106,7 +106,7 @@ class SessionServiceTest {
             SELECT * FROM test_table ORDER BY id;
         """.trimIndent()
 
-        val result = sessionService.executeStatement(testLiveSession, multipleStatements)
+        val result = sessionService.executeStatement(testLiveSession, multipleStatements, testUser.getId()!!)
 
         assertTrue(result is DBExecutionResult)
         result as DBExecutionResult
@@ -135,12 +135,17 @@ class SessionServiceTest {
     @Test
     fun testExecuteStatementDataModification() {
         // Setup: Create a table
-        sessionService.executeStatement(testLiveSession, "CREATE TABLE test_table (id INT, name VARCHAR(50))")
+        sessionService.executeStatement(
+            testLiveSession,
+            "CREATE TABLE test_table (id INT, name VARCHAR(50))",
+            testUser.getId()!!,
+        )
 
         // Test INSERT
         val insertResult = sessionService.executeStatement(
             testLiveSession,
             "INSERT INTO test_table VALUES (1, 'Alice'), (2, 'Bob')",
+            testUser.getId()!!,
         )
         assertTrue(insertResult is DBExecutionResult)
         insertResult as DBExecutionResult
@@ -151,6 +156,7 @@ class SessionServiceTest {
         val updateResult = sessionService.executeStatement(
             testLiveSession,
             "UPDATE test_table SET name = 'Charlie' WHERE id = 1",
+            testUser.getId()!!,
         )
         assertTrue(updateResult is DBExecutionResult)
         updateResult as DBExecutionResult
@@ -158,14 +164,22 @@ class SessionServiceTest {
         assertEquals(1, (updateResult.results[0] as UpdateQueryResult).rowsUpdated)
 
         // Test DELETE
-        val deleteResult = sessionService.executeStatement(testLiveSession, "DELETE FROM test_table WHERE id = 2")
+        val deleteResult = sessionService.executeStatement(
+            testLiveSession,
+            "DELETE FROM test_table WHERE id = 2",
+            testUser.getId()!!,
+        )
         assertTrue(deleteResult is DBExecutionResult)
         deleteResult as DBExecutionResult
         assertTrue(deleteResult.results[0] is UpdateQueryResult)
         assertEquals(1, (deleteResult.results[0] as UpdateQueryResult).rowsUpdated)
 
         // Verify final state
-        val selectResult = sessionService.executeStatement(testLiveSession, "SELECT * FROM test_table")
+        val selectResult = sessionService.executeStatement(
+            testLiveSession,
+            "SELECT * FROM test_table",
+            testUser.getId()!!,
+        )
         assertTrue(selectResult is DBExecutionResult)
         selectResult as DBExecutionResult
         assertTrue(selectResult.results[0] is RecordsQueryResult)

--- a/frontend/src/routes/LiveSessionWebsockets.tsx
+++ b/frontend/src/routes/LiveSessionWebsockets.tsx
@@ -20,6 +20,7 @@ import {
   ThemeContext,
   ThemeStatusContext,
 } from "../components/ThemeStatusProvider";
+import { UserStatusContext } from "../components/UserStatusProvider";
 
 interface LiveSessionWebsocketsProps {
   requestId: string;
@@ -90,6 +91,15 @@ const LiveSessionWebsockets: React.FC<LiveSessionWebsocketsProps> = ({
   }, [isSyncing]);
 
   const { request } = useRequest(requestId);
+  const userContext = useContext(UserStatusContext);
+  const isAuthor =
+    !!request &&
+    !!userContext.userStatus &&
+    userContext.userStatus.id === request.author?.id;
+
+  useEffect(() => {
+    editor?.updateOptions({ readOnly: !isAuthor });
+  }, [editor, isAuthor]);
 
   useEffect(() => {
     if (monacoEl.current) {
@@ -173,20 +183,30 @@ const LiveSessionWebsockets: React.FC<LiveSessionWebsocketsProps> = ({
           </div>
         </div>
         <div className="mb-4 flex flex-row items-center justify-end gap-2">
-          {request?._type === "DATASOURCE" && isRelationalDatabase(request) && (
-            <a href="#" onClick={handleResultDownload}>
-              <Button>Execute and Download Results</Button>
-            </a>
+          {isAuthor ? (
+            <>
+              {request?._type === "DATASOURCE" &&
+                isRelationalDatabase(request) && (
+                  <a href="#" onClick={handleResultDownload}>
+                    <Button>Execute and Download Results</Button>
+                  </a>
+                )}
+              <LoadingCancelButton
+                onClick={onExecuteQueryClick}
+                onCancel={() => cancelQuery()}
+                variant="primary"
+                dataTestId="run-query-button"
+              >
+                <div className="play-triangle mr-2 inline-block h-3 w-2 bg-slate-50"></div>
+                Run Query
+              </LoadingCancelButton>
+            </>
+          ) : (
+            <div className="text-sm text-slate-500 dark:text-slate-400">
+              You are watching this session — only{" "}
+              {request?.author?.fullName || "the requester"} can run statements.
+            </div>
           )}
-          <LoadingCancelButton
-            onClick={onExecuteQueryClick}
-            onCancel={() => cancelQuery()}
-            variant="primary"
-            dataTestId="run-query-button"
-          >
-            <div className="play-triangle mr-2 inline-block h-3 w-2 bg-slate-50"></div>
-            Run Query
-          </LoadingCancelButton>
         </div>
         {updatedRows !== undefined && (
           <div className="mb-4 text-green-500">{updatedRows} rows updated</div>

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, MouseEvent } from "react";
+import { useContext, useEffect, useState, MouseEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   DatasourceExecutionRequestResponseWithComments,
@@ -16,6 +16,7 @@ import SQLDumpConfirm from "../../components/SQLDumpConfirm";
 import useNotification from "../../hooks/useNotification";
 import { Highlighter } from "./components/Highlighter";
 import ApprovalProgress from "./ApprovalProgress";
+import { UserStatusContext } from "../../components/UserStatusProvider";
 
 function DatasourceRequestBox({
   request,
@@ -32,6 +33,10 @@ function DatasourceRequestBox({
 }) {
   const [editMode, setEditMode] = useState(false);
   const { addNotification } = useNotification();
+  const userContext = useContext(UserStatusContext);
+  const isAuthor =
+    !!userContext.userStatus &&
+    userContext.userStatus.id === request?.author?.id;
   const [showSQLDumpModal, setShowSQLDumpModal] = useState(false);
   const navigate = useNavigate();
   const [statement, setStatement] = useState(request?.statement || "");
@@ -69,6 +74,8 @@ function DatasourceRequestBox({
       return "Request needs to be approved before execution";
     } else if (request?.executionStatus === "EXECUTED") {
       return "Request has already been executed";
+    } else if (request?.type === "Dump" && !isAuthor) {
+      return "Only the requester can download the dump";
     }
     return undefined;
   };
@@ -141,7 +148,10 @@ function DatasourceRequestBox({
             onClick: () => {
               void startServer();
             },
-            enabled: request?.reviewStatus === "APPROVED",
+            enabled: isAuthor && request?.reviewStatus === "APPROVED",
+            tooltip: isAuthor
+              ? undefined
+              : "Proxy access is granted only to the requester",
             content: "Start Proxy",
           },
         ]
@@ -326,7 +336,8 @@ function DatasourceRequestBox({
                 variant="primary"
                 disabled={
                   request?.reviewStatus !== "APPROVED" ||
-                  request?.executionStatus === "EXECUTED"
+                  request?.executionStatus === "EXECUTED" ||
+                  (request?.type === "Dump" && !isAuthor)
                 }
                 onClick={handleButtonClick}
                 onCancel={() => void cancelQuery()}
@@ -336,7 +347,9 @@ function DatasourceRequestBox({
                 {request?.type === "SingleExecution"
                   ? "Run Query"
                   : request?.type === "TemporaryAccess"
-                  ? "Start Session"
+                  ? isAuthor
+                    ? "Start Session"
+                    : "Watch Session"
                   : "Get SQL Dump"}
               </LoadingCancelButton>
             ) : (
@@ -355,7 +368,9 @@ function DatasourceRequestBox({
               >
                 {request?.type == "SingleExecution"
                   ? "Run Query"
-                  : "Start Session"}
+                  : isAuthor
+                  ? "Start Session"
+                  : "Watch Session"}
               </Button>
             )}
           </div>

--- a/frontend/src/routes/Review/KubernetesRequestBox.tsx
+++ b/frontend/src/routes/Review/KubernetesRequestBox.tsx
@@ -5,8 +5,9 @@ import Button from "../../components/Button";
 import { timeSince } from "../Requests";
 import MenuDropDown from "../../components/MenuDropdown";
 import { Highlighter } from "./components/Highlighter";
-import { FC, useEffect, useState, MouseEvent } from "react";
+import { FC, useContext, useEffect, useState, MouseEvent } from "react";
 import ApprovalProgress from "./ApprovalProgress";
+import { UserStatusContext } from "../../components/UserStatusProvider";
 
 interface KubernetesRequestBoxProps {
   request: KubernetesExecutionRequestResponseWithComments;
@@ -22,6 +23,10 @@ const KubernetesRequestBox: FC<KubernetesRequestBoxProps> = ({
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [command, setCommand] = useState(request?.command || "");
+  const userContext = useContext(UserStatusContext);
+  const isAuthor =
+    !!userContext.userStatus &&
+    userContext.userStatus.id === request?.author?.id;
 
   const navigate = useNavigate();
 
@@ -135,7 +140,9 @@ const KubernetesRequestBox: FC<KubernetesRequestBoxProps> = ({
             >
               {request?.type == "SingleExecution"
                 ? "Run Command"
-                : "Start Session"}
+                : isAuthor
+                ? "Start Session"
+                : "Watch Session"}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
Anyone with execute permission on a connection can now execute approved **SingleExecution** requests, not just the request author. The rationale: approvals on single executions attach to the reviewed statement (which is frozen at review time — editing resets approvals), so who presses the button doesn't change what was vetted.

**Temporary access and dump requests stay author-only** — those approvals are grants to a person, not a statement. The proxy path keeps its existing author check, and the websocket path still rejects execute/update from non-authors.

Changes:

- `ExecutionRequestDetails.auth()` now allows `EXECUTION_REQUEST_EXECUTE` for non-authors on SingleExecution requests only.
- Live session executions are attributed to the user who sent the execute message instead of always the request author (previously masked by the author-only check, but would have falsified the audit trail once cross-user execution became possible anywhere).
- Frontend: non-authors on temporary access requests see **Watch Session** instead of Start Session and get the live session read-only (editor locked, run/download hidden, note showing who can run statements). Start Proxy and Get SQL Dump are disabled for non-authors with an explanatory tooltip.

Note for the changelog: existing users with a broad execute policy (e.g. the default role) can execute other people's approved single execution requests after this change.