### PR TITLE
Show the review actions without opening the comment box

### DIFF
--- a/frontend/src/routes/Review/CommentBox/index.test.tsx
+++ b/frontend/src/routes/Review/CommentBox/index.test.tsx
@@ -1,0 +1,182 @@
+import { vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { UserStatusContext } from "../../../components/UserStatusProvider";
+import { ReviewTypes } from "../../../hooks/request";
+import CommentBox from "./index";
+
+const REVIEWER_ID = "reviewer-1";
+const AUTHOR_ID = "author-1";
+
+const renderCommentBox = (
+  props: Partial<Parameters<typeof CommentBox>[0]> = {},
+) => {
+  const sendReview = vi.fn().mockResolvedValue(true);
+  const closeRequest = vi.fn().mockResolvedValue(true);
+  render(
+    <UserStatusContext.Provider
+      value={{
+        userStatus: {
+          id: REVIEWER_ID,
+          email: "reviewer@example.com",
+          fullName: "Rev Iewer",
+          status: "ok",
+        },
+        refreshState: async () => {},
+      }}
+    >
+      <CommentBox
+        sendReview={sendReview}
+        closeRequest={closeRequest}
+        userId={AUTHOR_ID}
+        {...props}
+      />
+    </UserStatusContext.Provider>,
+  );
+  return { sendReview, closeRequest };
+};
+
+describe("CommentBox review actions", () => {
+  test("shows the review actions without having to open the comment box", () => {
+    renderCommentBox();
+
+    for (const action of ["Comment", "Approve", "Request Changes", "Reject"]) {
+      const pill = screen.getByTestId(`review-type-${action}`);
+      expect(pill).toBeVisible();
+      expect(pill).toHaveAttribute("aria-disabled", "false");
+    }
+    expect(screen.getByTestId("submit-review-button")).toBeVisible();
+  });
+
+  test("approves with one click on the action and one on submit", async () => {
+    const { sendReview } = renderCommentBox();
+
+    fireEvent.click(screen.getByTestId("review-type-Approve"));
+    expect(screen.getByTestId("review-type-Approve")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByTestId("submit-review-button")).toHaveTextContent(
+      "Approve",
+    );
+
+    fireEvent.click(screen.getByTestId("submit-review-button"));
+
+    await waitFor(() =>
+      expect(sendReview).toHaveBeenCalledWith("", ReviewTypes.Approve),
+    );
+  });
+
+  test("sends the typed comment along with the review", async () => {
+    const { sendReview } = renderCommentBox();
+
+    fireEvent.change(screen.getByTestId("expand-comment-box"), {
+      target: { value: "looks fine to me" },
+    });
+    fireEvent.click(screen.getByTestId("review-type-Approve"));
+    fireEvent.click(screen.getByTestId("submit-review-button"));
+
+    await waitFor(() =>
+      expect(sendReview).toHaveBeenCalledWith(
+        "looks fine to me",
+        ReviewTypes.Approve,
+      ),
+    );
+  });
+
+  test("submits the selected action with the keyboard shortcut", async () => {
+    const { sendReview } = renderCommentBox();
+
+    fireEvent.click(screen.getByTestId("review-type-Approve"));
+    fireEvent.keyDown(screen.getByTestId("expand-comment-box"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() =>
+      expect(sendReview).toHaveBeenCalledWith("", ReviewTypes.Approve),
+    );
+  });
+
+  test("will not post an empty comment", () => {
+    const { sendReview } = renderCommentBox();
+
+    fireEvent.click(screen.getByTestId("submit-review-button"));
+
+    expect(sendReview).not.toHaveBeenCalled();
+  });
+
+  test("keeps review actions visible but blocked on your own request", () => {
+    renderCommentBox({ userId: REVIEWER_ID });
+
+    const approve = screen.getByTestId("review-type-Approve");
+    expect(approve).toBeVisible();
+    expect(approve).toHaveAttribute("aria-disabled", "true");
+    expect(approve).toHaveAttribute(
+      "title",
+      "You cannot review your own request",
+    );
+
+    fireEvent.click(approve);
+    expect(approve).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByTestId("submit-review-button")).toHaveTextContent(
+      "Comment",
+    );
+  });
+
+  test("keeps review actions visible but blocked on a rejected request", () => {
+    renderCommentBox({ isRejected: true });
+
+    const reject = screen.getByTestId("review-type-Reject");
+    expect(reject).toBeVisible();
+    expect(reject).toHaveAttribute("aria-disabled", "true");
+    expect(reject).toHaveAttribute("title", "This request has been rejected");
+  });
+
+  test("does not offer Close to a reviewer", () => {
+    renderCommentBox();
+    expect(screen.queryByTestId("review-type-Close")).not.toBeInTheDocument();
+  });
+
+  test("offers Close to the author", () => {
+    renderCommentBox({ userId: REVIEWER_ID });
+    expect(screen.getByTestId("review-type-Close")).toBeVisible();
+  });
+
+  test("exposes the actions as a radio group driven by the arrow keys", () => {
+    renderCommentBox();
+
+    expect(
+      screen.getByRole("radiogroup", { name: "Review action" }),
+    ).toBeVisible();
+    const comment = screen.getByTestId("review-type-Comment");
+    expect(comment).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.keyDown(comment, { key: "ArrowRight" });
+    expect(screen.getByTestId("review-type-Approve")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+
+    fireEvent.keyDown(screen.getByTestId("review-type-Approve"), {
+      key: "ArrowLeft",
+    });
+    expect(screen.getByTestId("review-type-Comment")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+
+  test("skips blocked actions when arrowing through the group", () => {
+    renderCommentBox({ isRejected: true });
+
+    const comment = screen.getByTestId("review-type-Comment");
+    expect(comment).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.keyDown(comment, { key: "ArrowRight" });
+    expect(comment).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("review-type-Approve")).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+});

--- a/frontend/src/routes/Review/CommentBox/index.tsx
+++ b/frontend/src/routes/Review/CommentBox/index.tsx
@@ -12,13 +12,15 @@ import { AbsoluteInitialBubble as InitialBubble } from "../../../components/Init
 import { ReviewTypes } from "../../../hooks/request";
 import { componentMap } from "../components/Highlighter";
 
+type ReviewTone = "neutral" | "affirm" | "danger";
+
 type ReviewOption = {
   id: ReviewTypes;
   title: string;
   description: string;
   visible: boolean;
   disabledReason?: string;
-  danger: boolean;
+  tone: ReviewTone;
 };
 
 const isMac =
@@ -64,7 +66,7 @@ function CommentBox({
       title: "Comment",
       description: "Submit a general comment without explicit approval",
       visible: true,
-      danger: false,
+      tone: "neutral",
     },
     {
       id: ReviewTypes.Approve,
@@ -72,7 +74,7 @@ function CommentBox({
       description: "Give your approval to execute this request",
       visible: true,
       disabledReason: reviewBlockedReason,
-      danger: false,
+      tone: "affirm",
     },
     {
       id: ReviewTypes.RequestChange,
@@ -81,7 +83,7 @@ function CommentBox({
         "Request a change on this Request, you can later approve it again",
       visible: true,
       disabledReason: reviewBlockedReason,
-      danger: true,
+      tone: "danger",
     },
     {
       id: ReviewTypes.Reject,
@@ -89,7 +91,7 @@ function CommentBox({
       description: "Reject this request from ever executing",
       visible: true,
       disabledReason: reviewBlockedReason,
-      danger: true,
+      tone: "danger",
     },
     {
       id: ReviewTypes.Close,
@@ -97,7 +99,7 @@ function CommentBox({
       description: "Close this request without executing it",
       visible: !!(isOwnRequest && closeRequest),
       disabledReason: isRejected ? "This request has been rejected" : undefined,
-      danger: false,
+      tone: "neutral",
     },
   ];
 
@@ -207,13 +209,23 @@ function CommentBox({
     }
     const selected = reviewType.id === selectedReviewType.id;
     if (selected) {
-      return reviewType.danger
-        ? "border-red-600 bg-red-50 text-red-700 dark:border-red-500/60 dark:bg-red-500/20 dark:text-red-300"
-        : "border-indigo-600 bg-indigo-50 text-indigo-700 dark:border-indigo-500/60 dark:bg-indigo-500/20 dark:text-indigo-300";
+      return {
+        danger:
+          "border-red-600 bg-red-50 text-red-700 dark:border-red-500/60 dark:bg-red-500/20 dark:text-red-300",
+        affirm:
+          "border-green-600 bg-green-50 text-green-700 dark:border-green-500/60 dark:bg-green-500/20 dark:text-green-300",
+        neutral:
+          "border-indigo-600 bg-indigo-50 text-indigo-700 dark:border-indigo-500/60 dark:bg-indigo-500/20 dark:text-indigo-300",
+      }[reviewType.tone];
     }
-    return reviewType.danger
-      ? "border-slate-200 text-red-600/80 hover:border-red-300 dark:border-slate-700 dark:text-red-400/80 dark:hover:border-red-500/50"
-      : "border-slate-200 text-slate-600 hover:border-slate-300 dark:border-slate-700 dark:text-slate-400 dark:hover:border-slate-500";
+    return {
+      danger:
+        "border-slate-200 text-red-600/80 hover:border-red-300 dark:border-slate-700 dark:text-red-400/80 dark:hover:border-red-500/50",
+      affirm:
+        "border-slate-200 text-green-700/90 hover:border-green-300 dark:border-slate-700 dark:text-green-400/90 dark:hover:border-green-500/50",
+      neutral:
+        "border-slate-200 text-slate-600 hover:border-slate-300 dark:border-slate-700 dark:text-slate-400 dark:hover:border-slate-500",
+    }[reviewType.tone];
   };
 
   const placeholder =
@@ -315,7 +327,7 @@ function CommentBox({
               variant={
                 submitDisabled
                   ? "disabled"
-                  : selectedReviewType.danger
+                  : selectedReviewType.tone === "danger"
                   ? "danger"
                   : "primary"
               }

--- a/frontend/src/routes/Review/CommentBox/index.tsx
+++ b/frontend/src/routes/Review/CommentBox/index.tsx
@@ -1,10 +1,29 @@
-import { ChangeEvent, KeyboardEvent, useContext, useState } from "react";
+import {
+  ChangeEvent,
+  KeyboardEvent,
+  useContext,
+  useRef,
+  useState,
+} from "react";
 import ReactMarkdown from "react-markdown";
 import Button from "../../../components/Button";
 import { UserStatusContext } from "../../../components/UserStatusProvider";
 import { AbsoluteInitialBubble as InitialBubble } from "../../../components/InitialBubble";
 import { ReviewTypes } from "../../../hooks/request";
 import { componentMap } from "../components/Highlighter";
+
+type ReviewOption = {
+  id: ReviewTypes;
+  title: string;
+  description: string;
+  visible: boolean;
+  disabledReason?: string;
+  danger: boolean;
+};
+
+const isMac =
+  typeof navigator !== "undefined" && navigator.userAgent.includes("Mac");
+const submitShortcut = isMac ? "⌘↵" : "Ctrl+↵";
 
 function CommentBox({
   sendReview,
@@ -25,24 +44,34 @@ function CommentBox({
     ReviewTypes.Comment,
   );
 
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const radioGroupRef = useRef<HTMLDivElement>(null);
+
   const userContext = useContext(UserStatusContext);
 
   const isOwnRequest =
     userContext.userStatus && userContext.userStatus?.id === userId;
 
-  const reviewTypes = [
+  const reviewBlockedReason = isOwnRequest
+    ? "You cannot review your own request"
+    : isRejected
+    ? "This request has been rejected"
+    : undefined;
+
+  const reviewTypes: ReviewOption[] = [
     {
       id: ReviewTypes.Comment,
       title: "Comment",
       description: "Submit a general comment without explicit approval",
-      enabled: true,
+      visible: true,
       danger: false,
     },
     {
       id: ReviewTypes.Approve,
       title: "Approve",
       description: "Give your approval to execute this request",
-      enabled: !isOwnRequest && !isRejected,
+      visible: true,
+      disabledReason: reviewBlockedReason,
       danger: false,
     },
     {
@@ -50,36 +79,55 @@ function CommentBox({
       title: "Request Changes",
       description:
         "Request a change on this Request, you can later approve it again",
-      enabled: !isOwnRequest && !isRejected,
+      visible: true,
+      disabledReason: reviewBlockedReason,
       danger: true,
     },
     {
       id: ReviewTypes.Reject,
       title: "Reject",
       description: "Reject this request from ever executing",
-      enabled: !isOwnRequest && !isRejected,
+      visible: true,
+      disabledReason: reviewBlockedReason,
       danger: true,
     },
     {
       id: ReviewTypes.Close,
       title: "Close",
       description: "Close this request without executing it",
-      enabled: !!(isOwnRequest && closeRequest) && !isRejected,
+      visible: !!(isOwnRequest && closeRequest),
+      disabledReason: isRejected ? "This request has been rejected" : undefined,
       danger: false,
     },
   ];
 
-  const availableReviewTypes = reviewTypes.filter(
-    (reviewType) => reviewType.enabled,
+  const visibleReviewTypes = reviewTypes.filter(
+    (reviewType) => reviewType.visible,
+  );
+  const selectableReviewTypes = visibleReviewTypes.filter(
+    (reviewType) => !reviewType.disabledReason,
   );
   const selectedReviewType =
-    availableReviewTypes.find(
+    selectableReviewTypes.find(
       (reviewType) => reviewType.id === chosenReviewType,
-    ) ?? availableReviewTypes[0];
+    ) ?? selectableReviewTypes[0];
 
   // a bare comment with no text would just add an empty event to the timeline
   const submitDisabled =
     selectedReviewType.id === ReviewTypes.Comment && comment.trim() === "";
+
+  const autoGrow = (element: HTMLTextAreaElement) => {
+    element.style.height = "auto";
+    element.style.height = `${Math.min(element.scrollHeight, 256)}px`;
+  };
+
+  const collapse = () => {
+    setExpanded(false);
+    setPreviewVisible(false);
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "";
+    }
+  };
 
   const handleReview = async () => {
     if (submitDisabled) {
@@ -94,26 +142,69 @@ function CommentBox({
     if (result) {
       setComment("");
       setChosenReviewType(ReviewTypes.Comment);
-      setPreviewVisible(false);
-      setExpanded(false);
+      collapse();
     }
   };
 
   const handleCommentChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     setComment(event.target.value);
-    event.target.style.height = "auto";
-    event.target.style.height = `${Math.min(event.target.scrollHeight, 256)}px`;
+    autoGrow(event.target);
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === "Escape") {
-      setExpanded(false);
+      if (comment.trim() === "") {
+        collapse();
+      }
+      textareaRef.current?.blur();
     } else if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
       void handleReview();
     }
   };
 
-  const pillClassName = (reviewType: (typeof reviewTypes)[number]) => {
+  const selectReviewType = (reviewType: ReviewOption) => {
+    if (reviewType.disabledReason) {
+      return;
+    }
+    setChosenReviewType(reviewType.id);
+    setExpanded(true);
+  };
+
+  const handleReviewTypeClick = (reviewType: ReviewOption) => {
+    if (reviewType.disabledReason) {
+      return;
+    }
+    selectReviewType(reviewType);
+    textareaRef.current?.focus();
+  };
+
+  const handleReviewTypeKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    const forward = event.key === "ArrowRight" || event.key === "ArrowDown";
+    const backward = event.key === "ArrowLeft" || event.key === "ArrowUp";
+    if (!forward && !backward) {
+      return;
+    }
+    event.preventDefault();
+    const current = selectableReviewTypes.findIndex(
+      (reviewType) => reviewType.id === selectedReviewType.id,
+    );
+    const next =
+      selectableReviewTypes[
+        (current + (forward ? 1 : -1) + selectableReviewTypes.length) %
+          selectableReviewTypes.length
+      ];
+    selectReviewType(next);
+    radioGroupRef.current
+      ?.querySelector<HTMLButtonElement>(
+        `[data-testid="review-type-${next.title}"]`,
+      )
+      ?.focus();
+  };
+
+  const pillClassName = (reviewType: ReviewOption) => {
+    if (reviewType.disabledReason) {
+      return "cursor-not-allowed border-slate-200 text-slate-400 dark:border-slate-800 dark:text-slate-600";
+    }
     const selected = reviewType.id === selectedReviewType.id;
     if (selected) {
       return reviewType.danger
@@ -125,6 +216,11 @@ function CommentBox({
       : "border-slate-200 text-slate-600 hover:border-slate-300 dark:border-slate-700 dark:text-slate-400 dark:hover:border-slate-500";
   };
 
+  const placeholder =
+    selectedReviewType.id === ReviewTypes.Comment
+      ? "Leave a comment"
+      : "Add an optional comment";
+
   return (
     <div className="relative mt-4">
       <InitialBubble
@@ -132,86 +228,106 @@ function CommentBox({
           (userContext.userStatus && userContext.userStatus?.fullName) || ""
         }
       />
-      {expanded ? (
-        <div className="rounded-md border bg-white shadow-md dark:border-slate-700 dark:bg-slate-900 dark:shadow-none">
-          {previewVisible ? (
-            <div className="max-h-64 min-h-[5rem] overflow-y-auto px-3 py-2 text-sm">
-              {comment.trim() === "" ? (
-                <p className="text-slate-400 dark:text-slate-500">
-                  Nothing to preview
-                </p>
-              ) : (
-                <ReactMarkdown components={componentMap}>
-                  {comment}
-                </ReactMarkdown>
-              )}
-            </div>
-          ) : (
-            <textarea
-              autoFocus
-              id="comment"
-              name="comment"
-              rows={3}
-              className="block max-h-64 w-full resize-none rounded-t-md border-0 bg-transparent px-3 py-2 text-sm leading-normal text-slate-900 placeholder:text-slate-400 focus:outline-none dark:text-slate-50 dark:placeholder:text-slate-500"
-              onChange={handleCommentChange}
-              onKeyDown={handleKeyDown}
-              value={comment}
-              placeholder="Leave a comment"
-            ></textarea>
-          )}
-          <div className="flex flex-wrap items-center gap-1.5 border-t border-slate-200 px-2 py-2 dark:border-slate-700">
-            {availableReviewTypes.map((reviewType) => (
-              <button
-                key={reviewType.id}
-                type="button"
-                title={reviewType.description}
-                data-testid={`review-type-${reviewType.title}`}
-                onClick={() => setChosenReviewType(reviewType.id)}
-                className={`rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors ${pillClassName(
-                  reviewType,
-                )}`}
+      <div
+        className={`rounded-md border bg-white transition-shadow dark:bg-slate-900 dark:shadow-none ${
+          expanded
+            ? "border-slate-300 shadow-md dark:border-slate-600"
+            : "border-slate-200 shadow-sm dark:border-slate-700"
+        }`}
+      >
+        {previewVisible ? (
+          <div className="max-h-64 min-h-[5rem] overflow-y-auto px-3 py-2 text-sm">
+            {comment.trim() === "" ? (
+              <p className="text-slate-400 dark:text-slate-500">
+                Nothing to preview
+              </p>
+            ) : (
+              <ReactMarkdown components={componentMap}>{comment}</ReactMarkdown>
+            )}
+          </div>
+        ) : (
+          <textarea
+            ref={textareaRef}
+            id="comment"
+            name="comment"
+            rows={1}
+            aria-label="Comment"
+            data-testid="expand-comment-box"
+            className={`block max-h-64 w-full resize-none rounded-t-md border-0 bg-transparent px-3 py-2 text-sm leading-normal text-slate-900 placeholder:text-slate-400 focus:outline-none dark:text-slate-50 dark:placeholder:text-slate-500 ${
+              expanded ? "min-h-[4.5rem]" : ""
+            }`}
+            onChange={handleCommentChange}
+            onKeyDown={handleKeyDown}
+            onFocus={() => setExpanded(true)}
+            value={comment}
+            placeholder={placeholder}
+          ></textarea>
+        )}
+        <div className="flex flex-wrap items-center gap-1.5 border-t border-slate-200 px-2 py-2 dark:border-slate-700">
+          <div
+            ref={radioGroupRef}
+            role="radiogroup"
+            aria-label="Review action"
+            className="flex flex-wrap items-center gap-1.5"
+          >
+            {visibleReviewTypes.map((reviewType) => {
+              const selected = reviewType.id === selectedReviewType.id;
+              return (
+                <button
+                  key={reviewType.id}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  aria-disabled={reviewType.disabledReason !== undefined}
+                  tabIndex={selected ? 0 : -1}
+                  title={reviewType.disabledReason ?? reviewType.description}
+                  data-testid={`review-type-${reviewType.title}`}
+                  onClick={() => handleReviewTypeClick(reviewType)}
+                  onKeyDown={handleReviewTypeKeyDown}
+                  className={`rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors ${pillClassName(
+                    reviewType,
+                  )}`}
+                >
+                  {reviewType.title}
+                </button>
+              );
+            })}
+          </div>
+          <div className="ml-auto flex items-center gap-2 pl-2">
+            {expanded && (
+              <span
+                aria-hidden="true"
+                className="hidden text-xs text-slate-400 dark:text-slate-500 sm:inline"
               >
-                {reviewType.title}
-              </button>
-            ))}
-            <div className="ml-auto flex items-center gap-2 pl-2">
-              <button
-                type="button"
-                title="Markdown supported"
-                className="text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
-                onClick={() => setPreviewVisible(!previewVisible)}
-              >
-                {previewVisible ? "Write" : "Preview"}
-              </button>
-              <Button
-                id="submit"
-                variant={
-                  submitDisabled
-                    ? "disabled"
-                    : selectedReviewType.danger
-                    ? "danger"
-                    : "primary"
-                }
-                onClick={() => void handleReview()}
-                dataTestId="submit-review-button"
-              >
-                {selectedReviewType.title}
-              </Button>
-            </div>
+                {submitShortcut}
+              </span>
+            )}
+            <button
+              type="button"
+              title="Markdown supported"
+              className="text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+              onClick={() => setPreviewVisible(!previewVisible)}
+            >
+              {previewVisible ? "Write" : "Preview"}
+            </button>
+            <Button
+              id="submit"
+              variant={
+                submitDisabled
+                  ? "disabled"
+                  : selectedReviewType.danger
+                  ? "danger"
+                  : "primary"
+              }
+              onClick={() => void handleReview()}
+              dataTestId="submit-review-button"
+              title={`${selectedReviewType.title} (${submitShortcut})`}
+            >
+              {selectedReviewType.title}
+            </Button>
           </div>
         </div>
-      ) : (
-        <button
-          type="button"
-          data-testid="expand-comment-box"
-          className="w-full rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-left text-sm text-slate-500 shadow-sm transition-colors hover:border-slate-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400 dark:hover:border-slate-600"
-          onClick={() => setExpanded(true)}
-        >
-          {isOwnRequest || isRejected
-            ? "Leave a comment…"
-            : "Leave a comment or review…"}
-        </button>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Since #511 the review actions live inside the comment composer, which is collapsed by default. `Approve`, `Request Changes` and `Reject` are not just hidden, they aren't rendered until you click the placeholder, and nothing about it reads as expandable. Reviewers on our instance repeatedly concluded they were missing a permission and went to an admin instead. This keeps the compact composer from #511 and only stops it hiding the actions.

**Before**, everything the reviewer gets on page load:

![Before, on page load](https://raw.githubusercontent.com/DerkSchooltink/kviklet/pr-519-assets/before-on-load.png)

**After**, the actions are on screen and the comment field is what grows on focus:

![After, on page load](https://raw.githubusercontent.com/DerkSchooltink/kviklet/pr-519-assets/after-on-load.png)

![After, Approve selected](https://raw.githubusercontent.com/DerkSchooltink/kviklet/pr-519-assets/after-approve-selected.png)

## Changes

- **Actions always rendered**: the review row and submit button no longer depend on the composer being open. Only the textarea expands (one row to three), so an idle page is the same height as today. Approving is now two clicks instead of three, and zero clicks instead of one to discover it exists.
- **Blocked actions are disabled, not removed**: `reviewTypes.filter(rt => rt.enabled)` dropped unavailable options entirely, so the row silently changed shape per viewer with no explanation. They now stay in place, greyed, with the reason in the tooltip (`You cannot review your own request`, `This request has been rejected`). Options that can never apply, like `Close` for a non-author, are still filtered out. That is the `visible` / `disabledReason` split on `ReviewOption`.
- **Accessibility**: the pills were four plain buttons, so no selected state was announced and there was no keyboard navigation between them. They are a `role="radiogroup"` now with `aria-checked`, `aria-disabled` and a roving tabindex.
- **Keyboard**: the existing Cmd/Ctrl+Enter shortcut is shown next to the submit button, and Escape no longer collapses the field over text that has already been typed.
- **Approve gets its own colour** (second commit, separable): `danger: boolean` becomes `tone: "neutral" | "affirm" | "danger"`, and Approve takes the green `ApprovalProgress` already uses for a satisfied requirement. Request Changes and Reject were the only tinted options, which was fine when the row appeared only after a deliberate click but makes the two ways to say no the most prominent thing in a permanently visible row. The submit button stays indigo, red still means destructive. Drop this commit if you'd rather keep the pills neutral.

Author's own request, and dark mode:

![After, your own request](https://raw.githubusercontent.com/DerkSchooltink/kviklet/pr-519-assets/after-own-request.png)

![After, dark mode](https://raw.githubusercontent.com/DerkSchooltink/kviklet/pr-519-assets/after-dark.png)

## Notes

`e2e/tests/pages.ts` needs no change. Every `data-testid` is unchanged and the click it does on `expand-comment-box` is a no-op now rather than a requirement.

Adds `frontend/src/routes/Review/CommentBox/index.test.tsx` (11 tests). CONTRIBUTING mentions frontend coverage is thin, so this seemed a reasonable place to add some.

`feat/permission-foundation-482` adds a `canReview` prop to this component and touches the same lines, so whichever lands second needs a rebase. The `visible` / `disabledReason` split is meant to take that flag on `visible`, since an action the viewer can never perform is better hidden than greyed.
