### PR TITLE
Fix backend CI test sharding (no-op since #344) and resulting test drift

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -13,13 +13,13 @@ jobs:
           - group-3
         include:
           - test-group: group-1
-            test-pattern: "**/[A-I]*"
+            letter-range: "A-I"
             description: "Tests A-I"
           - test-group: group-2
-            test-pattern: "**/[J-O]*"
+            letter-range: "J-O"
             description: "Tests J-O"
           - test-group: group-3
-            test-pattern: "**/[P-Z]*"
+            letter-range: "P-Z"
             description: "Tests P-Z"
     defaults:
       run:
@@ -34,7 +34,34 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
       - name: Run tests for ${{ matrix.description }}
-        run: ./gradlew test --tests ${{ matrix.test-pattern }} --stacktrace --info
+        # Gradle's --tests filter only supports '*' wildcards (no [A-I] character
+        # classes), and prefix patterns like '*.A*' also match test *method* names,
+        # pulling classes into the wrong shard. So enumerate the test classes and
+        # pass each one as an exact '--tests *.ClassName' filter instead.
+        # Note: ArchitectureTest (ArchUnit engine) ignores Gradle's class filter and
+        # runs in every shard — that's expected and cheap.
+        run: |
+          args=()
+          for class in $(find src/test -name '*Test.kt' -exec basename {} .kt \; | sort); do
+            case "$class" in
+              [${{ matrix.letter-range }}]*) args+=(--tests "*.$class") ;;
+            esac
+          done
+          if [ "${#args[@]}" -eq 0 ]; then
+            echo "::error::No test classes matched letter range ${{ matrix.letter-range }}"
+            exit 1
+          fi
+          echo "Running $((${#args[@]} / 2)) test classes: ${args[*]}"
+          ./gradlew test "${args[@]}" --stacktrace --info
+      - name: Verify shard actually ran tests
+        run: |
+          class_count=$(ls build/test-results/test/TEST-*.xml 2>/dev/null | wc -l)
+          test_count=$(grep -ho 'tests="[0-9]*"' build/test-results/test/TEST-*.xml 2>/dev/null | grep -o '[0-9]*' | awk '{s+=$1} END {print s+0}')
+          echo "Shard executed $class_count test classes, $test_count tests"
+          if [ "$class_count" -lt 10 ]; then
+            echo "::error::Test sharding regression: only $class_count test classes ran in this shard (expected at least 10). The --tests filters are likely no longer matching."
+            exit 1
+          fi
   ktlint:
     name: Ktlint
     runs-on: ubuntu-latest

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -90,7 +90,9 @@ dependencies {
     testImplementation("io.mockk:mockk:1.13.4")
     testImplementation("com.ninja-squad:springmockk:4.0.2")
     testImplementation("net.sourceforge.htmlunit:htmlunit:2.70.0")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    // Must match the okhttp version pulled in transitively (kubernetes client-java -> okhttp 5.x);
+    // mockwebserver 4.x crashes with NoClassDefFoundError against okhttp 5 at runtime.
+    testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
 
     // querydsl
     implementation("com.querydsl:querydsl-core:$queryDslVersion")

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionTest.kt
@@ -196,8 +196,9 @@ class ExecutionTest {
             updateExecutionRequest(testExecutionRequest.getId(), updatedStatement, userCookie)
                 .andExpect(status().isOk)
 
-            // Verify events and status is still CHANGE_REQUESTED
-            verifyRequestStatus(testExecutionRequest.getId(), "CHANGE_REQUESTED", reviewerCookie)
+            // An edit resets all prior reviews, including change requests,
+            // so the request goes back to AWAITING_APPROVAL
+            verifyRequestStatus(testExecutionRequest.getId(), "AWAITING_APPROVAL", reviewerCookie)
             verifyRequestEvents(testExecutionRequest.getId(), 2, reviewerCookie)
             verifyLatestEvent(testExecutionRequest.getId(), "EDIT", null, reviewerCookie)
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/GitHubOAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/GitHubOAuthTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -24,6 +25,7 @@ import org.springframework.test.context.DynamicPropertySource
     properties = ["server.port=8084"],
 )
 @ActiveProfiles("test")
+@DirtiesContext
 class GitHubOAuthTest {
 
     @LocalServerPort

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/OIDCRoleSyncTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/OIDCRoleSyncTest.kt
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -41,6 +42,7 @@ import java.time.LocalDateTime
 )
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@DirtiesContext
 @Testcontainers
 class OIDCRoleSyncTest {
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/OIDCTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/OIDCTest.kt
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -30,6 +31,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 )
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@DirtiesContext
 @Testcontainers
 class OIDCTest {
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/SAMLTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/SAMLTest.kt
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -41,6 +42,7 @@ import java.time.LocalDateTime
 )
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@DirtiesContext
 @Testcontainers
 class SAMLTest {
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/SessionServiceTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/SessionServiceTest.kt
@@ -6,6 +6,7 @@ import dev.kviklet.kviklet.helper.ExecutionRequestHelper
 import dev.kviklet.kviklet.helper.LiveSessionHelper
 import dev.kviklet.kviklet.helper.UserHelper
 import dev.kviklet.kviklet.service.dto.DBExecutionResult
+import dev.kviklet.kviklet.service.dto.ExecutionResult
 import dev.kviklet.kviklet.service.dto.LiveSessionId
 import dev.kviklet.kviklet.service.dto.RecordsQueryResult
 import dev.kviklet.kviklet.service.dto.RequestType
@@ -76,16 +77,24 @@ class SessionServiceTest {
 
     @AfterEach
     fun cleanup() {
-        sessionService.executeStatement(testLiveSession, "DROP TABLE IF EXISTS test_table", testUser.getId()!!)
+        executeStatement(testLiveSession, "DROP TABLE IF EXISTS test_table", testUser.getId()!!)
         liveSessionHelper.deleteAll()
         executionRequestHelper.deleteAll()
         connectionHelper.deleteAll()
         userHelper.deleteAll()
     }
 
+    // Executes via the service and then clears the executing flag, like
+    // SessionWebsocketHandler does after each query completes
+    private fun executeStatement(sessionId: LiveSessionId, statement: String, userId: String): ExecutionResult = try {
+        sessionService.executeStatement(sessionId, statement, userId)
+    } finally {
+        sessionService.clearExecutingFlag(sessionId)
+    }
+
     @Test
     fun testExecuteStatementSimpleSelect() {
-        val result = sessionService.executeStatement(testLiveSession, "SELECT 1 as test", testUser.getId()!!)
+        val result = executeStatement(testLiveSession, "SELECT 1 as test", testUser.getId()!!)
 
         assertTrue(result is DBExecutionResult)
         result as DBExecutionResult
@@ -106,7 +115,7 @@ class SessionServiceTest {
             SELECT * FROM test_table ORDER BY id;
         """.trimIndent()
 
-        val result = sessionService.executeStatement(testLiveSession, multipleStatements, testUser.getId()!!)
+        val result = executeStatement(testLiveSession, multipleStatements, testUser.getId()!!)
 
         assertTrue(result is DBExecutionResult)
         result as DBExecutionResult
@@ -135,14 +144,14 @@ class SessionServiceTest {
     @Test
     fun testExecuteStatementDataModification() {
         // Setup: Create a table
-        sessionService.executeStatement(
+        executeStatement(
             testLiveSession,
             "CREATE TABLE test_table (id INT, name VARCHAR(50))",
             testUser.getId()!!,
         )
 
         // Test INSERT
-        val insertResult = sessionService.executeStatement(
+        val insertResult = executeStatement(
             testLiveSession,
             "INSERT INTO test_table VALUES (1, 'Alice'), (2, 'Bob')",
             testUser.getId()!!,
@@ -153,7 +162,7 @@ class SessionServiceTest {
         assertEquals(2, (insertResult.results[0] as UpdateQueryResult).rowsUpdated)
 
         // Test UPDATE
-        val updateResult = sessionService.executeStatement(
+        val updateResult = executeStatement(
             testLiveSession,
             "UPDATE test_table SET name = 'Charlie' WHERE id = 1",
             testUser.getId()!!,
@@ -164,7 +173,7 @@ class SessionServiceTest {
         assertEquals(1, (updateResult.results[0] as UpdateQueryResult).rowsUpdated)
 
         // Test DELETE
-        val deleteResult = sessionService.executeStatement(
+        val deleteResult = executeStatement(
             testLiveSession,
             "DELETE FROM test_table WHERE id = 2",
             testUser.getId()!!,
@@ -175,7 +184,7 @@ class SessionServiceTest {
         assertEquals(1, (deleteResult.results[0] as UpdateQueryResult).rowsUpdated)
 
         // Verify final state
-        val selectResult = sessionService.executeStatement(
+        val selectResult = executeStatement(
             testLiveSession,
             "SELECT * FROM test_table",
             testUser.getId()!!,

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/executor/AbstractJDBCExecutorTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/executor/AbstractJDBCExecutorTest.kt
@@ -8,6 +8,7 @@ import dev.kviklet.kviklet.service.dto.ExecutionRequestId
 import dev.kviklet.kviklet.service.dto.RecordsQueryResult
 import dev.kviklet.kviklet.service.dto.UpdateQueryResult
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -60,11 +61,12 @@ abstract class AbstractJDBCExecutorTest(@Autowired val JDBCExecutorService: JDBC
 
     @Test
     fun testConnectionError() {
-        executeQuery("SELECT 1;", username = "root", password = "foo") shouldBe
-            ErrorQueryResult(
-                1045,
-                "Access denied for user 'root'@'172.17.0.1' (using password: YES)",
-            )
+        // The client IP in the error message depends on the Docker host (e.g. 172.17.0.1
+        // on Linux, 192.168.65.1 on macOS), so don't assert on it
+        val result = executeQuery("SELECT 1;", username = "root", password = "foo") as ErrorQueryResult
+        result.errorCode shouldBe 1045
+        result.message shouldContain "Access denied for user 'root'@"
+        result.message shouldContain "(using password: YES)"
     }
 
     @Test

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/security/AuthenticationProviderValidatorTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/security/AuthenticationProviderValidatorTest.kt
@@ -103,7 +103,6 @@ class AuthenticationProviderValidatorTest {
             .run { context ->
                 assertThat(context).hasFailed()
                 assertThat(context.startupFailure)
-                    .rootCause()
                     .isInstanceOf(IllegalStateException::class.java)
                     .hasMessageContaining("Only one external authentication provider can be enabled at a time")
                     .hasMessageContaining("LDAP")
@@ -126,7 +125,6 @@ class AuthenticationProviderValidatorTest {
             .run { context ->
                 assertThat(context).hasFailed()
                 assertThat(context.startupFailure)
-                    .rootCause()
                     .isInstanceOf(IllegalStateException::class.java)
                     .hasMessageContaining("Only one external authentication provider can be enabled at a time")
                     .hasMessageContaining("LDAP")
@@ -150,7 +148,6 @@ class AuthenticationProviderValidatorTest {
             .run { context ->
                 assertThat(context).hasFailed()
                 assertThat(context.startupFailure)
-                    .rootCause()
                     .isInstanceOf(IllegalStateException::class.java)
                     .hasMessageContaining("Only one external authentication provider can be enabled at a time")
                     .hasMessageContaining("OAuth2/OIDC")
@@ -229,7 +226,6 @@ class AuthenticationProviderValidatorTest {
             .run { context ->
                 assertThat(context).hasFailed()
                 assertThat(context.startupFailure)
-                    .rootCause()
                     .isInstanceOf(IllegalStateException::class.java)
                     .hasMessageContaining("Only one external authentication provider can be enabled at a time")
                     .hasMessageContaining("LDAP")

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/websocket/OidcWebSocketTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/websocket/OidcWebSocketTest.kt
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -52,12 +53,15 @@ import java.util.concurrent.TimeUnit
  */
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    // Each DEFINED_PORT test class needs a unique port: cached Spring contexts from other
-    // test classes keep their server running, so sharing a port fails with PortInUseException
+    // Each DEFINED_PORT test class carries @DirtiesContext (so its server is shut down
+    // after the class instead of idling in the context cache) and its own unique port,
+    // as a safety net: a class missing the annotation would otherwise keep its port
+    // bound for the rest of the JVM and fail later classes with PortInUseException
     properties = ["server.port=8085"],
 )
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@DirtiesContext
 @Testcontainers
 class OidcWebSocketTest {
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/websocket/OidcWebSocketTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/websocket/OidcWebSocketTest.kt
@@ -52,7 +52,9 @@ import java.util.concurrent.TimeUnit
  */
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = ["server.port=8081"],
+    // Each DEFINED_PORT test class needs a unique port: cached Spring contexts from other
+    // test classes keep their server running, so sharing a port fails with PortInUseException
+    properties = ["server.port=8085"],
 )
 @AutoConfigureMockMvc
 @ActiveProfiles("test")

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/websocket/WebSocketHandlerTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/websocket/WebSocketHandlerTest.kt
@@ -140,7 +140,8 @@ class WebSocketHandlerTest {
         val updateMessage = """
             {
                 "type": "update_content",
-                "content": "SELECT * FROM users"
+                "content": "SELECT * FROM users",
+                "ref": "test-ref-1"
             }
         """.trimIndent()
         session.sendMessage(TextMessage(updateMessage))
@@ -161,7 +162,8 @@ class WebSocketHandlerTest {
         val updateMessage = """
             {
                 "type": "update_content",
-                "content": "SELECT * FROM users"
+                "content": "SELECT * FROM users",
+                "ref": "test-ref-2"
             }
         """.trimIndent()
         session.sendMessage(TextMessage(updateMessage))
@@ -218,7 +220,8 @@ class WebSocketHandlerTest {
                 """
                 {
                     "type": "update_content",
-                    "content": "SELECT * FROM users"
+                    "content": "SELECT * FROM users",
+                    "ref": "test-ref-3"
                 }
                 """.trimIndent(),
             ),
@@ -239,7 +242,8 @@ class WebSocketHandlerTest {
                 """
                 {
                     "type": "update_content",
-                    "content": "SELECT * FROM users"
+                    "content": "SELECT * FROM users",
+                    "ref": "test-ref-4"
                 }
                 """.trimIndent(),
             ),
@@ -287,7 +291,9 @@ class WebSocketHandlerTest {
         )
         val receivedMessages = waitForResponses(messages, 2)
         val errorMessage = receivedMessages.last()
-        assert(errorMessage.get("error").asText().contains("Error processing message"))
+        // Execution runs in a background thread since #366; access denial is reported
+        // with a dedicated error message rather than the generic processing error
+        assert(errorMessage.get("error").asText().contains("You don't have permission to execute on this session"))
         session.close()
     }
 

--- a/backend/src/test/resources/dex/config.yaml
+++ b/backend/src/test/resources/dex/config.yaml
@@ -9,7 +9,8 @@ web:
 staticClients:
   - id: example-app
     redirectURIs:
-      - 'http://localhost:8081/login/oauth2/code/dex'
+      - 'http://localhost:8081/login/oauth2/code/dex' # OIDCTest
+      - 'http://localhost:8085/login/oauth2/code/dex' # OidcWebSocketTest
     name: 'Example App'
     secret: example-app-secret
 


### PR DESCRIPTION
Since #344 the backend CI matrix filtered tests with `--tests **/[A-I]*` etc. Gradle's `--tests` only supports `*` wildcards, so the character classes matched no normal test class — every shard silently ran only ArchitectureTest (its ArchUnit engine ignores the class filter), and the backend suite hasn't run in CI since.

**Workflow fix:** each shard now enumerates `*Test.kt` files in a shell step and passes exact `--tests '*.ClassName'` filters (bash `case` ranges handle the A-I / J-O / P-Z split; prefix patterns like `'*.M*'` were ruled out because they also match uppercase backtick *method* names across shards). A guard step fails any shard that executes fewer than 10 test classes so this can't silently regress again. Shards verified disjoint with full union coverage via `--test-dry-run`.

**Drift fixes the reactivated suite required:**
- `mockwebserver` 4.12.0 → 5.3.2 — real dependency breakage: the kubernetes client pulls okhttp 5.x, which makes mockwebserver 4.x crash at class-load (`GitHubOAuthTest`).
- `AuthenticationProviderValidatorTest` — never-passing assertions: the validator throws unwrapped from `afterSingletonsInstantiated()`, but 4 tests asserted via `.rootCause()`, which requires a cause chain. Aligned with the newer GitHub-OAuth assertions in the same file.
- `ExecutionTest` — stale test: since #434 an edit resets change requests along with approvals, so the request returns to `AWAITING_APPROVAL` instead of staying `CHANGE_REQUESTED`. ⚠️ **User-facing semantic change shipped in #434 without test coverage** — the test now encodes the new behavior; flagging in case the old GitHub-style "changes requested persists across edits" behavior was intended.
- `OidcWebSocketTest` — real test bug that would also fail in CI: it reused `OIDCTest`'s fixed port 8081, which the cached Spring context still holds (`PortInUseException`). Moved to its own port 8085 per the existing one-port-per-class convention, with a matching dex redirect URI.
- `AbstractJDBCExecutorTest.testConnectionError` — brittle assertion: hardcoded the Linux Docker gateway IP (`172.17.0.1`) in MySQL's access-denied message; now asserts error code + message fragments like the MariaDB override already did.
- `SessionServiceTest` — stale tests: the executing-flag guard added in #366 is only cleared by the WebSocket handler, so direct service-level executes locked the session and even broke `@AfterEach` cleanup (leaking users into other classes). Tests now clear the flag after each execute, mirroring the handler.
- `WebSocketHandlerTest` — stale tests: `update_content` requires the `ref` field since #396, and unapproved execution is rejected from the background thread with a dedicated permission error since #366.

Not touched: the `*IAMAuthExecutorTest` classes are intentionally disabled in CI via `@DisabledIfEnvironmentVariable(named = "CI", ...)` and still skip as designed. No genuinely flaky tests were found — all failures reproduced deterministically and are fixed.

**Follow-up:** the five `DEFINED_PORT` test classes now carry `@DirtiesContext` so each class's server (and full Spring context) is closed when the class finishes instead of idling in the context cache for the rest of the JVM — their unique-port configs made those cached contexts unreusable anyway. Unique ports are kept as a safety net.
