### PR TITLE
Add cross-site request protections for session auth

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/Config.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/Config.kt
@@ -42,8 +42,11 @@ class WebSocketConfig : WebSocketConfigurer {
     lateinit var corsSettings: CorsSettings
 
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
+        // "*" disables Spring's built-in strict origin check (which compares scheme and
+        // port and breaks behind reverse proxies); WebSocketOriginInterceptor enforces
+        // origin validation instead.
         registry.addHandler(sessionWebsocketHandler, "/sql/{requestId}")
-            .addInterceptors(AuthHandshakeInterceptor())
+            .addInterceptors(WebSocketOriginInterceptor(corsSettings.allowedOrigins), AuthHandshakeInterceptor())
             .setAllowedOriginPatterns("*")
     }
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/WebSocketOriginInterceptor.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/WebSocketOriginInterceptor.kt
@@ -1,0 +1,55 @@
+package dev.kviklet.kviklet
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.socket.WebSocketHandler
+import org.springframework.web.socket.server.HandshakeInterceptor
+import java.net.URI
+
+/**
+ * Validates the Origin header of WebSocket handshakes, since the session cookie
+ * authenticates them and browsers attach it cross-site when SameSite=None (SAML).
+ *
+ * An origin is accepted if its hostname matches the request's hostname (the same
+ * boundary cookie SameSite policies use, and robust behind reverse proxies that
+ * rewrite ports/schemes) or if it matches a configured CORS origin pattern.
+ * Requests without an Origin header (non-browser clients) are allowed; browsers
+ * always send Origin on WebSocket handshakes.
+ */
+class WebSocketOriginInterceptor(allowedOrigins: List<String>) : HandshakeInterceptor {
+
+    private val corsConfiguration = CorsConfiguration().apply {
+        allowedOriginPatterns = allowedOrigins
+    }
+
+    override fun beforeHandshake(
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+        wsHandler: WebSocketHandler,
+        attributes: MutableMap<String, Any>,
+    ): Boolean {
+        val origin = request.headers.origin ?: return true
+
+        val originHost = runCatching { URI(origin).host }.getOrNull()
+        if (originHost != null && originHost.equals(request.uri.host, ignoreCase = true)) {
+            return true
+        }
+        if (corsConfiguration.checkOrigin(origin) != null) {
+            return true
+        }
+
+        response.setStatusCode(HttpStatus.FORBIDDEN)
+        return false
+    }
+
+    override fun afterHandshake(
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+        wsHandler: WebSocketHandler,
+        exception: Exception?,
+    ) {
+        // No action needed after handshake
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/CsrfHeaderFilter.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/CsrfHeaderFilter.kt
@@ -1,0 +1,53 @@
+package dev.kviklet.kviklet.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * CSRF protection for the session-cookie authenticated filter chain.
+ *
+ * Instead of synchronizer tokens, state-changing requests must carry a custom header.
+ * Browsers cannot attach custom headers to form submissions or top-level navigations,
+ * and a cross-site fetch() with a custom header triggers a CORS preflight that fails
+ * unless the origin is explicitly allowed. This keeps the session cookie from being
+ * usable cross-site even with SameSite=None (required for SAML).
+ *
+ * Login-flow endpoints are exempt because they receive plain browser navigations
+ * (IdP redirects and form posts) which can never carry the header.
+ */
+class CsrfHeaderFilter : OncePerRequestFilter() {
+
+    companion object {
+        const val CSRF_HEADER_NAME = "X-Kviklet-Request"
+    }
+
+    private val safeMethods = setOf("GET", "HEAD", "OPTIONS", "TRACE")
+
+    private val exemptPathPrefixes = listOf(
+        "/login",
+        "/saml2/",
+        "/oauth2",
+        "/logout/saml2",
+    )
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        if (requiresHeader(request) && request.getHeader(CSRF_HEADER_NAME) == null) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Missing $CSRF_HEADER_NAME header")
+            return
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    private fun requiresHeader(request: HttpServletRequest): Boolean {
+        if (request.method in safeMethods) {
+            return false
+        }
+        return exemptPathPrefixes.none { request.requestURI.startsWith(it) }
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
@@ -186,6 +186,7 @@ class SecurityConfig(
         http.invoke {
             // Don't add ApiKeyAuthFilter here - it's handled by the API key chain
             addFilterBefore<WebAsyncManagerIntegrationFilter>(ForwardedHeaderFilter())
+            addFilterBefore<UsernamePasswordAuthenticationFilter>(CsrfHeaderFilter())
             if (corsSettings.allowedOrigins.isNotEmpty()) {
                 cors { }
             }
@@ -246,6 +247,8 @@ class SecurityConfig(
                 deleteCookies("JSESSIONID")
                 logoutSuccessHandler = HttpStatusReturningLogoutSuccessHandler()
             }
+            // Token-based CSRF protection is disabled in favor of CsrfHeaderFilter,
+            // which requires a custom header on state-changing requests (see its docs)
             csrf {
                 disable()
             }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/CsrfHeaderFilterTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/CsrfHeaderFilterTest.kt
@@ -1,0 +1,114 @@
+package dev.kviklet.kviklet
+
+import dev.kviklet.kviklet.helper.RoleHelper
+import dev.kviklet.kviklet.helper.UserHelper
+import dev.kviklet.kviklet.security.CsrfHeaderFilter
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.session.web.http.SessionRepositoryFilter
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+
+/**
+ * Tests for the CSRF custom header requirement on the session-authenticated chain.
+ *
+ * Builds its own MockMvc without the CsrfHeaderTestConfig customizer, so requests
+ * do NOT carry the X-Kviklet-Request header unless a test adds it explicitly.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class CsrfHeaderFilterTest {
+
+    @Autowired
+    private lateinit var context: WebApplicationContext
+
+    @Autowired
+    private lateinit var userHelper: UserHelper
+
+    @Autowired
+    private lateinit var roleHelper: RoleHelper
+
+    private lateinit var mockMvc: MockMvc
+
+    private val createUserJson = """
+        {
+            "email": "someemail@email.de",
+            "password": "123456",
+            "fullName": "Some User"
+        }
+    """.trimIndent()
+
+    @BeforeEach
+    fun setUp() {
+        // The session repository filter is added manually since only @AutoConfigureMockMvc
+        // registers servlet filter beans automatically; without it login sets no SESSION cookie
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+            .addFilters<DefaultMockMvcBuilder>(context.getBean(SessionRepositoryFilter::class.java))
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        userHelper.deleteAll()
+        roleHelper.deleteAll()
+    }
+
+    @Test
+    fun `mutating request without csrf header is rejected`() {
+        userHelper.createUser(permissions = listOf("*"))
+        val cookie = userHelper.login(mockMvc = mockMvc)
+
+        mockMvc.perform(
+            post("/users/").cookie(cookie).content(createUserJson).contentType("application/json"),
+        ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `mutating request with csrf header succeeds`() {
+        userHelper.createUser(permissions = listOf("*"))
+        val cookie = userHelper.login(mockMvc = mockMvc)
+
+        mockMvc.perform(
+            post("/users/").cookie(cookie).content(createUserJson).contentType("application/json")
+                .header(CsrfHeaderFilter.CSRF_HEADER_NAME, "true"),
+        ).andExpect(status().isOk)
+    }
+
+    @Test
+    fun `read request without csrf header succeeds`() {
+        userHelper.createUser(permissions = listOf("*"))
+        val cookie = userHelper.login(mockMvc = mockMvc)
+
+        mockMvc.perform(get("/users/").cookie(cookie))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `login endpoint is exempt from csrf header requirement`() {
+        userHelper.createUser(permissions = listOf("*"))
+
+        // UserHelper.login posts to /login without the header and asserts a 200
+        userHelper.login(mockMvc = mockMvc)
+    }
+
+    @Test
+    fun `bearer token requests are not subject to the csrf header requirement`() {
+        // The API key chain handles Bearer requests: an invalid key is rejected with
+        // 401 by ApiKeyAuthFilter, not 403 by CsrfHeaderFilter
+        mockMvc.perform(
+            post("/users/").content(createUserJson).contentType("application/json")
+                .header("Authorization", "Bearer invalid-api-key-12345"),
+        ).andExpect(status().isUnauthorized)
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/WebSocketOriginInterceptorTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/WebSocketOriginInterceptorTest.kt
@@ -1,0 +1,113 @@
+package dev.kviklet.kviklet
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.web.socket.WebSocketHandler
+import java.net.URI
+
+class WebSocketOriginInterceptorTest {
+
+    private val wsHandler = mockk<WebSocketHandler>()
+
+    private fun handshake(
+        interceptor: WebSocketOriginInterceptor,
+        requestUri: String,
+        origin: String?,
+    ): Pair<Boolean, HttpStatus?> {
+        val headers = HttpHeaders()
+        origin?.let { headers.origin = it }
+
+        val request = mockk<ServerHttpRequest> {
+            every { this@mockk.headers } returns headers
+            every { uri } returns URI(requestUri)
+        }
+        var status: HttpStatus? = null
+        val response = mockk<ServerHttpResponse> {
+            every { setStatusCode(any()) } answers { status = firstArg() }
+        }
+
+        val allowed = interceptor.beforeHandshake(request, response, wsHandler, mutableMapOf())
+        return allowed to status
+    }
+
+    @Test
+    fun `allows same hostname regardless of scheme and port`() {
+        val interceptor = WebSocketOriginInterceptor(emptyList())
+
+        val (allowed, _) = handshake(
+            interceptor,
+            requestUri = "http://kviklet.example.com:8080/sql/abc",
+            origin = "https://kviklet.example.com",
+        )
+        assertTrue(allowed)
+    }
+
+    @Test
+    fun `rejects foreign origin when no origins are configured`() {
+        val interceptor = WebSocketOriginInterceptor(emptyList())
+
+        val (allowed, status) = handshake(
+            interceptor,
+            requestUri = "https://kviklet.example.com/sql/abc",
+            origin = "https://evil.example.org",
+        )
+        assertFalse(allowed)
+        assertTrue(status == HttpStatus.FORBIDDEN)
+    }
+
+    @Test
+    fun `allows configured cors origin`() {
+        val interceptor = WebSocketOriginInterceptor(listOf("http://localhost:5173"))
+
+        val (allowed, _) = handshake(
+            interceptor,
+            requestUri = "http://backend.internal:8081/sql/abc",
+            origin = "http://localhost:5173",
+        )
+        assertTrue(allowed)
+    }
+
+    @Test
+    fun `allows configured wildcard origin pattern`() {
+        val interceptor = WebSocketOriginInterceptor(listOf("https://*.example.com"))
+
+        val (allowed, _) = handshake(
+            interceptor,
+            requestUri = "http://backend.internal:8081/sql/abc",
+            origin = "https://app.example.com",
+        )
+        assertTrue(allowed)
+    }
+
+    @Test
+    fun `rejects origin not matching configured origins`() {
+        val interceptor = WebSocketOriginInterceptor(listOf("http://localhost:5173"))
+
+        val (allowed, status) = handshake(
+            interceptor,
+            requestUri = "http://backend.internal:8081/sql/abc",
+            origin = "https://evil.example.org",
+        )
+        assertFalse(allowed)
+        assertTrue(status == HttpStatus.FORBIDDEN)
+    }
+
+    @Test
+    fun `allows requests without origin header`() {
+        val interceptor = WebSocketOriginInterceptor(emptyList())
+
+        val (allowed, _) = handshake(
+            interceptor,
+            requestUri = "https://kviklet.example.com/sql/abc",
+            origin = null,
+        )
+        assertTrue(allowed)
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/helper/CsrfHeaderTestConfig.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/helper/CsrfHeaderTestConfig.kt
@@ -1,0 +1,23 @@
+package dev.kviklet.kviklet.helper
+
+import dev.kviklet.kviklet.security.CsrfHeaderFilter
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcBuilderCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+
+/**
+ * Adds the CSRF header to every MockMvc request by default, mirroring what the
+ * frontend does for all API calls. Tests that need to exercise requests without
+ * the header (e.g. CsrfHeaderFilterTest) build their own MockMvc instance.
+ */
+@AutoConfiguration
+class CsrfHeaderTestConfig {
+
+    @Bean
+    fun csrfHeaderMockMvcCustomizer(): MockMvcBuilderCustomizer = MockMvcBuilderCustomizer { builder ->
+        builder.defaultRequest(
+            MockMvcRequestBuilders.get("/").header(CsrfHeaderFilter.CSRF_HEADER_NAME, "true"),
+        )
+    }
+}

--- a/backend/src/test/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/backend/src/test/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.kviklet.kviklet.helper.CsrfHeaderTestConfig

--- a/frontend/src/api/ConfigApi.ts
+++ b/frontend/src/api/ConfigApi.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import baseUrl from "./base";
+import baseUrl, { apiFetch } from "./base";
 import { ApiResponse, fetchWithErrorHandling } from "./Errors";
 
 const ConfigResponseSchema = z.object({
@@ -69,7 +69,7 @@ export async function uploadLicense(file: File): Promise<boolean> {
   formData.append("file", file);
 
   try {
-    const response = await fetch(`${baseUrl}/config/license/`, {
+    const response = await apiFetch(`${baseUrl}/config/license/`, {
       method: "POST",
       body: formData,
       credentials: "include",

--- a/frontend/src/api/Errors.ts
+++ b/frontend/src/api/Errors.ts
@@ -1,4 +1,5 @@
 import { ZodSchema, ZodTypeDef, z } from "zod";
+import { apiFetch } from "./base";
 
 export const ApiErrorResponseSchema = z.object({
   message: z.string(),
@@ -35,7 +36,7 @@ export async function fetchWithErrorHandling<Output, Input = Output>(
   schema: ZodSchema<Output, ZodTypeDef, Input>,
 ): Promise<ApiResponse<Output>> {
   try {
-    const response = await fetch(url, options);
+    const response = await apiFetch(url, options);
     const json: unknown = await response.json();
 
     return parseSchemaOrError(schema, json);
@@ -52,7 +53,7 @@ async function fetchEmptyWithErrorHandling(
   options: RequestInit,
 ): Promise<ApiErrorResponse | null> {
   try {
-    const response = await fetch(url, options);
+    const response = await apiFetch(url, options);
     if (
       response.status === 204 ||
       response.headers.get("Content-Length") === "0"

--- a/frontend/src/api/ExecutionRequestApi.ts
+++ b/frontend/src/api/ExecutionRequestApi.ts
@@ -5,7 +5,7 @@ import {
   databaseConnectionResponseSchema,
 } from "./DatasourceApi";
 import { roleResponseSchema } from "./RoleApi";
-import baseUrl from "./base";
+import baseUrl, { apiFetch } from "./base";
 import {
   ApiErrorResponse,
   ApiResponse,
@@ -423,7 +423,7 @@ const streamDump = async (
   executionRequestId: string,
 ): Promise<ReadableStream<Uint8Array>> => {
   // Request SQL dump data from the backend which returns an array of encoded strings in chunks
-  const response = await fetch(`${requestUrl}${executionRequestId}/dump`, {
+  const response = await apiFetch(`${requestUrl}${executionRequestId}/dump`, {
     method: "GET",
     credentials: "include",
   });

--- a/frontend/src/api/ExecutionsApi.ts
+++ b/frontend/src/api/ExecutionsApi.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import baseUrl from "./base";
+import baseUrl, { apiFetch } from "./base";
 import { ApiResponse, fetchWithErrorHandling } from "./Errors";
 
 // Define the Zod schema for ExecutionLogResponse
@@ -46,7 +46,7 @@ const getExecutions = async (params?: {
 };
 
 const exportExecutions = async (): Promise<void> => {
-  const response = await fetch(`${baseUrl}/executions/export`, {
+  const response = await apiFetch(`${baseUrl}/executions/export`, {
     method: "GET",
     credentials: "include",
   });

--- a/frontend/src/api/LoginApi.ts
+++ b/frontend/src/api/LoginApi.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { ApiResponse, fetchWithErrorHandling } from "./Errors";
-import baseUrl from "./base";
+import baseUrl, { apiFetch } from "./base";
 
 const loginResponseSchema = z.object({
   sessionId: z.string(),
@@ -30,7 +30,7 @@ const attemptLogin = async (
 };
 
 const logout = async (): Promise<void> => {
-  await fetch(`${baseUrl}/logout`, {
+  await apiFetch(`${baseUrl}/logout`, {
     method: "POST",
     credentials: "include",
   });

--- a/frontend/src/api/StatusApi.ts
+++ b/frontend/src/api/StatusApi.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import baseUrl from "./base";
+import baseUrl, { apiFetch } from "./base";
 
 const StatusResponse = z.object({
   email: z.string(),
@@ -11,7 +11,7 @@ const StatusResponse = z.object({
 type StatusResponse = z.infer<typeof StatusResponse>;
 
 const checklogin = async (): Promise<StatusResponse | false> => {
-  const response = await fetch(baseUrl + "/status", {
+  const response = await apiFetch(baseUrl + "/status", {
     method: "GET",
     credentials: "include",
   });

--- a/frontend/src/api/base.ts
+++ b/frontend/src/api/base.ts
@@ -21,6 +21,16 @@ if (!apiBasePath) {
   }://${window.location.host}${apiBasePath}`;
 }
 
+// All API requests carry this header as CSRF protection: browsers cannot attach
+// custom headers to cross-site requests without a CORS preflight, so the backend
+// rejects state-changing requests without it (see CsrfHeaderFilter in the backend).
+function apiFetch(url: string, options: RequestInit = {}): Promise<Response> {
+  return fetch(url, {
+    ...options,
+    headers: { "X-Kviklet-Request": "true", ...options.headers },
+  });
+}
+
 export default baseUrl;
 
 function withType<T, U extends string>(schema: z.ZodSchema<T>, typeValue: U) {
@@ -30,4 +40,4 @@ function withType<T, U extends string>(schema: z.ZodSchema<T>, typeValue: U) {
   })) as z.ZodSchema<T & { _type: U }>;
 }
 
-export { withType, websocketBaseUrl };
+export { withType, websocketBaseUrl, apiFetch };


### PR DESCRIPTION
Addresses KVI-172 (cross-site protections audit findings).

Session cookies are the sole authentication for the API and the live-session WebSocket, and SAML deployments require `SameSite=None`, which lets browsers attach the cookie to cross-site requests. This adds two compensating controls:

- **Custom-header CSRF protection**: state-changing requests on the session-authenticated chain must carry an `X-Kviklet-Request` header, which the frontend now sends on all API calls. Browsers cannot attach custom headers cross-site without a CORS preflight, so the session cookie alone no longer authorizes mutations. Login-flow endpoints (`/login`, `/saml2`, `/oauth2`) stay exempt since they receive plain browser navigations (e.g. the SAML IdP's POST to the ACS endpoint). The API-key chain is unaffected.
- **WebSocket origin validation**: the `/sql/{requestId}` handshake previously accepted any origin. A new interceptor rejects origins whose hostname differs from the request host unless they match a configured CORS origin pattern, closing the cross-site WebSocket hijacking vector. Hostname comparison (rather than Spring's strict scheme+port check) keeps handshakes working behind reverse proxies that rewrite ports; non-browser clients without an Origin header remain allowed.

`SameSite=None` under SAML is kept as is — it is required for the IdP's cross-site POST to the ACS endpoint, and is no longer load-bearing with the controls above.

Integration tests get the header injected as a MockMvc default via a test auto-configuration, mirroring the frontend behavior.