### PR TITLE
GitHub-style review sidebar with one-click Approve

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -7,13 +7,15 @@ function Button(props: {
   className?: string;
   size?: "sm" | "md" | "lg";
   textSize?: "sm" | "md" | "lg";
-  variant?: "primary" | "danger" | "disabled" | undefined;
+  variant?: "primary" | "danger" | "success" | "disabled" | undefined;
   htmlType?: "button" | "submit" | "reset" | undefined;
   dataTestId?: string;
   title?: string;
 }) {
   const submitStyle =
     "bg-indigo-700 font-medium text-white hover:bg-indigo-800 dark:hover:bg-indigo-600 dark:bg-indigo-700 dark:text-slate-50 transition-colors";
+  const successStyle =
+    "bg-green-700 font-medium text-white hover:bg-green-800 dark:hover:bg-green-600 dark:bg-green-700 dark:text-slate-50 transition-colors";
   const disabledStyle =
     "bg-slate-300 text-slate-500 hover:bg-slate-300 hover:border-slate-300 dark:bg-slate-700 dark:text-slate-500 dark:hover:bg-slate-700 dark:hover:border-slate-700 dark:hover:text-slate-500";
   const defaultStyle =
@@ -40,6 +42,7 @@ function Button(props: {
         (props.variant == "primary" && submitStyle) ||
         (props.variant == "disabled" && disabledStyle) ||
         (props.variant == "danger" && dangerStyle) ||
+        (props.variant == "success" && successStyle) ||
         defaultStyle
       }
       rounded align-middle leading-5

--- a/frontend/src/hooks/request.ts
+++ b/frontend/src/hooks/request.ts
@@ -28,6 +28,56 @@ enum ReviewTypes {
   Close = "close",
 }
 
+// Approvals reset when the request is edited, or (except for temporary access)
+// when an execution fails — mirrors latestResetTimestamp() in the backend's
+// ExecutionRequest.kt, which ignores reviews from before that point.
+const latestResetTimestamp = (
+  request: ExecutionRequestResponseWithComments,
+): number => {
+  const latestEdit = Math.max(
+    0,
+    ...request.events
+      .filter((event) => event._type === "EDIT")
+      .map((event) => event.createdAt.getTime()),
+  );
+  if (request.type === "TemporaryAccess") {
+    return latestEdit;
+  }
+  const latestExecutionError = Math.max(
+    0,
+    ...request.events
+      .filter(
+        (event) =>
+          event._type === "EXECUTE" &&
+          (event.results ?? []).some((result) => result.type === "ERROR"),
+      )
+      .map((event) => event.createdAt.getTime()),
+  );
+  return Math.max(latestEdit, latestExecutionError);
+};
+
+// The verdict this user's review currently stands at: only their latest review
+// since the last reset counts, matching the backend's approval tally.
+const latestReviewAction = (
+  request: ExecutionRequestResponseWithComments,
+  userId: string | undefined,
+): "APPROVE" | "REQUEST_CHANGE" | "REJECT" | undefined => {
+  if (!userId) {
+    return undefined;
+  }
+  const resetTimestamp = latestResetTimestamp(request);
+  const myReviews = request.events
+    .filter(
+      (event) =>
+        event._type === "REVIEW" &&
+        event.author?.id === userId &&
+        event.createdAt.getTime() > resetTimestamp,
+    )
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  const latest = myReviews[myReviews.length - 1];
+  return latest?._type === "REVIEW" ? latest.action : undefined;
+};
+
 const isRelationalDatabase = (
   request: DatasourceExecutionRequestResponseWithComments | undefined,
 ): boolean => {
@@ -218,4 +268,4 @@ const useRequest = (id: string) => {
 
 export default useRequest;
 
-export { ReviewTypes, isRelationalDatabase };
+export { ReviewTypes, isRelationalDatabase, latestReviewAction };

--- a/frontend/src/routes/Review/ActivityTimeline.tsx
+++ b/frontend/src/routes/Review/ActivityTimeline.tsx
@@ -1,10 +1,12 @@
+import { useContext } from "react";
 import {
   ExecutionRequestResponseWithComments,
   Execute,
 } from "../../api/ExecutionRequestApi";
 import { DatabaseType } from "../../api/DatasourceApi";
-import { ReviewTypes } from "../../hooks/request";
+import { ReviewTypes, latestReviewAction } from "../../hooks/request";
 import { hasPermission } from "../../api/Permissions";
+import { UserStatusContext } from "../../components/UserStatusProvider";
 import CommentBox from "./CommentBox";
 import EditEvent from "./events/EditEvent";
 import ExecuteEvent from "./events/ExecuteEvent";
@@ -22,6 +24,13 @@ export default function ActivityTimeline({
   sendReview?: (comment: string, type: ReviewTypes) => Promise<boolean>;
   closeRequest?: (comment: string) => Promise<boolean>;
 }) {
+  const userContext = useContext(UserStatusContext);
+  const hasApproved =
+    latestReviewAction(
+      request,
+      userContext.userStatus ? userContext.userStatus.id : undefined,
+    ) === "APPROVE";
+
   const historicalEvents = request?.events ? [...request.events] : [];
 
   // Websocket events carry live results, so they supersede their
@@ -54,6 +63,7 @@ export default function ActivityTimeline({
             closeRequest={closeRequest}
             userId={request?.author?.id}
             isRejected={request.reviewStatus === "REJECTED"}
+            hasApproved={hasApproved}
             canReview={hasPermission(
               request.permissions,
               "execution_request:review",

--- a/frontend/src/routes/Review/ActivityTimeline.tsx
+++ b/frontend/src/routes/Review/ActivityTimeline.tsx
@@ -96,6 +96,7 @@ export default function ActivityTimeline({
                 key={event.id}
                 event={event}
                 connectTop={connectTop}
+                connectBottom={index < events.length - 1}
               />
             );
           return null;

--- a/frontend/src/routes/Review/CommentBox/index.tsx
+++ b/frontend/src/routes/Review/CommentBox/index.tsx
@@ -12,6 +12,7 @@ function CommentBox({
   userId,
   isRejected,
   canReview = true,
+  hasApproved = false,
 }: {
   sendReview: (comment: string, type: ReviewTypes) => Promise<boolean>;
   closeRequest?: (comment: string) => Promise<boolean>;
@@ -19,6 +20,8 @@ function CommentBox({
   isRejected?: boolean;
   /** Whether the backend would allow this user to review this request (execution_request:review). */
   canReview?: boolean;
+  /** The user's approval already stands — hide the Approve pill so it doesn't read as "didn't take". */
+  hasApproved?: boolean;
 }) {
   const [expanded, setExpanded] = useState<boolean>(false);
   const [previewVisible, setPreviewVisible] = useState<boolean>(false);
@@ -45,7 +48,7 @@ function CommentBox({
       id: ReviewTypes.Approve,
       title: "Approve",
       description: "Give your approval to execute this request",
-      enabled: canReview && !isOwnRequest && !isRejected,
+      enabled: canReview && !isOwnRequest && !isRejected && !hasApproved,
       danger: false,
     },
     {
@@ -210,7 +213,7 @@ function CommentBox({
           className="w-full rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-left text-sm text-slate-500 shadow-sm transition-colors hover:border-slate-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400 dark:hover:border-slate-600"
           onClick={() => setExpanded(true)}
         >
-          {isOwnRequest || isRejected || !canReview
+          {isOwnRequest || isRejected || !canReview || hasApproved
             ? "Leave a comment…"
             : "Leave a comment or review…"}
         </button>

--- a/frontend/src/routes/Review/DatasourceRequestActions.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestActions.tsx
@@ -12,7 +12,6 @@ import { isRelationalDatabase } from "../../hooks/request";
 import Modal from "../../components/Modal";
 import SQLDumpConfirm from "../../components/SQLDumpConfirm";
 import useNotification from "../../hooks/useNotification";
-import ApprovalProgress from "./ApprovalProgress";
 import { UserStatusContext } from "../../components/UserStatusProvider";
 import {
   hasPermission,
@@ -21,7 +20,7 @@ import {
 } from "../../api/Permissions";
 import { useHasPermission } from "../../hooks/permissions";
 
-function DatasourceRequestSidebar({
+function DatasourceRequestActions({
   request,
   runQuery,
   cancelQuery,
@@ -285,9 +284,8 @@ function DatasourceRequestSidebar({
   };
 
   return (
-    <div className="flex items-start justify-between gap-4 md:flex-col md:items-stretch">
-      {request && <ApprovalProgress request={request} />}
-      <div className="flex md:w-full">
+    <>
+      <div className="flex w-full">
         <MenuDropDown items={menuDropDownItems}></MenuDropDown>
         {isRelationalDatabase(request) ? (
           <LoadingCancelButton
@@ -337,8 +335,8 @@ function DatasourceRequestSidebar({
         )}
       </div>
       <SQLDumpModal />
-    </div>
+    </>
   );
 }
 
-export default DatasourceRequestSidebar;
+export default DatasourceRequestActions;

--- a/frontend/src/routes/Review/DatasourceRequestBox.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestBox.tsx
@@ -4,7 +4,6 @@ import Button from "../../components/Button";
 import { timeSince } from "../Requests";
 import { AbsoluteInitialBubble as InitialBubble } from "../../components/InitialBubble";
 import { Highlighter } from "./components/Highlighter";
-import ConnectionLink from "./components/ConnectionLink";
 import { UserStatusContext } from "../../components/UserStatusProvider";
 
 function DatasourceRequestBox({
@@ -29,37 +28,22 @@ function DatasourceRequestBox({
     setStatement(request?.statement || "");
   }, [request?.statement]);
 
-  const questionText =
-    request?.type == "SingleExecution"
-      ? " wants to execute a statement on "
-      : request?.type == "TemporaryAccess"
-      ? " wants to have access to "
-      : " wants to get a SQL dump from ";
-
   return (
     <div className="relative border-slate-500 dark:border dark:border-slate-950 dark:bg-slate-950">
       <InitialBubble name={request?.author.fullName} />
       <div className="py-2">
-        <div className="flex text-sm text-slate-800 dark:text-slate-50">
-          <div>
-            {request?.author?.fullName + questionText}
-            {request && (
-              <ConnectionLink
-                connectionId={request.connection.id}
-                displayName={request.connection.displayName}
-              />
-            )}
-          </div>
-          <div
-            className="ml-auto dark:text-slate-500"
+        <div className="text-sm text-slate-800 dark:text-slate-50">
+          {request?.author?.fullName}{" "}
+          <span
+            className="text-slate-500 dark:text-slate-400"
             title={
               request?.createdAt
                 ? new Date(request.createdAt).toLocaleString()
                 : undefined
             }
           >
-            {timeSince(new Date(request?.createdAt ?? ""))}
-          </div>
+            requested {timeSince(new Date(request?.createdAt ?? ""))}
+          </span>
         </div>
         <div className="py-3">
           <p className="max-w-prose pb-6 text-slate-500">
@@ -117,23 +101,8 @@ function DatasourceRequestBox({
           ) : (
             ""
           )}
-          {request?.type === "TemporaryAccess" && (
-            <div className="pt-3">
-              <AccessDurationInfo duration={request?.temporaryAccessDuration} />
-            </div>
-          )}
         </div>
       </div>
-    </div>
-  );
-}
-
-function AccessDurationInfo({ duration }: { duration: number | null }) {
-  return (
-    <div className="text-sm text-slate-500">
-      {duration !== null
-        ? `The session will be valid for ${duration} minutes.`
-        : "The session will be valid indefinitely."}
     </div>
   );
 }

--- a/frontend/src/routes/Review/KubernetesRequestActions.tsx
+++ b/frontend/src/routes/Review/KubernetesRequestActions.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import { KubernetesExecutionRequestResponseWithComments } from "../../api/ExecutionRequestApi";
 import Button from "../../components/Button";
 import MenuDropDown from "../../components/MenuDropdown";
-import ApprovalProgress from "./ApprovalProgress";
 import { UserStatusContext } from "../../components/UserStatusProvider";
 import {
   hasPermission,
@@ -12,12 +11,12 @@ import {
 } from "../../api/Permissions";
 import { useHasPermission } from "../../hooks/permissions";
 
-interface KubernetesRequestSidebarProps {
+interface KubernetesRequestActionsProps {
   request: KubernetesExecutionRequestResponseWithComments;
   runQuery: (explain?: boolean) => Promise<void>;
 }
 
-const KubernetesRequestSidebar: FC<KubernetesRequestSidebarProps> = ({
+const KubernetesRequestActions: FC<KubernetesRequestActionsProps> = ({
   request,
   runQuery,
 }) => {
@@ -73,31 +72,28 @@ const KubernetesRequestSidebar: FC<KubernetesRequestSidebarProps> = ({
   ];
 
   return (
-    <div className="flex items-start justify-between gap-4 md:flex-col md:items-stretch">
-      <ApprovalProgress request={request} />
-      <div className="flex md:w-full">
-        <MenuDropDown items={menuDropDownItems}></MenuDropDown>
-        <Button
-          className="flex-1"
-          id="runQuery"
-          variant={
-            (request?.reviewStatus == "APPROVED" &&
-              !(executesDirectly && !canExecute) &&
-              "primary") ||
-            "disabled"
-          }
-          title={getDisabledReason()}
-          onClick={() => void runQuery(false)}
-        >
-          {request?.type == "SingleExecution"
-            ? "Run Command"
-            : isAuthor
-            ? "Start Session"
-            : "Watch Session"}
-        </Button>
-      </div>
+    <div className="flex w-full">
+      <MenuDropDown items={menuDropDownItems}></MenuDropDown>
+      <Button
+        className="flex-1"
+        id="runQuery"
+        variant={
+          (request?.reviewStatus == "APPROVED" &&
+            !(executesDirectly && !canExecute) &&
+            "primary") ||
+          "disabled"
+        }
+        title={getDisabledReason()}
+        onClick={() => void runQuery(false)}
+      >
+        {request?.type == "SingleExecution"
+          ? "Run Command"
+          : isAuthor
+          ? "Start Session"
+          : "Watch Session"}
+      </Button>
     </div>
   );
 };
 
-export default KubernetesRequestSidebar;
+export default KubernetesRequestActions;

--- a/frontend/src/routes/Review/KubernetesRequestBox.tsx
+++ b/frontend/src/routes/Review/KubernetesRequestBox.tsx
@@ -1,8 +1,8 @@
 import { KubernetesExecutionRequestResponseWithComments } from "../../api/ExecutionRequestApi";
 import Button from "../../components/Button";
 import { timeSince } from "../Requests";
+import { AbsoluteInitialBubble as InitialBubble } from "../../components/InitialBubble";
 import { Highlighter } from "./components/Highlighter";
-import ConnectionLink from "./components/ConnectionLink";
 import { FC, useContext, useEffect, useState, MouseEvent } from "react";
 import { UserStatusContext } from "../../components/UserStatusProvider";
 
@@ -34,25 +34,20 @@ const KubernetesRequestBox: FC<KubernetesRequestBoxProps> = ({
 
   return (
     <div className="relative border-slate-500 dark:border dark:border-slate-950 dark:bg-slate-950">
+      <InitialBubble name={request?.author.fullName} />
       <div className="py-2">
-        <div className="flex text-sm text-slate-800 dark:text-slate-50">
-          <div>
-            {request?.author.fullName} wants to execute a Kubernetes command in:{" "}
-            <ConnectionLink
-              connectionId={request.connection.id}
-              displayName={request.connection.displayName}
-            />
-          </div>
-          <div
-            className="ml-auto dark:text-slate-500"
+        <div className="text-sm text-slate-800 dark:text-slate-50">
+          {request?.author?.fullName}{" "}
+          <span
+            className="text-slate-500 dark:text-slate-400"
             title={
               request?.createdAt
                 ? new Date(request.createdAt).toLocaleString()
                 : undefined
             }
           >
-            {timeSince(new Date(request?.createdAt ?? ""))}
-          </div>
+            requested {timeSince(new Date(request?.createdAt ?? ""))}
+          </span>
         </div>
         <div className="px-4 py-3">
           <p className="max-w-prose pb-6 text-slate-500">

--- a/frontend/src/routes/Review/RequestSidebar.tsx
+++ b/frontend/src/routes/Review/RequestSidebar.tsx
@@ -1,6 +1,11 @@
-import { ReactNode } from "react";
+import { ReactNode, useContext, useState } from "react";
+import { CheckIcon } from "@heroicons/react/20/solid";
 import { ExecutionRequestResponseWithComments } from "../../api/ExecutionRequestApi";
 import { mapStatus, mapStatusToLabelColor, timeSince } from "../Requests";
+import { ReviewTypes, latestReviewAction } from "../../hooks/request";
+import { hasPermission } from "../../api/Permissions";
+import { UserStatusContext } from "../../components/UserStatusProvider";
+import Button from "../../components/Button";
 import InitialBubble from "../../components/InitialBubble";
 import ConnectionLink from "./components/ConnectionLink";
 import ApprovalProgress from "./ApprovalProgress";
@@ -45,15 +50,53 @@ function SidebarDivider() {
 // The action buttons differ per request type, so they come in as children.
 function RequestSidebar({
   request,
+  sendReview,
   children,
 }: {
   request: ExecutionRequestResponseWithComments;
+  sendReview?: (comment: string, type: ReviewTypes) => Promise<boolean>;
   children: ReactNode;
 }) {
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
+  const userContext = useContext(UserStatusContext);
   const progress = request.approvalProgress;
   const showApprovals =
     !!progress &&
     (progress.totalRequired > 0 || progress.roleProgress.length > 0);
+
+  const currentUserId = userContext.userStatus
+    ? userContext.userStatus.id
+    : undefined;
+  const isOwnRequest = currentUserId === request.author.id;
+  const canReview = hasPermission(
+    request.permissions,
+    "execution_request:review",
+  );
+  const hasApproved = latestReviewAction(request, currentUserId) === "APPROVE";
+  // No disabled states here: users who can never approve (authors, missing
+  // permission) see nothing, a stale approval after an edit re-shows the button.
+  const showApproveButton =
+    !!sendReview &&
+    canReview &&
+    !isOwnRequest &&
+    !hasApproved &&
+    (request.reviewStatus === "AWAITING_APPROVAL" ||
+      request.reviewStatus === "CHANGE_REQUESTED") &&
+    request.executionStatus !== "EXECUTED";
+  const showYouApproved =
+    hasApproved && !isOwnRequest && request.reviewStatus !== "REJECTED";
+
+  const handleApprove = async () => {
+    if (!sendReview || reviewSubmitting) {
+      return;
+    }
+    setReviewSubmitting(true);
+    try {
+      await sendReview("", ReviewTypes.Approve);
+    } finally {
+      setReviewSubmitting(false);
+    }
+  };
 
   return (
     <aside className="flex w-full flex-col gap-4 border-slate-200 dark:border-slate-700 md:order-last md:w-60 md:shrink-0 md:border-l md:pl-4">
@@ -95,11 +138,32 @@ function RequestSidebar({
           </span>
         </SidebarSection>
       </div>
-      {showApprovals && (
+      {(showApprovals || showApproveButton || showYouApproved) && (
         <>
           <SidebarDivider />
           <SidebarSection label="Approvals">
-            <ApprovalProgress request={request} />
+            <div className="flex flex-col gap-3">
+              <ApprovalProgress request={request} />
+              {showApproveButton && (
+                <Button
+                  className="w-full"
+                  variant={reviewSubmitting ? "disabled" : "success"}
+                  onClick={() => void handleApprove()}
+                  dataTestId="sidebar-approve-button"
+                >
+                  Approve
+                </Button>
+              )}
+              {showYouApproved && (
+                <div
+                  className="flex items-center gap-1 text-sm text-green-600 dark:text-green-400"
+                  data-testid="sidebar-you-approved"
+                >
+                  <CheckIcon className="h-4 w-4 shrink-0" />
+                  You approved
+                </div>
+              )}
+            </div>
           </SidebarSection>
         </>
       )}

--- a/frontend/src/routes/Review/RequestSidebar.tsx
+++ b/frontend/src/routes/Review/RequestSidebar.tsx
@@ -147,7 +147,7 @@ function RequestSidebar({
               {showApproveButton && (
                 <Button
                   className="w-full"
-                  variant={reviewSubmitting ? "disabled" : "success"}
+                  variant="success"
                   onClick={() => void handleApprove()}
                   dataTestId="sidebar-approve-button"
                 >

--- a/frontend/src/routes/Review/RequestSidebar.tsx
+++ b/frontend/src/routes/Review/RequestSidebar.tsx
@@ -1,0 +1,110 @@
+import { ReactNode } from "react";
+import { ExecutionRequestResponseWithComments } from "../../api/ExecutionRequestApi";
+import { mapStatus, mapStatusToLabelColor, timeSince } from "../Requests";
+import InitialBubble from "../../components/InitialBubble";
+import ConnectionLink from "./components/ConnectionLink";
+import ApprovalProgress from "./ApprovalProgress";
+
+const requestTypeLabel = (
+  request: ExecutionRequestResponseWithComments,
+): string => {
+  if (request.type === "TemporaryAccess") {
+    return "Temporary Access";
+  }
+  if (request._type === "KUBERNETES") {
+    return "Command";
+  }
+  return request.type === "Dump" ? "SQL Dump" : "Query";
+};
+
+function SidebarSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-xs font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400">
+        {label}
+      </div>
+      <div className="text-sm text-slate-800 dark:text-slate-200">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function SidebarDivider() {
+  return <div className="border-b border-slate-200 dark:border-slate-700" />;
+}
+
+// GitHub-PR-style sidebar: status and actions on top (always reachable without
+// scrolling past long statements), then the request metadata, then approvals.
+// The action buttons differ per request type, so they come in as children.
+function RequestSidebar({
+  request,
+  children,
+}: {
+  request: ExecutionRequestResponseWithComments;
+  children: ReactNode;
+}) {
+  const progress = request.approvalProgress;
+  const showApprovals =
+    !!progress &&
+    (progress.totalRequired > 0 || progress.roleProgress.length > 0);
+
+  return (
+    <aside className="flex w-full flex-col gap-4 border-slate-200 dark:border-slate-700 md:order-last md:w-60 md:shrink-0 md:border-l md:pl-4">
+      <div
+        className={`${mapStatusToLabelColor(
+          mapStatus(request.reviewStatus, request.executionStatus),
+        )} w-fit rounded-md px-2 py-1 text-sm font-medium ring-1 ring-inset`}
+      >
+        {mapStatus(request.reviewStatus, request.executionStatus)}
+      </div>
+      {children}
+      <SidebarDivider />
+      <div className="grid grid-cols-2 gap-4 md:flex md:flex-col">
+        <SidebarSection label="Requester">
+          <div className="flex items-center gap-2">
+            <InitialBubble name={request.author.fullName} />
+            <span className="min-w-0 truncate">{request.author.fullName}</span>
+          </div>
+        </SidebarSection>
+        <SidebarSection label="Connection">
+          <ConnectionLink
+            connectionId={request.connection.id}
+            displayName={request.connection.displayName}
+          />
+        </SidebarSection>
+        <SidebarSection label="Type">
+          {requestTypeLabel(request)}
+          {request.type === "TemporaryAccess" && (
+            <div className="text-slate-500 dark:text-slate-400">
+              {request.temporaryAccessDuration != null
+                ? `Valid for ${request.temporaryAccessDuration} minutes`
+                : "Valid indefinitely"}
+            </div>
+          )}
+        </SidebarSection>
+        <SidebarSection label="Created">
+          <span title={request.createdAt.toLocaleString()}>
+            {timeSince(request.createdAt)}
+          </span>
+        </SidebarSection>
+      </div>
+      {showApprovals && (
+        <>
+          <SidebarDivider />
+          <SidebarSection label="Approvals">
+            <ApprovalProgress request={request} />
+          </SidebarSection>
+        </>
+      )}
+    </aside>
+  );
+}
+
+export default RequestSidebar;

--- a/frontend/src/routes/Review/components/ConnectionLink.tsx
+++ b/frontend/src/routes/Review/components/ConnectionLink.tsx
@@ -14,12 +14,12 @@ const ConnectionLink = ({
   const canViewConnections = useHasPermission("datasource_connection:get");
 
   if (!canViewConnections) {
-    return <span className="italic">{displayName}</span>;
+    return <span>{displayName}</span>;
   }
   return (
     <Link
       to={`/settings/connections/${encodeURIComponent(connectionId)}`}
-      className="italic hover:underline"
+      className="hover:underline"
       title="View connection settings"
     >
       {displayName}

--- a/frontend/src/routes/Review/events/ReviewEvent.tsx
+++ b/frontend/src/routes/Review/events/ReviewEvent.tsx
@@ -11,28 +11,43 @@ import TimelineItem from "./TimelineItem";
 function ReviewEvent({
   event,
   connectTop,
+  connectBottom,
 }: {
   event: Review;
   connectTop?: boolean;
+  connectBottom?: boolean;
 }) {
+  const timestamp = event?.createdAt && (
+    <span
+      className="text-slate-400 dark:text-slate-600"
+      title={event.createdAt.toLocaleString()}
+    >
+      {" "}
+      · {timeSince(event.createdAt)}
+    </span>
+  );
+
   const notificationText = (): ReactElement => {
     switch (event.action) {
       case "APPROVE":
         return (
           <div className="text-sm text-slate-500">
             {event.author?.fullName} approved
+            {timestamp}
           </div>
         );
       case "REJECT":
         return (
           <div className="text-sm text-red-500">
             {event.author?.fullName} rejected
+            {timestamp}
           </div>
         );
       case "REQUEST_CHANGE":
         return (
           <div className="text-sm text-red-500">
             {event.author?.fullName} requested changes
+            {timestamp}
           </div>
         );
     }
@@ -67,10 +82,12 @@ function ReviewEvent({
     }
   };
   // A review without a comment (e.g. a plain approval from the sidebar) is
-  // just the timeline notice — no empty comment card below it.
+  // just the timeline notice — no empty comment card below it. The timestamp
+  // lives in the notice, so the card holds only the comment itself.
   return (
     <TimelineItem
       connectTop={connectTop}
+      connectBottom={connectBottom}
       header={
         <div className="flex justify-center align-middle">
           {notificationIcon()}
@@ -81,14 +98,7 @@ function ReviewEvent({
       {event.comment.trim() !== "" && (
         <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
           <InitialBubble name={event?.author?.fullName} />
-          <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-            <div title={event?.createdAt?.toLocaleString()}>
-              {((event?.createdAt && timeSince(event.createdAt)) as
-                | string
-                | undefined) || ""}
-            </div>
-          </p>
-          <div className="rounded-b-md px-4 py-3 dark:bg-slate-900">
+          <div className="rounded-md px-4 py-3 dark:bg-slate-900">
             <ReactMarkdown components={componentMap}>
               {event.comment}
             </ReactMarkdown>

--- a/frontend/src/routes/Review/events/ReviewEvent.tsx
+++ b/frontend/src/routes/Review/events/ReviewEvent.tsx
@@ -66,6 +66,8 @@ function ReviewEvent({
         );
     }
   };
+  // A review without a comment (e.g. a plain approval from the sidebar) is
+  // just the timeline notice — no empty comment card below it.
   return (
     <TimelineItem
       connectTop={connectTop}
@@ -76,21 +78,23 @@ function ReviewEvent({
         </div>
       }
     >
-      <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
-        <InitialBubble name={event?.author?.fullName} />
-        <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
-          <div title={event?.createdAt?.toLocaleString()}>
-            {((event?.createdAt && timeSince(event.createdAt)) as
-              | string
-              | undefined) || ""}
+      {event.comment.trim() !== "" && (
+        <div className="relative rounded-md border shadow-md dark:border-slate-700 dark:shadow-none">
+          <InitialBubble name={event?.author?.fullName} />
+          <p className="flex justify-between rounded-t-md px-4 pt-2 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-500">
+            <div title={event?.createdAt?.toLocaleString()}>
+              {((event?.createdAt && timeSince(event.createdAt)) as
+                | string
+                | undefined) || ""}
+            </div>
+          </p>
+          <div className="rounded-b-md px-4 py-3 dark:bg-slate-900">
+            <ReactMarkdown components={componentMap}>
+              {event.comment}
+            </ReactMarkdown>
           </div>
-        </p>
-        <div className="rounded-b-md px-4 py-3 dark:bg-slate-900">
-          <ReactMarkdown components={componentMap}>
-            {event.comment}
-          </ReactMarkdown>
         </div>
-      </div>
+      )}
     </TimelineItem>
   );
 }

--- a/frontend/src/routes/Review/events/TimelineItem.tsx
+++ b/frontend/src/routes/Review/events/TimelineItem.tsx
@@ -2,20 +2,27 @@ import { ReactNode } from "react";
 
 function TimelineItem({
   connectTop = true,
+  connectBottom = true,
   header,
   children,
 }: {
   connectTop?: boolean;
+  /** Whether another timeline item follows below this one. */
+  connectBottom?: boolean;
   header: ReactNode;
   children?: ReactNode;
 }) {
+  // The line always runs down to a content card, but on the timeline's last
+  // card-less item it would dangle into nothing, so it stops at the icon
+  // (which masks the line end with its own background).
+  const connectorExtent = `${connectTop ? "top-0" : "top-5"} ${
+    connectBottom || children ? "bottom-0" : "bottom-1/2"
+  }`;
   return (
     <div>
       <div className="relative ml-4 flex py-4">
         <div
-          className={`absolute bottom-0 left-0 ${
-            connectTop ? "top-0" : "top-5"
-          } block w-0.5 whitespace-pre bg-slate-700`}
+          className={`absolute left-0 ${connectorExtent} block w-0.5 whitespace-pre bg-slate-700`}
         >
           {" "}
         </div>

--- a/frontend/src/routes/Review/index.tsx
+++ b/frontend/src/routes/Review/index.tsx
@@ -55,7 +55,7 @@ function RequestReview() {
             />
             <h1 className="my-2 text-3xl">{request?.title}</h1>
             <div className="flex flex-col gap-6 md:flex-row md:items-start">
-              <RequestSidebar request={request}>
+              <RequestSidebar request={request} sendReview={sendReview}>
                 {request._type === "DATASOURCE" ? (
                   <DatasourceRequestActions
                     request={request}

--- a/frontend/src/routes/Review/index.tsx
+++ b/frontend/src/routes/Review/index.tsx
@@ -1,12 +1,12 @@
 import { useNavigate, useParams } from "react-router-dom";
-import { mapStatus, mapStatusToLabelColor } from "../Requests";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import Spinner from "../../components/Spinner";
 import useRequest from "../../hooks/request";
 import KubernetesRequestDisplay from "./KubernetesRequestDisplay";
 import DatasourceRequestDisplay from "./DatasourceRequestDisplay";
-import DatasourceRequestSidebar from "./DatasourceRequestSidebar";
-import KubernetesRequestSidebar from "./KubernetesRequestSidebar";
+import DatasourceRequestActions from "./DatasourceRequestActions";
+import KubernetesRequestActions from "./KubernetesRequestActions";
+import RequestSidebar from "./RequestSidebar";
 import ActivityTimeline from "./ActivityTimeline";
 import NotAuthorized from "../../components/NotAuthorized";
 
@@ -55,25 +55,18 @@ function RequestReview() {
             />
             <h1 className="my-2 text-3xl">{request?.title}</h1>
             <div className="flex flex-col gap-6 md:flex-row md:items-start">
-              <aside className="flex w-full flex-col gap-4 border-slate-200 dark:border-slate-700 md:order-last md:w-60 md:shrink-0 md:border-l md:pl-4">
-                <div
-                  className={`${mapStatusToLabelColor(
-                    mapStatus(request.reviewStatus, request.executionStatus),
-                  )} w-fit rounded-md px-2 py-1 text-sm font-medium ring-1 ring-inset`}
-                >
-                  {mapStatus(request.reviewStatus, request.executionStatus)}
-                </div>
+              <RequestSidebar request={request}>
                 {request._type === "DATASOURCE" ? (
-                  <DatasourceRequestSidebar
+                  <DatasourceRequestActions
                     request={request}
                     runQuery={run}
                     cancelQuery={cancelQuery}
                     startServer={start}
                   />
                 ) : (
-                  <KubernetesRequestSidebar request={request} runQuery={run} />
+                  <KubernetesRequestActions request={request} runQuery={run} />
                 )}
-              </aside>
+              </RequestSidebar>
               <div className="min-w-0 flex-1">
                 {request._type === "DATASOURCE" ? (
                   <DatasourceRequestDisplay


### PR DESCRIPTION
Restructures the review page sidebar into GitHub-PR-style sections and makes approving a one-click action.

## Sidebar

The sidebar (shared between datasource and Kubernetes requests via a new `RequestSidebar` component) now shows, top to bottom: status badge, the request's action buttons, a metadata block (Requester, Connection, Type, Created), and the approval progress. The request box header becomes a plain "<name> requested <time> ago" comment header instead of the "wants to execute a statement on …" sentence; the temporary-access duration moves into the sidebar's Type section. On mobile the metadata renders as a two-column grid so the stacked sidebar stays compact.

## One-click Approve

Since most requests are approved without any comment, the verdict no longer requires opening the comment composer: reviewers get a green **Approve** button in the Approvals section, which becomes a "✓ You approved" line once their approval stands (mirroring the backend tally — latest review per user since the last reset by edit or failed execution). The composer stays collapsed and keeps its pills for verdicts that need prose, but hides the Approve pill while an approval is standing. Users who can never approve (authors, missing review permission) see no controls rather than disabled ones.

Review events without a comment no longer render an empty comment card in the timeline.

Addresses the discoverability complaint behind #519 from a different angle: the primary review action is now always visible, without expanding the composer.
Looks like this:

<details>
<summary> light mode </summary>
<img width="1466" height="728" alt="Screenshot 2026-08-08 at 19 56 19" src="https://github.com/user-attachments/assets/ea45a11d-3252-49a9-92a1-9adf49f4b370" />


</details>


<details>
<summary> dark mode </summary>
<img width="1466" height="728" alt="Screenshot 2026-08-08 at 19 56 24" src="https://github.com/user-attachments/assets/b5cd80dd-e70e-4228-941d-f4f82efe2479" />


</details>

