### PR TITLE
Add connection, author, and date range filters to the requests page

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
@@ -690,22 +690,24 @@ class ExecutionRequestController(val executionRequestService: ExecutionRequestSe
     fun list(
         @RequestParam(required = false) reviewStatuses: Set<ReviewStatus>?,
         @RequestParam(required = false) executionStatuses: Set<ExecutionStatus>?,
-        @RequestParam(required = false) connectionId: ConnectionId?,
+        @RequestParam(required = false) connectionIds: Set<ConnectionId>?,
+        @RequestParam(required = false) authorId: String?,
+        @RequestParam(required = false) createdAfter: Instant?,
+        @RequestParam(required = false) createdBefore: Instant?,
         @RequestParam(required = false) after: Instant?,
         @RequestParam(required = false, defaultValue = "${Int.MAX_VALUE}") limit: Int,
-    ): ExecutionRequestListResponse {
-        val afterLocalDateTime = after?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
-
-        return ExecutionRequestListResponse.fromDto(
-            executionRequestService.list(
-                reviewStatuses = reviewStatuses,
-                executionStatuses = executionStatuses,
-                connectionId = connectionId,
-                after = afterLocalDateTime,
-                limit = limit,
-            ),
-        )
-    }
+    ): ExecutionRequestListResponse = ExecutionRequestListResponse.fromDto(
+        executionRequestService.list(
+            reviewStatuses = reviewStatuses,
+            executionStatuses = executionStatuses,
+            connectionIds = connectionIds,
+            authorId = authorId,
+            createdAfter = createdAfter?.atZone(ZoneOffset.UTC)?.toLocalDateTime(),
+            createdBefore = createdBefore?.atZone(ZoneOffset.UTC)?.toLocalDateTime(),
+            after = after?.atZone(ZoneOffset.UTC)?.toLocalDateTime(),
+            limit = limit,
+        ),
+    )
 
     @Operation(summary = "Review Execution Request", description = "Approve or disapprove an execution request.")
     @PostMapping("/{executionRequestId}/reviews")

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/ExecutionRequest.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/ExecutionRequest.kt
@@ -143,7 +143,10 @@ interface CustomExecutionRequestRepository {
     fun findAllWithDetailsFiltered(
         reviewStatuses: Set<ReviewStatus>?,
         executionStatuses: Set<ExecutionStatus>?,
-        connectionId: ConnectionId?,
+        connectionIds: Set<ConnectionId>?,
+        authorId: String?,
+        createdAfter: LocalDateTime?,
+        createdBefore: LocalDateTime?,
         after: LocalDateTime?,
         limit: Int,
     ): List<ExecutionRequestEntity>
@@ -174,7 +177,10 @@ class CustomExecutionRequestRepositoryImpl(private val entityManager: EntityMana
     override fun findAllWithDetailsFiltered(
         reviewStatuses: Set<ReviewStatus>?,
         executionStatuses: Set<ExecutionStatus>?,
-        connectionId: ConnectionId?,
+        connectionIds: Set<ConnectionId>?,
+        authorId: String?,
+        createdAfter: LocalDateTime?,
+        createdBefore: LocalDateTime?,
         after: LocalDateTime?,
         limit: Int,
     ): List<ExecutionRequestEntity> {
@@ -197,8 +203,22 @@ class CustomExecutionRequestRepositoryImpl(private val entityManager: EntityMana
             }
         }
 
-        connectionId?.let {
-            query.where(qExecutionRequestEntity.connection.id.eq(it.toString()))
+        connectionIds?.let {
+            if (it.isNotEmpty()) {
+                query.where(qExecutionRequestEntity.connection.id.`in`(it.map { id -> id.toString() }))
+            }
+        }
+
+        authorId?.let {
+            query.where(qExecutionRequestEntity.author.id.eq(it))
+        }
+
+        createdAfter?.let {
+            query.where(qExecutionRequestEntity.createdAt.goe(it))
+        }
+
+        createdBefore?.let {
+            query.where(qExecutionRequestEntity.createdAt.loe(it))
         }
 
         // Apply cursor-based pagination
@@ -377,13 +397,19 @@ class ExecutionRequestAdapter(
     fun listExecutionRequestsFiltered(
         reviewStatuses: Set<ReviewStatus>? = null,
         executionStatuses: Set<ExecutionStatus>? = null,
-        connectionId: ConnectionId? = null,
+        connectionIds: Set<ConnectionId>? = null,
+        authorId: String? = null,
+        createdAfter: LocalDateTime? = null,
+        createdBefore: LocalDateTime? = null,
         after: LocalDateTime? = null,
         limit: Int = Int.MAX_VALUE,
     ): List<ExecutionRequestDetails> = executionRequestRepository.findAllWithDetailsFiltered(
         reviewStatuses = reviewStatuses,
         executionStatuses = executionStatuses,
-        connectionId = connectionId,
+        connectionIds = connectionIds,
+        authorId = authorId,
+        createdAfter = createdAfter,
+        createdBefore = createdBefore,
         after = after,
         limit = limit,
     ).map {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -362,7 +362,10 @@ class ExecutionRequestService(
     fun list(
         reviewStatuses: Set<ReviewStatus>?,
         executionStatuses: Set<ExecutionStatus>?,
-        connectionId: ConnectionId?,
+        connectionIds: Set<ConnectionId>?,
+        authorId: String?,
+        createdAfter: LocalDateTime?,
+        createdBefore: LocalDateTime?,
         after: LocalDateTime?,
         limit: Int = 20,
     ): ExecutionRequestList {
@@ -376,7 +379,10 @@ class ExecutionRequestService(
         val requests = executionRequestAdapter.listExecutionRequestsFiltered(
             reviewStatuses = reviewStatuses,
             executionStatuses = executionStatuses,
-            connectionId = connectionId,
+            connectionIds = connectionIds,
+            authorId = authorId,
+            createdAfter = createdAfter,
+            createdBefore = createdBefore,
             after = after,
             limit = fetchLimit,
         ).map { ensureMaterializedStatuses(it) }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestStatusService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestStatusService.kt
@@ -12,7 +12,7 @@ class ExecutionRequestStatusService(private val executionRequestAdapter: Executi
     @Transactional
     @Policy(Permission.DATASOURCE_CONNECTION_EDIT, checkIsPresentOnly = true)
     fun recalculateStatusForRequests(connectionId: ConnectionId) {
-        val requests = executionRequestAdapter.listExecutionRequestsFiltered(connectionId = connectionId)
+        val requests = executionRequestAdapter.listExecutionRequestsFiltered(connectionIds = setOf(connectionId))
 
         requests.forEach { executionRequestDetails ->
             executionRequestAdapter.updateExecutionRequest(

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionRequestPaginationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionRequestPaginationTest.kt
@@ -160,7 +160,7 @@ class ExecutionRequestPaginationTest {
             // Filter by connection1
             mockMvc.perform(
                 get("/execution-requests/")
-                    .param("connectionId", testConnection.id.toString())
+                    .param("connectionIds", testConnection.id.toString())
                     .cookie(cookie),
             ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(1)))
@@ -170,12 +170,125 @@ class ExecutionRequestPaginationTest {
             // Filter by connection2
             mockMvc.perform(
                 get("/execution-requests/")
-                    .param("connectionId", testConnection2.id.toString())
+                    .param("connectionIds", testConnection2.id.toString())
                     .cookie(cookie),
             ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(1)))
                 .andExpect(jsonPath("$.requests[0].id").value(req2.getId()))
                 .andExpect(jsonPath("$.requests[0].connection.id").value(testConnection2.id.toString()))
+        }
+
+        @Test
+        fun `filter by multiple connections returns requests for all of them`() {
+            val cookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+            val testConnection3 = connectionHelper.createPostgresConnection(db)
+
+            val req1 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            val req2 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection2)
+            executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection3)
+
+            mockMvc.perform(
+                get("/execution-requests/")
+                    .param("connectionIds", testConnection.id.toString())
+                    .param("connectionIds", testConnection2.id.toString())
+                    .cookie(cookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(2)))
+                .andExpect(
+                    jsonPath(
+                        "$.requests[*].id",
+                        org.hamcrest.Matchers.containsInAnyOrder(req1.getId(), req2.getId()),
+                    ),
+                )
+        }
+
+        @Test
+        fun `filter by author returns only that user's requests`() {
+            val cookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+            val otherUser = userHelper.createUser(permissions = listOf("*"))
+
+            val req1 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            executionRequestHelper.createExecutionRequest(db, otherUser, connection = testConnection)
+
+            mockMvc.perform(
+                get("/execution-requests/")
+                    .param("authorId", testUser.getId()!!)
+                    .cookie(cookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(1)))
+                .andExpect(jsonPath("$.requests[0].id").value(req1.getId()))
+                .andExpect(jsonPath("$.requests[0].author.id").value(testUser.getId()))
+        }
+
+        @Test
+        fun `filter by created date range returns only requests within the range`() {
+            val cookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+
+            val req1 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            Thread.sleep(10)
+            val req2 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            Thread.sleep(10)
+            val req3 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+
+            val req2Timestamp = req2.request.createdAt.atZone(java.time.ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT)
+
+            // createdAfter is inclusive: req2 and req3
+            mockMvc.perform(
+                get("/execution-requests/")
+                    .param("createdAfter", req2Timestamp)
+                    .cookie(cookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(2)))
+                .andExpect(
+                    jsonPath(
+                        "$.requests[*].id",
+                        org.hamcrest.Matchers.containsInAnyOrder(req2.getId(), req3.getId()),
+                    ),
+                )
+
+            // createdBefore is inclusive: req1 and req2
+            mockMvc.perform(
+                get("/execution-requests/")
+                    .param("createdBefore", req2Timestamp)
+                    .cookie(cookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(2)))
+                .andExpect(
+                    jsonPath(
+                        "$.requests[*].id",
+                        org.hamcrest.Matchers.containsInAnyOrder(req1.getId(), req2.getId()),
+                    ),
+                )
+
+            // Both bounds combined: only req2
+            mockMvc.perform(
+                get("/execution-requests/")
+                    .param("createdAfter", req2Timestamp)
+                    .param("createdBefore", req2Timestamp)
+                    .cookie(cookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(1)))
+                .andExpect(jsonPath("$.requests[0].id").value(req2.getId()))
+        }
+
+        @Test
+        fun `combined filters apply together`() {
+            val cookie = userHelper.login(email = testUser.email, mockMvc = mockMvc)
+            val otherUser = userHelper.createUser(permissions = listOf("*"))
+
+            val req1 = executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection)
+            executionRequestHelper.createExecutionRequest(db, otherUser, connection = testConnection)
+            executionRequestHelper.createExecutionRequest(db, testUser, connection = testConnection2)
+
+            mockMvc.perform(
+                get("/execution-requests/")
+                    .param("connectionIds", testConnection.id.toString())
+                    .param("authorId", testUser.getId()!!)
+                    .cookie(cookie),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.requests", hasSize<Collection<*>>(1)))
+                .andExpect(jsonPath("$.requests[0].id").value(req1.getId()))
         }
     }
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionRequestStatusRefreshTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ExecutionRequestStatusRefreshTest.kt
@@ -133,7 +133,7 @@ class ExecutionRequestStatusRefreshTest {
         assertEquals("ACTIVE", storedBefore)
 
         entityManager.clear()
-        val listResult = executionRequestService.list(null, null, null, null, 20)
+        val listResult = executionRequestService.list(null, null, null, null, null, null, null, 20)
         val listDetails = listResult.requests.first { it.request.id == requestId }
         val refreshedStatus = listDetails.request.executionStatus
         assertEquals("EXECUTED", refreshedStatus, "expected EXECUTED in list but was $refreshedStatus")
@@ -235,7 +235,7 @@ class ExecutionRequestStatusRefreshTest {
 
         entityManager.clear()
 
-        val listResult = executionRequestService.list(null, null, null, null, 20)
+        val listResult = executionRequestService.list(null, null, null, null, null, null, null, 20)
         val refreshed = listResult.requests.first { it.request.id == requestId }
 
         assertEquals(ReviewStatus.APPROVED, refreshed.resolveReviewStatus())

--- a/frontend/src/api/ExecutionRequestApi.ts
+++ b/frontend/src/api/ExecutionRequestApi.ts
@@ -314,7 +314,10 @@ const postStartServer = async (
 interface GetRequestsParams {
   reviewStatuses?: string[];
   executionStatuses?: string[];
-  connectionId?: string;
+  connectionIds?: string[];
+  authorId?: string;
+  createdAfter?: Date;
+  createdBefore?: Date;
   after?: Date;
   limit?: number;
 }
@@ -336,8 +339,22 @@ const getRequestsPaginated = async (
     );
   }
 
-  if (params?.connectionId) {
-    searchParams.append("connectionId", params.connectionId);
+  if (params?.connectionIds && params.connectionIds.length > 0) {
+    params.connectionIds.forEach((id) =>
+      searchParams.append("connectionIds", id),
+    );
+  }
+
+  if (params?.authorId) {
+    searchParams.append("authorId", params.authorId);
+  }
+
+  if (params?.createdAfter) {
+    searchParams.append("createdAfter", params.createdAfter.toISOString());
+  }
+
+  if (params?.createdBefore) {
+    searchParams.append("createdBefore", params.createdBefore.toISOString());
   }
 
   if (params?.after) {

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -6,27 +6,41 @@ type SearchInputProps = {
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   placeholder?: string;
   className?: string;
+  // Matches the h-7 filter-pill height so search can share a row with pills
+  compact?: boolean;
 };
 
 const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
   (
-    { value, onChange, placeholder = "Search connections...", className = "" },
+    {
+      value,
+      onChange,
+      placeholder = "Search connections...",
+      className = "",
+      compact = false,
+    },
     ref,
   ) => {
     return (
       <div className={`${className} relative w-full`}>
-        <MagnifyingGlassIcon className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" />
+        <MagnifyingGlassIcon
+          className={`absolute top-1/2 -translate-y-1/2 text-slate-400 ${
+            compact ? "left-2.5 h-4 w-4" : "left-3 h-5 w-5"
+          }`}
+        />
         <input
           type="text"
           value={value}
           onChange={onChange}
           placeholder={placeholder}
           ref={ref}
-          className={`w-full rounded-md border-slate-300 py-2 pl-10 pr-4 text-sm placeholder:text-slate-400
+          className={`w-full rounded-md border-slate-300 placeholder:text-slate-400
             focus:outline-none focus:ring-1 focus:ring-indigo-600
-            dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 
-            dark:placeholder:text-slate-500 dark:focus:border-indigo-500 
-            dark:focus:ring-indigo-500`}
+            dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100
+            dark:placeholder:text-slate-500 dark:focus:border-indigo-500
+            dark:focus:ring-indigo-500 ${
+              compact ? "h-7 py-1 pl-8 pr-3 text-xs" : "py-2 pl-10 pr-4 text-sm"
+            }`}
         />
       </div>
     );

--- a/frontend/src/routes/RequestFilters.test.tsx
+++ b/frontend/src/routes/RequestFilters.test.tsx
@@ -1,0 +1,189 @@
+import { useState } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi, describe, it, expect, beforeEach, MockedFunction } from "vitest";
+import {
+  RequestFilterBar,
+  RequestListFilters,
+  emptyFilters,
+} from "./RequestFilters";
+import { getConnections, ConnectionResponse } from "../api/DatasourceApi";
+import { fetchUsers } from "../api/UserApi";
+import { UserStatusContext } from "../components/UserStatusProvider";
+import { StatusResponse } from "../api/StatusApi";
+
+vi.mock("../api/DatasourceApi");
+vi.mock("../api/UserApi");
+
+const mockGetConnections = getConnections as MockedFunction<
+  typeof getConnections
+>;
+const mockFetchUsers = fetchUsers as MockedFunction<typeof fetchUsers>;
+
+const currentUser = {
+  id: "me",
+  email: "me@example.com",
+  fullName: "Current User",
+} as unknown as StatusResponse;
+
+const makeConnection = (id: string, displayName: string) =>
+  ({ id, displayName }) as unknown as ConnectionResponse;
+
+const usersResponse = {
+  users: [
+    { id: "me", email: "me@example.com", fullName: "Current User", roles: [] },
+    { id: "u2", email: "other@example.com", fullName: "Other User", roles: [] },
+  ],
+};
+
+let lastFilters: RequestListFilters = emptyFilters;
+
+function Harness() {
+  const [filters, setFilters] = useState<RequestListFilters>(emptyFilters);
+  lastFilters = filters;
+  return <RequestFilterBar filters={filters} onChange={setFilters} />;
+}
+
+const renderFilterBar = () =>
+  render(
+    <UserStatusContext.Provider
+      value={{
+        userStatus: currentUser,
+        refreshState: async () => {},
+        hasPermission: () => true,
+      }}
+    >
+      <Harness />
+    </UserStatusContext.Provider>,
+  );
+
+describe("RequestFilterBar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastFilters = emptyFilters;
+    mockGetConnections.mockResolvedValue([
+      makeConnection("conn-a", "Prod Postgres"),
+      makeConnection("conn-b", "Staging MySQL"),
+    ]);
+    mockFetchUsers.mockResolvedValue(usersResponse);
+  });
+
+  describe("permission degradation", () => {
+    it("still offers 'Your requests' when the user list is not accessible", async () => {
+      mockFetchUsers.mockResolvedValue({ message: "Forbidden" });
+      renderFilterBar();
+
+      userEvent.click(await screen.findByTestId("filter-author"));
+
+      expect(await screen.findByTestId("filter-author-mine")).toBeVisible();
+      expect(screen.queryByText("Other User")).not.toBeInTheDocument();
+    });
+
+    it("hides the connection filter when connections are not accessible", async () => {
+      mockGetConnections.mockResolvedValue({ message: "Forbidden" });
+      renderFilterBar();
+
+      // The author filter loading proves the fetches settled
+      await screen.findByTestId("filter-author");
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("filter-connection"),
+        ).not.toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("filter-created")).toBeInTheDocument();
+      expect(screen.getByTestId("filter-pending")).toBeInTheDocument();
+    });
+  });
+
+  describe("selection semantics", () => {
+    it("toggles connections in and out of the multiselect", async () => {
+      renderFilterBar();
+
+      userEvent.click(await screen.findByTestId("filter-connection"));
+      userEvent.click(
+        await screen.findByTestId("filter-connection-Prod Postgres"),
+      );
+      expect(lastFilters.connectionIds).toEqual(["conn-a"]);
+      expect(screen.getByTestId("filter-connection")).toHaveTextContent(
+        "Prod Postgres",
+      );
+
+      userEvent.click(screen.getByTestId("filter-connection-Staging MySQL"));
+      expect(lastFilters.connectionIds).toEqual(["conn-a", "conn-b"]);
+      expect(screen.getByTestId("filter-connection")).toHaveTextContent(
+        "2 connections",
+      );
+
+      userEvent.click(screen.getByTestId("filter-connection-Prod Postgres"));
+      expect(lastFilters.connectionIds).toEqual(["conn-b"]);
+      expect(screen.getByTestId("filter-connection")).toHaveTextContent(
+        "Staging MySQL",
+      );
+    });
+
+    it("selects a single author exclusively", async () => {
+      renderFilterBar();
+
+      userEvent.click(await screen.findByTestId("filter-author"));
+      userEvent.click(await screen.findByTestId("filter-author-mine"));
+      expect(lastFilters.authorId).toBe("me");
+      expect(screen.getByTestId("filter-author")).toHaveTextContent(
+        "Your requests",
+      );
+
+      userEvent.click(screen.getByTestId("filter-author"));
+      userEvent.click(await screen.findByText("Other User"));
+      expect(lastFilters.authorId).toBe("u2");
+      expect(screen.getByTestId("filter-author")).toHaveTextContent(
+        "Other User",
+      );
+    });
+
+    it("clears a single filter from its pill", async () => {
+      renderFilterBar();
+
+      userEvent.click(await screen.findByTestId("filter-connection"));
+      userEvent.click(
+        await screen.findByTestId("filter-connection-Prod Postgres"),
+      );
+      expect(lastFilters.connectionIds).toEqual(["conn-a"]);
+
+      userEvent.click(
+        screen.getByRole("button", { name: /Clear Prod Postgres filter/ }),
+      );
+      expect(lastFilters.connectionIds).toEqual([]);
+    });
+
+    it("toggles the pending filter", async () => {
+      renderFilterBar();
+
+      const pendingPill = await screen.findByTestId("filter-pending");
+      userEvent.click(pendingPill);
+      expect(lastFilters.onlyPending).toBe(true);
+
+      userEvent.click(pendingPill);
+      expect(lastFilters.onlyPending).toBe(false);
+    });
+
+    it("clear filters resets everything including pending", async () => {
+      renderFilterBar();
+
+      userEvent.click(await screen.findByTestId("filter-connection"));
+      userEvent.click(
+        await screen.findByTestId("filter-connection-Prod Postgres"),
+      );
+      userEvent.click(document.body);
+      userEvent.click(screen.getByTestId("filter-author"));
+      userEvent.click(await screen.findByTestId("filter-author-mine"));
+      userEvent.click(screen.getByTestId("filter-pending"));
+      expect(lastFilters).toMatchObject({
+        connectionIds: ["conn-a"],
+        authorId: "me",
+        onlyPending: true,
+      });
+
+      userEvent.click(screen.getByTestId("filter-clear-all"));
+      expect(lastFilters).toEqual(emptyFilters);
+    });
+  });
+});

--- a/frontend/src/routes/RequestFilters.tsx
+++ b/frontend/src/routes/RequestFilters.tsx
@@ -99,8 +99,10 @@ function FilterPill({
   );
 }
 
+// Plain CSS positioning instead of the anchor prop: floating-ui's measuring
+// loop never converges in jsdom, which hangs component tests.
 const panelClasses =
-  "z-10 mt-1 w-64 rounded-md border border-slate-200 bg-white p-1 shadow-lg dark:border-slate-700 dark:bg-slate-900";
+  "absolute left-0 top-full z-10 mt-1 w-64 rounded-md border border-slate-200 bg-white p-1 shadow-lg dark:border-slate-700 dark:bg-slate-900";
 
 function OptionRow({
   label,
@@ -204,7 +206,7 @@ function RequestFilterBar({
             onClear={() => onChange({ ...filters, connectionIds: [] })}
             testId="filter-connection"
           />
-          <PopoverPanel anchor="bottom start" className={panelClasses}>
+          <PopoverPanel className={panelClasses}>
             <div className="max-h-64 overflow-y-auto">
               {connections.map((connection) => (
                 <OptionRow
@@ -228,7 +230,7 @@ function RequestFilterBar({
             onClear={() => onChange({ ...filters, authorId: null })}
             testId="filter-author"
           />
-          <PopoverPanel anchor="bottom start" className={panelClasses}>
+          <PopoverPanel className={panelClasses}>
             {({ close }) => (
               <div className="max-h-64 overflow-y-auto">
                 <OptionRow
@@ -290,7 +292,7 @@ function RequestFilterBar({
           }
           testId="filter-created"
         />
-        <PopoverPanel anchor="bottom start" className={`${panelClasses} p-3`}>
+        <PopoverPanel className={`${panelClasses} p-3`}>
           <div className="flex flex-col gap-2">
             <label className="block text-xs font-medium text-slate-600 dark:text-slate-300">
               From

--- a/frontend/src/routes/RequestFilters.tsx
+++ b/frontend/src/routes/RequestFilters.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { ReactNode, useContext, useEffect, useState } from "react";
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import {
   CheckIcon,
@@ -11,6 +11,7 @@ import { fetchUsers, UserResponse } from "../api/UserApi";
 import { isApiErrorResponse } from "../api/Errors";
 import { UserStatusContext } from "../components/UserStatusProvider";
 import Tooltip from "../components/Tooltip";
+import InitialBubble from "../components/InitialBubble";
 
 interface RequestListFilters {
   connectionIds: string[];
@@ -77,7 +78,7 @@ function FilterPill({
         active ? `pr-1.5 ${pillActiveClasses}` : `pr-2 ${pillInactiveClasses}`
       }`}
     >
-      {label}
+      <span className="max-w-[7rem] truncate">{label}</span>
       {active ? (
         <span
           role="button"
@@ -106,20 +107,23 @@ function OptionRow({
   selected,
   onClick,
   testId,
+  leading,
 }: {
   label: string;
   selected: boolean;
   onClick: () => void;
   testId?: string;
+  leading?: ReactNode;
 }) {
   return (
     <button
       type="button"
       data-testid={testId}
       onClick={onClick}
-      className="flex w-full items-center justify-between gap-2 rounded px-2.5 py-1.5 text-left text-sm text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800"
+      className="flex w-full items-center gap-2 rounded px-2.5 py-1.5 text-left text-sm text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800"
     >
-      <span className="truncate">{label}</span>
+      {leading}
+      <span className="min-w-0 flex-1 truncate">{label}</span>
       {selected && (
         <CheckIcon className="h-4 w-4 shrink-0 text-indigo-600 dark:text-indigo-400" />
       )}
@@ -141,6 +145,10 @@ function RequestFilterBar({
   const [users, setUsers] = useState<UserResponse[]>([]);
   const { userStatus } = useContext(UserStatusContext);
   const currentUserId = userStatus === false ? undefined : userStatus?.id;
+  const currentUserName =
+    userStatus === false
+      ? undefined
+      : userStatus?.fullName ?? userStatus?.email;
 
   useEffect(() => {
     // Both lists are permission-gated; a user who can't load them still gets
@@ -225,6 +233,12 @@ function RequestFilterBar({
               <div className="max-h-64 overflow-y-auto">
                 <OptionRow
                   label="Your requests"
+                  leading={
+                    <InitialBubble
+                      name={currentUserName}
+                      className="!h-5 !w-5 shrink-0 !text-[9px]"
+                    />
+                  }
                   selected={filters.authorId === currentUserId}
                   onClick={() => {
                     onChange({
@@ -245,6 +259,12 @@ function RequestFilterBar({
                   <OptionRow
                     key={user.id}
                     label={user.fullName ?? user.email}
+                    leading={
+                      <InitialBubble
+                        name={user.fullName ?? user.email}
+                        className="!h-5 !w-5 shrink-0 !text-[9px]"
+                      />
+                    }
                     selected={filters.authorId === user.id}
                     onClick={() => {
                       onChange({

--- a/frontend/src/routes/RequestFilters.tsx
+++ b/frontend/src/routes/RequestFilters.tsx
@@ -1,0 +1,318 @@
+import { useContext, useEffect, useState } from "react";
+import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  XMarkIcon,
+} from "@heroicons/react/20/solid";
+import { getConnections, ConnectionResponse } from "../api/DatasourceApi";
+import { fetchUsers, UserResponse } from "../api/UserApi";
+import { isApiErrorResponse } from "../api/Errors";
+import { UserStatusContext } from "../components/UserStatusProvider";
+
+interface RequestListFilters {
+  connectionIds: string[];
+  authorId: string | null;
+  createdFrom: string | null;
+  createdTo: string | null;
+}
+
+const emptyFilters: RequestListFilters = {
+  connectionIds: [],
+  authorId: null,
+  createdFrom: null,
+  createdTo: null,
+};
+
+const hasActiveFilters = (filters: RequestListFilters): boolean =>
+  filters.connectionIds.length > 0 ||
+  filters.authorId !== null ||
+  filters.createdFrom !== null ||
+  filters.createdTo !== null;
+
+function formatDay(isoDate: string): string {
+  const date = new Date(`${isoDate}T00:00:00`);
+  const sameYear = date.getFullYear() === new Date().getFullYear();
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  });
+}
+
+function dateRangeLabel(from: string | null, to: string | null): string {
+  if (from && to) return `${formatDay(from)} – ${formatDay(to)}`;
+  if (from) return `From ${formatDay(from)}`;
+  if (to) return `Until ${formatDay(to)}`;
+  return "Created";
+}
+
+function FilterPill({
+  label,
+  active,
+  onClear,
+  testId,
+}: {
+  label: string;
+  active: boolean;
+  onClear: () => void;
+  testId: string;
+}) {
+  const baseClasses =
+    "inline-flex h-7 items-center gap-1 rounded-md pl-2.5 text-xs font-medium ring-1 ring-inset transition-colors";
+  const inactiveClasses =
+    "pr-2 text-slate-600 ring-slate-300 hover:bg-white dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-900";
+  const activeClasses =
+    "pr-1.5 bg-indigo-50 text-indigo-600 ring-indigo-600/30 dark:bg-indigo-400/10 dark:text-indigo-400 dark:ring-indigo-400/30";
+  return (
+    <PopoverButton
+      data-testid={testId}
+      className={`${baseClasses} ${active ? activeClasses : inactiveClasses}`}
+    >
+      {label}
+      {active ? (
+        <span
+          role="button"
+          aria-label={`Clear ${label} filter`}
+          className="rounded p-0.5 hover:bg-indigo-100 dark:hover:bg-indigo-400/20"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onClear();
+          }}
+        >
+          <XMarkIcon className="h-3.5 w-3.5" />
+        </span>
+      ) : (
+        <ChevronDownIcon className="h-4 w-4 text-slate-400 dark:text-slate-500" />
+      )}
+    </PopoverButton>
+  );
+}
+
+const panelClasses =
+  "z-10 mt-1 w-64 rounded-md border border-slate-200 bg-white p-1 shadow-lg dark:border-slate-700 dark:bg-slate-900";
+
+function OptionRow({
+  label,
+  selected,
+  onClick,
+  testId,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+  testId?: string;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={onClick}
+      className="flex w-full items-center justify-between gap-2 rounded px-2.5 py-1.5 text-left text-sm text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800"
+    >
+      <span className="truncate">{label}</span>
+      {selected && (
+        <CheckIcon className="h-4 w-4 shrink-0 text-indigo-600 dark:text-indigo-400" />
+      )}
+    </button>
+  );
+}
+
+const dateInputClasses =
+  "mt-1 block w-full rounded-md border-slate-300 py-1.5 text-sm text-slate-900 focus:border-indigo-600 focus:ring-indigo-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:[color-scheme:dark]";
+
+function RequestFilterBar({
+  filters,
+  onChange,
+}: {
+  filters: RequestListFilters;
+  onChange: (filters: RequestListFilters) => void;
+}) {
+  const [connections, setConnections] = useState<ConnectionResponse[]>([]);
+  const [users, setUsers] = useState<UserResponse[]>([]);
+  const { userStatus } = useContext(UserStatusContext);
+  const currentUserId = userStatus === false ? undefined : userStatus?.id;
+
+  useEffect(() => {
+    // Both lists are permission-gated; a user who can't load them still gets
+    // the remaining filters, so failures stay silent.
+    const load = async () => {
+      const [connectionsResponse, usersResponse] = await Promise.all([
+        getConnections(),
+        fetchUsers(),
+      ]);
+      if (!isApiErrorResponse(connectionsResponse)) {
+        setConnections(connectionsResponse);
+      }
+      if (!isApiErrorResponse(usersResponse)) {
+        setUsers(usersResponse.users);
+      }
+    };
+    void load();
+  }, []);
+
+  const toggleConnection = (id: string) => {
+    const connectionIds = filters.connectionIds.includes(id)
+      ? filters.connectionIds.filter((existing) => existing !== id)
+      : [...filters.connectionIds, id];
+    onChange({ ...filters, connectionIds });
+  };
+
+  const connectionLabel =
+    filters.connectionIds.length === 0
+      ? "Connection"
+      : filters.connectionIds.length === 1
+      ? connections.find((c) => c.id === filters.connectionIds[0])
+          ?.displayName ?? "1 connection"
+      : `${filters.connectionIds.length} connections`;
+
+  const authorLabel =
+    filters.authorId === null
+      ? "Author"
+      : filters.authorId === currentUserId
+      ? "Your requests"
+      : users.find((u) => u.id === filters.authorId)?.fullName ??
+        users.find((u) => u.id === filters.authorId)?.email ??
+        "1 author";
+
+  const otherUsers = users.filter((u) => u.id !== currentUserId);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {connections.length > 0 && (
+        <Popover className="relative">
+          <FilterPill
+            label={connectionLabel}
+            active={filters.connectionIds.length > 0}
+            onClear={() => onChange({ ...filters, connectionIds: [] })}
+            testId="filter-connection"
+          />
+          <PopoverPanel anchor="bottom start" className={panelClasses}>
+            <div className="max-h-64 overflow-y-auto">
+              {connections.map((connection) => (
+                <OptionRow
+                  key={connection.id}
+                  label={connection.displayName}
+                  selected={filters.connectionIds.includes(connection.id)}
+                  onClick={() => toggleConnection(connection.id)}
+                  testId={`filter-connection-${connection.displayName}`}
+                />
+              ))}
+            </div>
+          </PopoverPanel>
+        </Popover>
+      )}
+
+      {currentUserId && (
+        <Popover className="relative">
+          <FilterPill
+            label={authorLabel}
+            active={filters.authorId !== null}
+            onClear={() => onChange({ ...filters, authorId: null })}
+            testId="filter-author"
+          />
+          <PopoverPanel anchor="bottom start" className={panelClasses}>
+            {({ close }) => (
+              <div className="max-h-64 overflow-y-auto">
+                <OptionRow
+                  label="Your requests"
+                  selected={filters.authorId === currentUserId}
+                  onClick={() => {
+                    onChange({
+                      ...filters,
+                      authorId:
+                        filters.authorId === currentUserId
+                          ? null
+                          : currentUserId,
+                    });
+                    close();
+                  }}
+                  testId="filter-author-mine"
+                />
+                {otherUsers.length > 0 && (
+                  <div className="mx-2.5 my-1 border-t border-slate-200 dark:border-slate-700" />
+                )}
+                {otherUsers.map((user) => (
+                  <OptionRow
+                    key={user.id}
+                    label={user.fullName ?? user.email}
+                    selected={filters.authorId === user.id}
+                    onClick={() => {
+                      onChange({
+                        ...filters,
+                        authorId: filters.authorId === user.id ? null : user.id,
+                      });
+                      close();
+                    }}
+                  />
+                ))}
+              </div>
+            )}
+          </PopoverPanel>
+        </Popover>
+      )}
+
+      <Popover className="relative">
+        <FilterPill
+          label={dateRangeLabel(filters.createdFrom, filters.createdTo)}
+          active={filters.createdFrom !== null || filters.createdTo !== null}
+          onClear={() =>
+            onChange({ ...filters, createdFrom: null, createdTo: null })
+          }
+          testId="filter-created"
+        />
+        <PopoverPanel anchor="bottom start" className={`${panelClasses} p-3`}>
+          <div className="flex flex-col gap-2">
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-300">
+              From
+              <input
+                type="date"
+                data-testid="filter-created-from"
+                value={filters.createdFrom ?? ""}
+                max={filters.createdTo ?? undefined}
+                onChange={(e) =>
+                  onChange({
+                    ...filters,
+                    createdFrom: e.target.value || null,
+                  })
+                }
+                className={dateInputClasses}
+              />
+            </label>
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-300">
+              To
+              <input
+                type="date"
+                data-testid="filter-created-to"
+                value={filters.createdTo ?? ""}
+                min={filters.createdFrom ?? undefined}
+                onChange={(e) =>
+                  onChange({
+                    ...filters,
+                    createdTo: e.target.value || null,
+                  })
+                }
+                className={dateInputClasses}
+              />
+            </label>
+          </div>
+        </PopoverPanel>
+      </Popover>
+
+      {hasActiveFilters(filters) && (
+        <button
+          type="button"
+          data-testid="filter-clear-all"
+          onClick={() => onChange(emptyFilters)}
+          className="text-xs font-medium text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+        >
+          Clear filters
+        </button>
+      )}
+    </div>
+  );
+}
+
+export { RequestFilterBar, emptyFilters, hasActiveFilters };
+export type { RequestListFilters };

--- a/frontend/src/routes/RequestFilters.tsx
+++ b/frontend/src/routes/RequestFilters.tsx
@@ -3,18 +3,21 @@ import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import {
   CheckIcon,
   ChevronDownIcon,
+  ClockIcon,
   XMarkIcon,
 } from "@heroicons/react/20/solid";
 import { getConnections, ConnectionResponse } from "../api/DatasourceApi";
 import { fetchUsers, UserResponse } from "../api/UserApi";
 import { isApiErrorResponse } from "../api/Errors";
 import { UserStatusContext } from "../components/UserStatusProvider";
+import Tooltip from "../components/Tooltip";
 
 interface RequestListFilters {
   connectionIds: string[];
   authorId: string | null;
   createdFrom: string | null;
   createdTo: string | null;
+  onlyPending: boolean;
 }
 
 const emptyFilters: RequestListFilters = {
@@ -22,13 +25,15 @@ const emptyFilters: RequestListFilters = {
   authorId: null,
   createdFrom: null,
   createdTo: null,
+  onlyPending: false,
 };
 
 const hasActiveFilters = (filters: RequestListFilters): boolean =>
   filters.connectionIds.length > 0 ||
   filters.authorId !== null ||
   filters.createdFrom !== null ||
-  filters.createdTo !== null;
+  filters.createdTo !== null ||
+  filters.onlyPending;
 
 function formatDay(isoDate: string): string {
   const date = new Date(`${isoDate}T00:00:00`);
@@ -47,6 +52,13 @@ function dateRangeLabel(from: string | null, to: string | null): string {
   return "Created";
 }
 
+const pillBaseClasses =
+  "inline-flex h-7 items-center gap-1 rounded-md pl-2.5 text-xs font-medium ring-1 ring-inset transition-colors";
+const pillInactiveClasses =
+  "text-slate-600 ring-slate-300 hover:bg-white dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-900";
+const pillActiveClasses =
+  "bg-indigo-50 text-indigo-600 ring-indigo-600/30 dark:bg-indigo-400/10 dark:text-indigo-400 dark:ring-indigo-400/30";
+
 function FilterPill({
   label,
   active,
@@ -58,16 +70,12 @@ function FilterPill({
   onClear: () => void;
   testId: string;
 }) {
-  const baseClasses =
-    "inline-flex h-7 items-center gap-1 rounded-md pl-2.5 text-xs font-medium ring-1 ring-inset transition-colors";
-  const inactiveClasses =
-    "pr-2 text-slate-600 ring-slate-300 hover:bg-white dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-900";
-  const activeClasses =
-    "pr-1.5 bg-indigo-50 text-indigo-600 ring-indigo-600/30 dark:bg-indigo-400/10 dark:text-indigo-400 dark:ring-indigo-400/30";
   return (
     <PopoverButton
       data-testid={testId}
-      className={`${baseClasses} ${active ? activeClasses : inactiveClasses}`}
+      className={`${pillBaseClasses} ${
+        active ? `pr-1.5 ${pillActiveClasses}` : `pr-2 ${pillInactiveClasses}`
+      }`}
     >
       {label}
       {active ? (
@@ -299,6 +307,22 @@ function RequestFilterBar({
           </div>
         </PopoverPanel>
       </Popover>
+
+      <Tooltip position="bottom" content="Show only pending requests">
+        <button
+          type="button"
+          data-testid="filter-pending"
+          onClick={() =>
+            onChange({ ...filters, onlyPending: !filters.onlyPending })
+          }
+          className={`${pillBaseClasses} pr-2.5 ${
+            filters.onlyPending ? pillActiveClasses : pillInactiveClasses
+          }`}
+        >
+          <ClockIcon className="h-3.5 w-3.5" />
+          Pending
+        </button>
+      </Tooltip>
 
       {hasActiveFilters(filters) && (
         <button

--- a/frontend/src/routes/Requests.test.ts
+++ b/frontend/src/routes/Requests.test.ts
@@ -1,0 +1,207 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, MockedFunction } from "vitest";
+import { useRequests } from "./Requests";
+import {
+  ExecutionRequestResponse,
+  getRequestsPaginated,
+} from "../api/ExecutionRequestApi";
+import { RequestListFilters, emptyFilters } from "./RequestFilters";
+
+vi.mock("../api/ExecutionRequestApi");
+
+vi.mock("../hooks/useNotification", () => ({
+  default: () => ({
+    addNotification: vi.fn(),
+  }),
+}));
+
+const mockGetRequestsPaginated = getRequestsPaginated as MockedFunction<
+  typeof getRequestsPaginated
+>;
+
+type ListResult = Awaited<ReturnType<typeof getRequestsPaginated>>;
+
+const makeRequest = (id: string, title: string): ExecutionRequestResponse =>
+  ({
+    id,
+    title,
+    description: "",
+    type: "SingleExecution",
+    reviewStatus: "AWAITING_APPROVAL",
+    executionStatus: "EXECUTABLE",
+    author: { id: "author-1", email: "author@example.com", fullName: "Author" },
+    connection: { id: "conn-1", displayName: "Test Connection" },
+    createdAt: "2026-08-01T12:00:00",
+    _type: "DATASOURCE",
+  }) as unknown as ExecutionRequestResponse;
+
+const listResponse = (
+  requests: ExecutionRequestResponse[],
+  hasMore = false,
+  cursor: Date | null = null,
+): ListResult => ({ requests, hasMore, cursor }) as ListResult;
+
+describe("useRequests hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRequestsPaginated.mockResolvedValue(listResponse([]));
+  });
+
+  describe("stale response guard", () => {
+    it("ignores an earlier fetch that resolves after a newer one", async () => {
+      let resolveFirst!: (value: ListResult) => void;
+      let resolveSecond!: (value: ListResult) => void;
+      mockGetRequestsPaginated
+        .mockReturnValueOnce(
+          new Promise<ListResult>((resolve) => {
+            resolveFirst = resolve;
+          }),
+        )
+        .mockReturnValueOnce(
+          new Promise<ListResult>((resolve) => {
+            resolveSecond = resolve;
+          }),
+        );
+
+      const { result, rerender } = renderHook(
+        ({ filters }: { filters: RequestListFilters }) =>
+          useRequests(filters, ""),
+        { initialProps: { filters: emptyFilters } },
+      );
+
+      // A filter change fires a second fetch while the first is in flight
+      rerender({ filters: { ...emptyFilters, authorId: "author-1" } });
+      await waitFor(() =>
+        expect(mockGetRequestsPaginated).toHaveBeenCalledTimes(2),
+      );
+
+      // The newer (filtered) response arrives first
+      await act(async () => {
+        resolveSecond(listResponse([makeRequest("2", "Filtered result")]));
+      });
+      // The stale (unfiltered) response arrives last and must be dropped
+      await act(async () => {
+        resolveFirst(listResponse([makeRequest("1", "Stale result")]));
+      });
+
+      expect(result.current.requests).toHaveLength(1);
+      expect(result.current.requests[0].title).toBe("Filtered result");
+    });
+  });
+
+  describe("filter to request param mapping", () => {
+    const lastCallParams = () =>
+      mockGetRequestsPaginated.mock.calls[
+        mockGetRequestsPaginated.mock.calls.length - 1
+      ][0];
+
+    it("sends no filter params for empty filters", async () => {
+      renderHook(() => useRequests(emptyFilters, ""));
+      await waitFor(() => expect(mockGetRequestsPaginated).toHaveBeenCalled());
+
+      expect(lastCallParams()).toEqual({
+        reviewStatuses: undefined,
+        executionStatuses: undefined,
+        connectionIds: undefined,
+        authorId: undefined,
+        createdAfter: undefined,
+        createdBefore: undefined,
+        after: undefined,
+        limit: 20,
+      });
+    });
+
+    it("maps onlyPending to the pending status sets", async () => {
+      const filters = { ...emptyFilters, onlyPending: true };
+      renderHook(() => useRequests(filters, ""));
+      await waitFor(() => expect(mockGetRequestsPaginated).toHaveBeenCalled());
+
+      expect(lastCallParams()).toMatchObject({
+        reviewStatuses: ["AWAITING_APPROVAL"],
+        executionStatuses: ["EXECUTABLE", "ACTIVE"],
+      });
+    });
+
+    it("passes selected connection ids and author id", async () => {
+      const filters = {
+        ...emptyFilters,
+        connectionIds: ["conn-a", "conn-b"],
+        authorId: "user-1",
+      };
+      renderHook(() => useRequests(filters, ""));
+      await waitFor(() => expect(mockGetRequestsPaginated).toHaveBeenCalled());
+
+      expect(lastCallParams()).toMatchObject({
+        connectionIds: ["conn-a", "conn-b"],
+        authorId: "user-1",
+      });
+    });
+
+    it("expands the date range to full local days", async () => {
+      const filters = {
+        ...emptyFilters,
+        createdFrom: "2026-08-01",
+        createdTo: "2026-08-19",
+      };
+      renderHook(() => useRequests(filters, ""));
+      await waitFor(() => expect(mockGetRequestsPaginated).toHaveBeenCalled());
+
+      expect(lastCallParams()).toMatchObject({
+        createdAfter: new Date("2026-08-01T00:00:00"),
+        createdBefore: new Date("2026-08-19T23:59:59.999"),
+      });
+    });
+
+    it("resets the list and cursor when filters change", async () => {
+      const cursor = new Date("2026-08-10T00:00:00");
+      mockGetRequestsPaginated
+        .mockResolvedValueOnce(
+          listResponse([makeRequest("1", "First page")], true, cursor),
+        )
+        .mockResolvedValueOnce(listResponse([makeRequest("2", "Filtered")]));
+
+      const { result, rerender } = renderHook(
+        ({ filters }: { filters: RequestListFilters }) =>
+          useRequests(filters, ""),
+        { initialProps: { filters: emptyFilters } },
+      );
+      await waitFor(() => expect(result.current.requests).toHaveLength(1));
+
+      rerender({ filters: { ...emptyFilters, authorId: "user-1" } });
+      await waitFor(() =>
+        expect(result.current.requests[0]?.title).toBe("Filtered"),
+      );
+
+      // Replaced, not appended, and fetched from the start again
+      expect(result.current.requests).toHaveLength(1);
+      expect(lastCallParams()).toMatchObject({ after: undefined });
+    });
+
+    it("passes the cursor when loading more and appends the results", async () => {
+      const cursor = new Date("2026-08-10T00:00:00");
+      mockGetRequestsPaginated
+        .mockResolvedValueOnce(
+          listResponse([makeRequest("1", "First page")], true, cursor),
+        )
+        .mockResolvedValueOnce(
+          listResponse([makeRequest("2", "Second page")], false, null),
+        );
+
+      const { result } = renderHook(() => useRequests(emptyFilters, ""));
+      await waitFor(() => expect(result.current.requests).toHaveLength(1));
+      expect(result.current.hasMore).toBe(true);
+
+      act(() => {
+        result.current.loadMore();
+      });
+      await waitFor(() => expect(result.current.requests).toHaveLength(2));
+
+      expect(lastCallParams()).toMatchObject({ after: cursor });
+      expect(result.current.requests.map((r) => r.title)).toEqual([
+        "First page",
+        "Second page",
+      ]);
+      expect(result.current.hasMore).toBe(false);
+    });
+  });
+});

--- a/frontend/src/routes/Requests.test.ts
+++ b/frontend/src/routes/Requests.test.ts
@@ -78,10 +78,12 @@ describe("useRequests hook", () => {
       // The newer (filtered) response arrives first
       await act(async () => {
         resolveSecond(listResponse([makeRequest("2", "Filtered result")]));
+        await Promise.resolve();
       });
       // The stale (unfiltered) response arrives last and must be dropped
       await act(async () => {
         resolveFirst(listResponse([makeRequest("1", "Stale result")]));
+        await Promise.resolve();
       });
 
       expect(result.current.requests).toHaveLength(1);

--- a/frontend/src/routes/Requests.tsx
+++ b/frontend/src/routes/Requests.tsx
@@ -15,7 +15,6 @@ import Spinner from "../components/Spinner";
 import InitialBubble from "../components/InitialBubble";
 import {
   CircleStackIcon,
-  ClockIcon,
   CloudIcon,
   EyeIcon,
   PlayIcon,
@@ -23,9 +22,7 @@ import {
 import { UserStatusContext } from "../components/UserStatusProvider";
 import { isApiErrorResponse } from "../api/Errors";
 import useNotification from "../hooks/useNotification";
-import Toggle from "../components/Toggle";
 import SearchInput from "../components/SearchInput";
-import Tooltip from "../components/Tooltip";
 import {
   RequestFilterBar,
   RequestListFilters,
@@ -129,11 +126,7 @@ function shortTypeLabel(type: string) {
   }
 }
 
-const useRequests = (
-  onlyPending: boolean,
-  filters: RequestListFilters,
-  searchTerm: string,
-) => {
+const useRequests = (filters: RequestListFilters, searchTerm: string) => {
   const [requests, setRequests] = useState<ExecutionRequestResponse[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [loadingMore, setLoadingMore] = useState<boolean>(false);
@@ -153,8 +146,10 @@ const useRequests = (
       }
 
       const response = await getRequestsPaginated({
-        reviewStatuses: onlyPending ? ["AWAITING_APPROVAL"] : undefined,
-        executionStatuses: onlyPending ? ["EXECUTABLE", "ACTIVE"] : undefined,
+        reviewStatuses: filters.onlyPending ? ["AWAITING_APPROVAL"] : undefined,
+        executionStatuses: filters.onlyPending
+          ? ["EXECUTABLE", "ACTIVE"]
+          : undefined,
         connectionIds:
           filters.connectionIds.length > 0 ? filters.connectionIds : undefined,
         authorId: filters.authorId ?? undefined,
@@ -188,12 +183,12 @@ const useRequests = (
       setLoading(false);
       setLoadingMore(false);
     },
-    [onlyPending, filters, cursor, addNotification],
+    [filters, cursor, addNotification],
   );
 
   useEffect(() => {
     void loadRequests(true);
-  }, [onlyPending, filters]);
+  }, [filters]);
 
   const loadMore = useCallback(() => {
     if (!loadingMore && hasMore) {
@@ -229,11 +224,9 @@ const useRequests = (
 };
 
 function Requests() {
-  const [onlyPending, setOnlyPending] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [filters, setFilters] = useState<RequestListFilters>(emptyFilters);
   const { requests, loading, loadingMore, hasMore, loadMore } = useRequests(
-    onlyPending,
     filters,
     searchTerm,
   );
@@ -266,30 +259,20 @@ function Requests() {
   return (
     <div className="h-full">
       <div className="border-b border-slate-300 bg-slate-50 dark:border-slate-700 dark:bg-slate-950">
-        <div className="mx-auto flex max-w-3xl flex-col gap-3 px-4 pt-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="mx-auto max-w-3xl px-4 pb-3 pt-4">
           <h1 className="text-xl font-medium">Requests</h1>
-          <div className="flex items-center gap-3">
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <RequestFilterBar filters={filters} onChange={setFilters} />
             <SearchInput
+              compact
               value={searchTerm}
               onChange={(e: ChangeEvent<HTMLInputElement>) =>
                 setSearchTerm(e.target.value)
               }
               placeholder="Search requests..."
-              className="w-full sm:w-64"
+              className="sm:ml-auto sm:w-56"
             />
-            <Tooltip position="bottom" content="Show only pending requests">
-              <div className="flex shrink-0 items-center">
-                <ClockIcon className="mr-2 h-5 w-5 text-slate-400" />
-                <Toggle
-                  active={onlyPending}
-                  onClick={() => setOnlyPending(!onlyPending)}
-                />
-              </div>
-            </Tooltip>
           </div>
-        </div>
-        <div className="mx-auto max-w-3xl px-4 pb-3 pt-3 sm:pt-2">
-          <RequestFilterBar filters={filters} onChange={setFilters} />
         </div>
       </div>
       {(loading && <Spinner size="lg" page />) || (

--- a/frontend/src/routes/Requests.tsx
+++ b/frontend/src/routes/Requests.tsx
@@ -26,6 +26,12 @@ import useNotification from "../hooks/useNotification";
 import Toggle from "../components/Toggle";
 import SearchInput from "../components/SearchInput";
 import Tooltip from "../components/Tooltip";
+import {
+  RequestFilterBar,
+  RequestListFilters,
+  emptyFilters,
+  hasActiveFilters,
+} from "./RequestFilters";
 
 function timeSince(date: Date) {
   const seconds = Math.floor((new Date().getTime() - date.getTime()) / 1000);
@@ -123,7 +129,11 @@ function shortTypeLabel(type: string) {
   }
 }
 
-const useRequests = (onlyPending: boolean, searchTerm: string) => {
+const useRequests = (
+  onlyPending: boolean,
+  filters: RequestListFilters,
+  searchTerm: string,
+) => {
   const [requests, setRequests] = useState<ExecutionRequestResponse[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [loadingMore, setLoadingMore] = useState<boolean>(false);
@@ -145,6 +155,16 @@ const useRequests = (onlyPending: boolean, searchTerm: string) => {
       const response = await getRequestsPaginated({
         reviewStatuses: onlyPending ? ["AWAITING_APPROVAL"] : undefined,
         executionStatuses: onlyPending ? ["EXECUTABLE", "ACTIVE"] : undefined,
+        connectionIds:
+          filters.connectionIds.length > 0 ? filters.connectionIds : undefined,
+        authorId: filters.authorId ?? undefined,
+        // The picker yields local calendar days; send the full day in local time.
+        createdAfter: filters.createdFrom
+          ? new Date(`${filters.createdFrom}T00:00:00`)
+          : undefined,
+        createdBefore: filters.createdTo
+          ? new Date(`${filters.createdTo}T23:59:59.999`)
+          : undefined,
         after: reset ? undefined : cursor ?? undefined,
         limit: 20,
       });
@@ -168,12 +188,12 @@ const useRequests = (onlyPending: boolean, searchTerm: string) => {
       setLoading(false);
       setLoadingMore(false);
     },
-    [onlyPending, cursor, addNotification],
+    [onlyPending, filters, cursor, addNotification],
   );
 
   useEffect(() => {
     void loadRequests(true);
-  }, [onlyPending]);
+  }, [onlyPending, filters]);
 
   const loadMore = useCallback(() => {
     if (!loadingMore && hasMore) {
@@ -211,8 +231,10 @@ const useRequests = (onlyPending: boolean, searchTerm: string) => {
 function Requests() {
   const [onlyPending, setOnlyPending] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
+  const [filters, setFilters] = useState<RequestListFilters>(emptyFilters);
   const { requests, loading, loadingMore, hasMore, loadMore } = useRequests(
     onlyPending,
+    filters,
     searchTerm,
   );
   const observerTarget = useRef<HTMLDivElement>(null);
@@ -244,8 +266,8 @@ function Requests() {
   return (
     <div className="h-full">
       <div className="border-b border-slate-300 bg-slate-50 dark:border-slate-700 dark:bg-slate-950">
-        <div className="mx-auto flex max-w-3xl flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <h1 className="text-xl font-medium">Open Requests</h1>
+        <div className="mx-auto flex max-w-3xl flex-col gap-3 px-4 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <h1 className="text-xl font-medium">Requests</h1>
           <div className="flex items-center gap-3">
             <SearchInput
               value={searchTerm}
@@ -266,6 +288,9 @@ function Requests() {
             </Tooltip>
           </div>
         </div>
+        <div className="mx-auto max-w-3xl px-4 pb-3 pt-3 sm:pt-2">
+          <RequestFilterBar filters={filters} onChange={setFilters} />
+        </div>
       </div>
       {(loading && <Spinner size="lg" page />) || (
         <div
@@ -274,8 +299,24 @@ function Requests() {
         >
           <div className="mx-auto max-w-3xl px-4 pt-2">
             {requests.length === 0 && (
-              <div className="mx-2 my-4 px-4 py-2">
-                <h2 className="text-center text-lg">No open requests</h2>
+              <div className="mx-2 my-4 flex flex-col items-center gap-2 px-4 py-2">
+                <h2 className="text-center text-lg">
+                  {hasActiveFilters(filters) || searchTerm
+                    ? "No requests match your filters"
+                    : "No requests"}
+                </h2>
+                {(hasActiveFilters(filters) || searchTerm) && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setFilters(emptyFilters);
+                      setSearchTerm("");
+                    }}
+                    className="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+                  >
+                    Clear filters
+                  </button>
+                )}
               </div>
             )}
             {requests.map((request) => {

--- a/frontend/src/routes/Requests.tsx
+++ b/frontend/src/routes/Requests.tsx
@@ -135,8 +135,14 @@ const useRequests = (filters: RequestListFilters, searchTerm: string) => {
 
   const { addNotification } = useNotification();
 
+  // Filter changes fire a fetch per change and responses can come back out of
+  // order; only the latest fetch may write, or a stale response overwrites the
+  // correctly filtered list.
+  const fetchSeq = useRef(0);
+
   const loadRequests = useCallback(
     async (reset: boolean = false) => {
+      const seq = ++fetchSeq.current;
       if (reset) {
         setLoading(true);
         setRequests([]);
@@ -163,6 +169,10 @@ const useRequests = (filters: RequestListFilters, searchTerm: string) => {
         after: reset ? undefined : cursor ?? undefined,
         limit: 20,
       });
+
+      if (seq !== fetchSeq.current) {
+        return;
+      }
 
       if (isApiErrorResponse(response)) {
         addNotification({
@@ -259,167 +269,168 @@ function Requests() {
   return (
     <div className="h-full">
       <div className="border-b border-slate-300 bg-slate-50 dark:border-slate-700 dark:bg-slate-950">
-        <div className="mx-auto max-w-3xl px-4 pb-3 pt-4">
+        <div className="mx-auto max-w-3xl px-4 py-4">
           <h1 className="text-xl font-medium">Requests</h1>
-          <div className="mt-3 flex flex-wrap items-center gap-2">
-            <RequestFilterBar filters={filters} onChange={setFilters} />
-            <SearchInput
-              compact
-              value={searchTerm}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                setSearchTerm(e.target.value)
-              }
-              placeholder="Search requests..."
-              className="sm:ml-auto sm:w-56"
-            />
-          </div>
         </div>
       </div>
-      {(loading && <Spinner size="lg" page />) || (
-        <div
-          className="h-full bg-slate-50 dark:bg-slate-950"
-          data-testid="requests-list"
-        >
-          <div className="mx-auto max-w-3xl px-4 pt-2">
-            {requests.length === 0 && (
-              <div className="mx-2 my-4 flex flex-col items-center gap-2 px-4 py-2">
-                <h2 className="text-center text-lg">
-                  {hasActiveFilters(filters) || searchTerm
-                    ? "No requests match your filters"
-                    : "No requests"}
-                </h2>
-                {(hasActiveFilters(filters) || searchTerm) && (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setFilters(emptyFilters);
-                      setSearchTerm("");
-                    }}
-                    className="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
-                  >
-                    Clear filters
-                  </button>
-                )}
-              </div>
-            )}
-            {requests.map((request) => {
-              const status = mapStatus(
-                request.reviewStatus,
-                request.executionStatus,
-              );
-              const isAuthor =
-                userStatus !== false && userStatus?.id === request.author.id;
-              const canOpenSession =
-                request.type === "TemporaryAccess" &&
-                (status === "Ready" || status === "Active") &&
-                isAuthor;
-              // Non-authors can only spectate, so link them in once the
-              // session is actually running
-              const canWatchSession =
-                request.type === "TemporaryAccess" &&
-                status === "Active" &&
-                !isAuthor;
-              return (
-                <Link
-                  key={request.id}
-                  to={`/requests/${request.id}`}
-                  data-testid={`request-link-${request.title}`}
-                >
-                  <div
-                    className={`my-2 rounded-lg border border-l-4 border-slate-200 bg-white px-4 py-3 shadow-sm transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:shadow-none dark:hover:bg-slate-800 ${mapStatusToBorderColor(
-                      status,
-                    )}`}
+      <div className="h-full bg-slate-50 dark:bg-slate-950">
+        <div className="mx-auto flex max-w-3xl flex-wrap items-center gap-2 px-4 pt-4">
+          <RequestFilterBar filters={filters} onChange={setFilters} />
+          <SearchInput
+            compact
+            value={searchTerm}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setSearchTerm(e.target.value)
+            }
+            placeholder="Search requests..."
+            className="sm:ml-auto sm:w-56"
+          />
+        </div>
+        {(loading && <Spinner size="lg" page />) || (
+          <div data-testid="requests-list">
+            <div className="mx-auto max-w-3xl px-4 pt-2">
+              {requests.length === 0 && (
+                <div className="mx-2 my-4 flex flex-col items-center gap-2 px-4 py-2">
+                  <h2 className="text-center text-lg">
+                    {hasActiveFilters(filters) || searchTerm
+                      ? "No requests match your filters"
+                      : "No requests"}
+                  </h2>
+                  {(hasActiveFilters(filters) || searchTerm) && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setFilters(emptyFilters);
+                        setSearchTerm("");
+                      }}
+                      className="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+                    >
+                      Clear filters
+                    </button>
+                  )}
+                </div>
+              )}
+              {requests.map((request) => {
+                const status = mapStatus(
+                  request.reviewStatus,
+                  request.executionStatus,
+                );
+                const isAuthor =
+                  userStatus !== false && userStatus?.id === request.author.id;
+                const canOpenSession =
+                  request.type === "TemporaryAccess" &&
+                  (status === "Ready" || status === "Active") &&
+                  isAuthor;
+                // Non-authors can only spectate, so link them in once the
+                // session is actually running
+                const canWatchSession =
+                  request.type === "TemporaryAccess" &&
+                  status === "Active" &&
+                  !isAuthor;
+                return (
+                  <Link
                     key={request.id}
+                    to={`/requests/${request.id}`}
+                    data-testid={`request-link-${request.title}`}
                   >
-                    <div className="flex items-start gap-3">
-                      <InitialBubble
-                        name={request.author.fullName || request.author.email}
-                        className="h-9 w-9 shrink-0"
-                      />
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-start justify-between gap-2">
-                          <h2 className="truncate text-sm font-medium">
-                            {request.title}
-                          </h2>
-                          <span
-                            className="shrink-0 text-xs text-slate-400 dark:text-slate-500"
-                            title={new Date(request.createdAt).toLocaleString()}
-                          >
-                            {timeSince(new Date(request.createdAt))}
-                          </span>
-                        </div>
-                        <p className="mt-0.5 flex flex-wrap items-center gap-1 text-sm text-slate-500 dark:text-slate-400">
-                          <span className="truncate font-medium text-slate-600 dark:text-slate-300">
-                            {request.author.fullName || request.author.email}
-                          </span>
-                          <span className="shrink-0">→</span>
-                          <span className="inline-flex items-center gap-1 font-medium text-slate-600 dark:text-slate-300">
-                            {request._type === "DATASOURCE" ? (
-                              <CircleStackIcon className="h-3.5 w-3.5 text-slate-400 dark:text-slate-500" />
-                            ) : (
-                              <CloudIcon className="h-3.5 w-3.5 text-slate-400 dark:text-slate-500" />
-                            )}
-                            {request.connection.displayName}
-                          </span>
-                        </p>
-                        {request.description && (
-                          <p className="mt-0.5 line-clamp-1 text-sm text-slate-500 dark:text-slate-400">
-                            {request.description}
-                          </p>
-                        )}
-                        <div className="mt-1.5 flex items-center justify-between gap-2">
-                          <p className="text-xs text-slate-400 dark:text-slate-500">
-                            <span>{shortTypeLabel(request.type)}</span>
-                            <span className="mx-1.5">·</span>
-                            <span className={mapStatusToTextColor(status)}>
-                              {status}
+                    <div
+                      className={`my-2 rounded-lg border border-l-4 border-slate-200 bg-white px-4 py-3 shadow-sm transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:shadow-none dark:hover:bg-slate-800 ${mapStatusToBorderColor(
+                        status,
+                      )}`}
+                      key={request.id}
+                    >
+                      <div className="flex items-start gap-3">
+                        <InitialBubble
+                          name={request.author.fullName || request.author.email}
+                          className="h-9 w-9 shrink-0"
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-start justify-between gap-2">
+                            <h2 className="truncate text-sm font-medium">
+                              {request.title}
+                            </h2>
+                            <span
+                              className="shrink-0 text-xs text-slate-400 dark:text-slate-500"
+                              title={new Date(
+                                request.createdAt,
+                              ).toLocaleString()}
+                            >
+                              {timeSince(new Date(request.createdAt))}
+                            </span>
+                          </div>
+                          <p className="mt-0.5 flex flex-wrap items-center gap-1 text-sm text-slate-500 dark:text-slate-400">
+                            <span className="truncate font-medium text-slate-600 dark:text-slate-300">
+                              {request.author.fullName || request.author.email}
+                            </span>
+                            <span className="shrink-0">→</span>
+                            <span className="inline-flex items-center gap-1 font-medium text-slate-600 dark:text-slate-300">
+                              {request._type === "DATASOURCE" ? (
+                                <CircleStackIcon className="h-3.5 w-3.5 text-slate-400 dark:text-slate-500" />
+                              ) : (
+                                <CloudIcon className="h-3.5 w-3.5 text-slate-400 dark:text-slate-500" />
+                              )}
+                              {request.connection.displayName}
                             </span>
                           </p>
-                          {(canOpenSession || canWatchSession) && (
-                            <button
-                              type="button"
-                              data-testid={`${
-                                canOpenSession ? "open" : "watch"
-                              }-session-${request.title}`}
-                              className="inline-flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-indigo-600 ring-1 ring-inset ring-indigo-600/30 transition-colors hover:bg-indigo-50 dark:text-indigo-400 dark:ring-indigo-400/30 dark:hover:bg-indigo-400/10"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                void navigate(
-                                  `/requests/${request.id}/session`,
-                                );
-                              }}
-                            >
-                              {canOpenSession ? (
-                                <PlayIcon className="h-3.5 w-3.5" />
-                              ) : (
-                                <EyeIcon className="h-3.5 w-3.5" />
-                              )}
-                              {canOpenSession
-                                ? "Open session"
-                                : "Watch session"}
-                            </button>
+                          {request.description && (
+                            <p className="mt-0.5 line-clamp-1 text-sm text-slate-500 dark:text-slate-400">
+                              {request.description}
+                            </p>
                           )}
+                          <div className="mt-1.5 flex items-center justify-between gap-2">
+                            <p className="text-xs text-slate-400 dark:text-slate-500">
+                              <span>{shortTypeLabel(request.type)}</span>
+                              <span className="mx-1.5">·</span>
+                              <span className={mapStatusToTextColor(status)}>
+                                {status}
+                              </span>
+                            </p>
+                            {(canOpenSession || canWatchSession) && (
+                              <button
+                                type="button"
+                                data-testid={`${
+                                  canOpenSession ? "open" : "watch"
+                                }-session-${request.title}`}
+                                className="inline-flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-indigo-600 ring-1 ring-inset ring-indigo-600/30 transition-colors hover:bg-indigo-50 dark:text-indigo-400 dark:ring-indigo-400/30 dark:hover:bg-indigo-400/10"
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  void navigate(
+                                    `/requests/${request.id}/session`,
+                                  );
+                                }}
+                              >
+                                {canOpenSession ? (
+                                  <PlayIcon className="h-3.5 w-3.5" />
+                                ) : (
+                                  <EyeIcon className="h-3.5 w-3.5" />
+                                )}
+                                {canOpenSession
+                                  ? "Open session"
+                                  : "Watch session"}
+                              </button>
+                            )}
+                          </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                </Link>
-              );
-            })}
+                  </Link>
+                );
+              })}
 
-            {/* Infinite scroll trigger */}
-            {hasMore && <div ref={observerTarget} className="h-10" />}
+              {/* Infinite scroll trigger */}
+              {hasMore && <div ref={observerTarget} className="h-10" />}
 
-            {/* Loading more indicator */}
-            {loadingMore && (
-              <div className="my-4 flex justify-center">
-                <Spinner size="sm" />
-              </div>
-            )}
+              {/* Loading more indicator */}
+              {loadingMore && (
+                <div className="my-4 flex justify-center">
+                  <Spinner size="sm" />
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/routes/Requests.tsx
+++ b/frontend/src/routes/Requests.tsx
@@ -435,4 +435,4 @@ function Requests() {
   );
 }
 
-export { Requests, mapStatusToLabelColor, mapStatus, timeSince };
+export { Requests, mapStatusToLabelColor, mapStatus, timeSince, useRequests };


### PR DESCRIPTION
Renames the page title from "Open Requests" to "Requests" and adds server-side filtering to the requests list:

- **Connection**: multi-select filter. The backend `connectionId` query param is replaced by a repeatable `connectionIds` param.
- **Author**: filter by your own requests or any specific user. The user list is permission-gated; without it the filter still offers "Your requests".
- **Created date range**: inclusive `createdAfter`/`createdBefore` params, picked as calendar days in the UI.

Filters render as pills under the page title, show their active value, can be cleared individually or all at once, and combine with the existing pending toggle and client-side search. The filtered empty state offers a clear action.