### PR TITLE
Allow comments on rejected requests

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -472,17 +472,12 @@ class ExecutionRequestService(
 
     @Transactional
     @Policy(Permission.EXECUTION_REQUEST_GET)
-    fun createComment(id: ExecutionRequestId, request: CreateCommentRequest, authorId: String): Event {
-        val executionRequest = executionRequestAdapter.getExecutionRequestDetails(id)
-        if (executionRequest.resolveReviewStatus() == ReviewStatus.REJECTED) {
-            throw InvalidReviewException("Can't comment on a rejected request!")
-        }
-        return eventService.saveEvent(
+    fun createComment(id: ExecutionRequestId, request: CreateCommentRequest, authorId: String): Event =
+        eventService.saveEvent(
             id,
             authorId,
             CommentPayload(comment = request.comment),
         )
-    }
 
     private fun executeDatasourceRequest(
         id: ExecutionRequestId,

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
@@ -142,15 +142,13 @@ class ExecutionTest {
         }
 
         @Test
-        fun `Request is locked from further events after rejection`() {
+        fun `Request is locked from reviews and execution after rejection`() {
             val cookie = userHelper.login(email = testReviewer.email, mockMvc = mockMvc)
             rejectRequest(testExecutionRequest.getId(), "This request is too sensitive.", cookie)
                 .andExpect(status().isOk)
             verifyRequestStatus(testExecutionRequest.getId(), "REJECTED", cookie)
 
-            performCommentAction(testExecutionRequest.getId(), "This comment should not be added", cookie)
-                .andExpect(status().is4xxClientError)
-            approveRequest(testExecutionRequest.getId(), "This should also not work.", cookie)
+            approveRequest(testExecutionRequest.getId(), "This should not work.", cookie)
                 .andExpect(status().is4xxClientError)
             executeRequest(testExecutionRequest.getId(), cookie)
                 .andExpect(status().is4xxClientError)
@@ -158,6 +156,22 @@ class ExecutionTest {
             // Verify that no new events were added after rejection
             verifyRequestEvents(testExecutionRequest.getId(), 1, cookie)
             verifyLatestEvent(testExecutionRequest.getId(), "REVIEW", "REJECT", cookie)
+        }
+
+        @Test
+        fun `Comments can still be added after rejection`() {
+            val cookie = userHelper.login(email = testReviewer.email, mockMvc = mockMvc)
+            rejectRequest(testExecutionRequest.getId(), "This request is too sensitive.", cookie)
+                .andExpect(status().isOk)
+            verifyRequestStatus(testExecutionRequest.getId(), "REJECTED", cookie)
+
+            performCommentAction(testExecutionRequest.getId(), "Some additional context for the rejection", cookie)
+                .andExpect(status().isOk)
+
+            verifyRequestEvents(testExecutionRequest.getId(), 2, cookie)
+            verifyLatestEvent(testExecutionRequest.getId(), "COMMENT", null, cookie)
+            // The request stays rejected, a comment doesn't change the status
+            verifyRequestStatus(testExecutionRequest.getId(), "REJECTED", cookie)
         }
 
         @Test

--- a/frontend/src/routes/Review/ActivityTimeline.tsx
+++ b/frontend/src/routes/Review/ActivityTimeline.tsx
@@ -52,6 +52,7 @@ export default function ActivityTimeline({
             sendReview={sendReview}
             closeRequest={closeRequest}
             userId={request?.author?.id}
+            isRejected={request.reviewStatus === "REJECTED"}
           ></CommentBox>
         )}
         {events.map((event, index) => {

--- a/frontend/src/routes/Review/CommentBox/index.tsx
+++ b/frontend/src/routes/Review/CommentBox/index.tsx
@@ -10,10 +10,12 @@ function CommentBox({
   sendReview,
   closeRequest,
   userId,
+  isRejected,
 }: {
   sendReview: (comment: string, type: ReviewTypes) => Promise<boolean>;
   closeRequest?: (comment: string) => Promise<boolean>;
   userId?: string;
+  isRejected?: boolean;
 }) {
   const [expanded, setExpanded] = useState<boolean>(false);
   const [previewVisible, setPreviewVisible] = useState<boolean>(false);
@@ -40,7 +42,7 @@ function CommentBox({
       id: ReviewTypes.Approve,
       title: "Approve",
       description: "Give your approval to execute this request",
-      enabled: !isOwnRequest,
+      enabled: !isOwnRequest && !isRejected,
       danger: false,
     },
     {
@@ -48,21 +50,21 @@ function CommentBox({
       title: "Request Changes",
       description:
         "Request a change on this Request, you can later approve it again",
-      enabled: !isOwnRequest,
+      enabled: !isOwnRequest && !isRejected,
       danger: true,
     },
     {
       id: ReviewTypes.Reject,
       title: "Reject",
       description: "Reject this request from ever executing",
-      enabled: !isOwnRequest,
+      enabled: !isOwnRequest && !isRejected,
       danger: true,
     },
     {
       id: ReviewTypes.Close,
       title: "Close",
       description: "Close this request without executing it",
-      enabled: !!(isOwnRequest && closeRequest),
+      enabled: !!(isOwnRequest && closeRequest) && !isRejected,
       danger: false,
     },
   ];
@@ -205,7 +207,9 @@ function CommentBox({
           className="w-full rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-left text-sm text-slate-500 shadow-sm transition-colors hover:border-slate-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400 dark:hover:border-slate-600"
           onClick={() => setExpanded(true)}
         >
-          {isOwnRequest ? "Leave a comment…" : "Leave a comment or review…"}
+          {isOwnRequest || isRejected
+            ? "Leave a comment…"
+            : "Leave a comment or review…"}
         </button>
       )}
     </div>


### PR DESCRIPTION
Removes the rejected-status check from `createComment` so comments can still be added after a request was rejected or closed (fixes #506). Comments are plain events and don't affect the review status, so a rejected request stays rejected — reviews and execution remain locked via the existing checks in `createReview` and the execution path.

On the review page, the Approve/Request Changes/Reject/Close options are now disabled for rejected requests, leaving only Comment selectable.