### PR TITLE
Link the connection name on the review page to its settings page

### DIFF
--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -4,6 +4,7 @@ import Button from "../../components/Button";
 import { timeSince } from "../Requests";
 import { AbsoluteInitialBubble as InitialBubble } from "../../components/InitialBubble";
 import { Highlighter } from "./components/Highlighter";
+import ConnectionLink from "./components/ConnectionLink";
 import { UserStatusContext } from "../../components/UserStatusProvider";
 
 function DatasourceRequestBox({
@@ -42,7 +43,12 @@ function DatasourceRequestBox({
         <div className="flex text-sm text-slate-800 dark:text-slate-50">
           <div>
             {request?.author?.fullName + questionText}
-            <span className="italic">{request?.connection.displayName}</span>
+            {request && (
+              <ConnectionLink
+                connectionId={request.connection.id}
+                displayName={request.connection.displayName}
+              />
+            )}
           </div>
           <div
             className="ml-auto dark:text-slate-500"

--- a/frontend/src/routes/Review/KubernetesRequestBox.tsx
+++ b/frontend/src/routes/Review/KubernetesRequestBox.tsx
@@ -2,6 +2,7 @@ import { KubernetesExecutionRequestResponseWithComments } from "../../api/Execut
 import Button from "../../components/Button";
 import { timeSince } from "../Requests";
 import { Highlighter } from "./components/Highlighter";
+import ConnectionLink from "./components/ConnectionLink";
 import { FC, useContext, useEffect, useState, MouseEvent } from "react";
 import { UserStatusContext } from "../../components/UserStatusProvider";
 
@@ -36,8 +37,11 @@ const KubernetesRequestBox: FC<KubernetesRequestBoxProps> = ({
       <div className="py-2">
         <div className="flex text-sm text-slate-800 dark:text-slate-50">
           <div>
-            {request?.author.fullName} wants to execute a Kubernetes command in:
-            <span className="italic"> {request?.connection.displayName}</span>
+            {request?.author.fullName} wants to execute a Kubernetes command in:{" "}
+            <ConnectionLink
+              connectionId={request.connection.id}
+              displayName={request.connection.displayName}
+            />
           </div>
           <div
             className="ml-auto dark:text-slate-500"

--- a/frontend/src/routes/Review/components/ConnectionLink.tsx
+++ b/frontend/src/routes/Review/components/ConnectionLink.tsx
@@ -1,0 +1,30 @@
+import { Link } from "react-router-dom";
+import { useHasPermission } from "../../../hooks/permissions";
+
+// Links a connection's display name to its settings page so reviewers can
+// inspect the connection (user, host, review config). Falls back to plain
+// text for users whose roles don't include the connection settings pages.
+const ConnectionLink = ({
+  connectionId,
+  displayName,
+}: {
+  connectionId: string;
+  displayName: string;
+}) => {
+  const canViewConnections = useHasPermission("datasource_connection:get");
+
+  if (!canViewConnections) {
+    return <span className="italic">{displayName}</span>;
+  }
+  return (
+    <Link
+      to={`/settings/connections/${encodeURIComponent(connectionId)}`}
+      className="italic hover:underline"
+      title="View connection settings"
+    >
+      {displayName}
+    </Link>
+  );
+};
+
+export default ConnectionLink;


### PR DESCRIPTION
On the request review page, the connection name in "X wants to execute a statement on <connection>" now links to that connection's settings page, so reviewers can check the configured database user, host, and review config directly from a request. Passwords stay hidden there anyway.

Applies to both datasource and Kubernetes requests. Users whose roles don't include the connection settings pages (`datasource_connection:get`) see plain text as before.