### PR TITLE
Fix rejected concurrent execution clearing the active session lock

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/SessionWebsocketHandler.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/SessionWebsocketHandler.kt
@@ -203,9 +203,6 @@ class SessionWebsocketHandler(
                                     liveSessionId,
                                 )
                             }
-                        } finally {
-                            // Clear the executing flag
-                            sessionService.clearExecutingFlag(liveSessionId)
                         }
                     }
                     // Handler returns immediately - can now process other messages!

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/websocket/SessionService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/websocket/SessionService.kt
@@ -39,11 +39,17 @@ class SessionService(
         // Atomically check and set executing flag - this will throw if already executing
         val session = sessionAdapter.checkAndSetExecuting(sessionId)
 
-        return executionRequestService.execute(
-            session.executionRequest.request.id!!,
-            statement,
-            userId,
-        )
+        try {
+            return executionRequestService.execute(
+                session.executionRequest.request.id!!,
+                statement,
+                userId,
+            )
+        } finally {
+            // Only reached if this execution acquired the flag above - a rejected
+            // execution must not release the lock held by the running query
+            sessionAdapter.setExecuting(sessionId, false)
+        }
     }
 
     @Policy(Permission.EXECUTION_REQUEST_EXECUTE)
@@ -57,10 +63,5 @@ class SessionService(
     fun cancelQuery(sessionId: LiveSessionId) {
         val session = sessionAdapter.findById(sessionId)
         executionRequestService.cancel(session.executionRequest.request.id!!)
-    }
-
-    @Policy(Permission.EXECUTION_REQUEST_EXECUTE)
-    fun clearExecutingFlag(sessionId: LiveSessionId) {
-        sessionAdapter.setExecuting(sessionId, false)
     }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/SessionServiceTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/SessionServiceTest.kt
@@ -1,5 +1,6 @@
 package dev.kviklet.kviklet.service.websocket
 
+import dev.kviklet.kviklet.db.LiveSessionAdapter
 import dev.kviklet.kviklet.db.User
 import dev.kviklet.kviklet.helper.ConnectionHelper
 import dev.kviklet.kviklet.helper.ExecutionRequestHelper
@@ -13,9 +14,11 @@ import dev.kviklet.kviklet.service.dto.RequestType
 import dev.kviklet.kviklet.service.dto.UpdateQueryResult
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -42,6 +45,9 @@ class SessionServiceTest {
 
     @Autowired
     private lateinit var liveSessionHelper: LiveSessionHelper
+
+    @Autowired
+    private lateinit var liveSessionAdapter: LiveSessionAdapter
 
     private lateinit var testUser: User
     private lateinit var testLiveSession: LiveSessionId
@@ -84,13 +90,8 @@ class SessionServiceTest {
         userHelper.deleteAll()
     }
 
-    // Executes via the service and then clears the executing flag, like
-    // SessionWebsocketHandler does after each query completes
-    private fun executeStatement(sessionId: LiveSessionId, statement: String, userId: String): ExecutionResult = try {
+    private fun executeStatement(sessionId: LiveSessionId, statement: String, userId: String): ExecutionResult =
         sessionService.executeStatement(sessionId, statement, userId)
-    } finally {
-        sessionService.clearExecutingFlag(sessionId)
-    }
 
     @Test
     fun testExecuteStatementSimpleSelect() {
@@ -196,5 +197,38 @@ class SessionServiceTest {
         assertEquals(1, finalState.data.size)
         assertEquals("1", finalState.data[0]["id"])
         assertEquals("Charlie", finalState.data[0]["name"])
+    }
+
+    @Test
+    fun testRejectedExecutionDoesNotClearSessionLock() {
+        // Simulate a query already running for this session, e.g. started via another replica
+        liveSessionAdapter.checkAndSetExecuting(testLiveSession)
+
+        // A competing execution is rejected
+        assertThrows<IllegalStateException> {
+            executeStatement(testLiveSession, "SELECT 1", testUser.getId()!!)
+        }
+
+        // The rejected attempt must not have released the running query's lock,
+        // so a retry is rejected as well
+        assertTrue(liveSessionAdapter.isExecuting(testLiveSession))
+        assertThrows<IllegalStateException> {
+            executeStatement(testLiveSession, "SELECT 1", testUser.getId()!!)
+        }
+
+        // Once the running query releases the lock, execution works again
+        liveSessionAdapter.setExecuting(testLiveSession, false)
+        val result = executeStatement(testLiveSession, "SELECT 1 as test", testUser.getId()!!)
+        assertTrue(result is DBExecutionResult)
+    }
+
+    @Test
+    fun testExecutionReleasesItsOwnSessionLock() {
+        executeStatement(testLiveSession, "SELECT 1", testUser.getId()!!)
+        assertFalse(liveSessionAdapter.isExecuting(testLiveSession))
+
+        // A failing statement releases the lock as well
+        executeStatement(testLiveSession, "SELECT * FROM does_not_exist", testUser.getId()!!)
+        assertFalse(liveSessionAdapter.isExecuting(testLiveSession))
     }
 }


### PR DESCRIPTION
Fixes #527

A rejected concurrent execution attempt on a live session cleared the `isExecuting` lock held by the query that was actually running: `SessionWebsocketHandler` unconditionally called `clearExecutingFlag()` in a `finally` block, even when `checkAndSetExecuting()` had thrown before this execution acquired the lock. Retrying the rejected query then ran it concurrently with the still-running one.

The lock lifecycle now lives entirely in `SessionService.executeStatement()`: the flag is released in a `try/finally` that is only reached after this execution acquired it, so a rejected attempt can no longer release another execution's lock. The handler's unconditional clear and the now-unused `clearExecutingFlag()` service method are removed.

Adds regression tests covering that a rejected execution leaves the lock intact (retries stay rejected until the lock is released) and that completed and failed executions release their own lock.