### PR TITLE
Re-enable the Postgres proxy test suites

### DIFF
--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyAuthTest.kt
@@ -13,7 +13,6 @@ import dev.kviklet.kviklet.service.dto.AuthenticationDetails
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -30,7 +29,6 @@ import java.util.concurrent.CompletableFuture
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Disabled()
 class PostgresProxyAuthTest {
     @Autowired
     lateinit var executionRequestAdapter: ExecutionRequestAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyQueriesSmokeTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyQueriesSmokeTest.kt
@@ -8,7 +8,6 @@ import dev.kviklet.kviklet.proxy.helpers.proxyServerFactory
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -18,7 +17,6 @@ import java.sql.Connection
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Disabled()
 class PostgresProxyQueriesSmokeTest {
     @Autowired
     lateinit var executionRequestAdapter: ExecutionRequestAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyTLSTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyTLSTest.kt
@@ -9,7 +9,6 @@ import dev.kviklet.kviklet.proxy.postgres.TLSCertificate
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.beans.factory.annotation.Autowired
@@ -22,7 +21,6 @@ import java.util.*
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Disabled()
 class PostgresProxyTLSTest {
     @Autowired
     lateinit var executionRequestAdapter: ExecutionRequestAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/TLSCertificateTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/TLSCertificateTest.kt
@@ -4,14 +4,12 @@ import dev.kviklet.kviklet.proxy.postgres.TLSCertificate
 import dev.kviklet.kviklet.proxy.postgres.TlsCertEnvConfig
 import dev.kviklet.kviklet.proxy.postgres.preprocessPEMObject
 import dev.kviklet.kviklet.proxy.postgres.tlsCertificateFactory
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.File
 import java.io.FileOutputStream
 import java.nio.file.Files
 
-@Disabled()
 class TLSCertificateTest {
     private var testCert: String = """
 -----BEGIN CERTIFICATE-----

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/TemplatePostgresProxyTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/TemplatePostgresProxyTest.kt
@@ -7,7 +7,6 @@ import dev.kviklet.kviklet.proxy.helpers.directConnectionFactory
 import dev.kviklet.kviklet.proxy.helpers.proxyServerFactory
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -17,7 +16,6 @@ import java.sql.Connection
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Disabled()
 class TemplatePostgresProxyTest {
     @Autowired
     lateinit var executionRequestAdapter: ExecutionRequestAdapter


### PR DESCRIPTION
Removes the bare `@Disabled()` annotations from the five Postgres proxy test classes (`PostgresProxyQueriesSmokeTest`, `PostgresProxyAuthTest`, `PostgresProxyTLSTest`, `TLSCertificateTest`, `TemplatePostgresProxyTest`) so the suite runs in CI again. Until now only `PostgresProxyErrorHandlingTest` and `GetShutdownDateTest` were active.

This is groundwork for the Postgres proxy cleanup — none of the upcoming fixes are verifiable without a running suite.