### PR TITLE
Fix SSO broken by empty Java trust store in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN npm run build
 
 # Needed to copy a working Java runtime to the final image
 FROM amazoncorretto:21 AS javaruntime
+# Replace the symlink to /etc/pki/java/cacerts with the actual file so it
+# survives COPY into the final image (fixes #524)
+RUN cp --remove-destination "$(readlink -f /usr/lib/jvm/java-21-amazon-corretto/lib/security/cacerts)" \
+    /usr/lib/jvm/java-21-amazon-corretto/lib/security/cacerts
 
 FROM nginxinc/nginx-unprivileged:1.27
 


### PR DESCRIPTION
## Problem

SSO is broken in recent Docker images. On startup, outbound TLS connections fail (including OIDC provider discovery) because the Java trust store is empty.

**Root cause:** The `amazoncorretto:21` base image now stores `cacerts` as a symlink:

```
/usr/lib/jvm/java-21-amazon-corretto/lib/security/cacerts → /etc/pki/java/cacerts
```

When the JVM directory is copied into the final `nginxinc/nginx-unprivileged` (Debian-based) image, that Red Hat-style path doesn't exist — leaving a dangling symlink and an empty trust anchor set.

## Fix

Dereference the symlink in the `javaruntime` build stage so the actual keystore file (not the symlink) gets copied into the final image:

```dockerfile
FROM amazoncorretto:21 AS javaruntime
RUN cp --remove-destination "\$(readlink -f /usr/lib/jvm/java-21-amazon-corretto/lib/security/cacerts)" \
    /usr/lib/jvm/java-21-amazon-corretto/lib/security/cacerts
```

Fixes #524