### PR TITLE
Audit simple-protocol queries in the Postgres proxy and fail closed on unparseable messages

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/ClientConnectionSetup.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/ClientConnectionSetup.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.postgres
 
 import dev.kviklet.kviklet.proxy.postgres.messages.authenticationOk

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.postgres
 
 import dev.kviklet.kviklet.db.ExecutePayload
@@ -6,11 +7,15 @@ import dev.kviklet.kviklet.proxy.postgres.messages.ExecuteMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.MessageOrBytes
 import dev.kviklet.kviklet.proxy.postgres.messages.ParseMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.ParsedMessage
+import dev.kviklet.kviklet.proxy.postgres.messages.QueryMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.Statement
+import dev.kviklet.kviklet.proxy.postgres.messages.errorResponse
 import dev.kviklet.kviklet.proxy.postgres.messages.isTermination
+import dev.kviklet.kviklet.proxy.postgres.messages.readyForQuery
 import dev.kviklet.kviklet.proxy.postgres.messages.writableBytes
 import dev.kviklet.kviklet.service.EventService
 import dev.kviklet.kviklet.service.dto.ExecutionRequest
+import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
@@ -31,6 +36,11 @@ class Connection(
     private val boundStatements: MutableMap<String, Statement> = mutableMapOf()
     private var terminationMessageReceived: Boolean = false
     private var serverTerminating: Boolean = false
+    private var sessionAborted: Boolean = false
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(Connection::class.java)
+    }
 
     fun close() {
         this.serverTerminating = true
@@ -38,15 +48,36 @@ class Connection(
     fun startHandling() {
         // This basically transfers messages between the client and the server sockets.
         // NOTE: At this point the client connection is set up. SSL, Auth etc... are handled in ClientConnectionSetup.kt
-        while (!terminationMessageReceived && !serverTerminating) {
+        while (!terminationMessageReceived && !serverTerminating && !sessionAborted) {
             readFromAnyStream(clientInput) { handleClientData(it) }
             readFromAnyStream(serverInput) { clientOutput.writeAndFlush(it) }
         }
     }
 
     private fun handleClientData(clientBuffer: ByteArray) {
-        for (messageOrBytes in parseDataToMessages(clientBuffer.copyOf(clientBuffer.size))) {
-            terminationMessageReceived = messageOrBytes.isTermination()
+        // Fail closed: nothing is forwarded to the server unless the whole chunk was parsed
+        // and every message in it was audited successfully.
+        val messages = try {
+            parseDataToMessages(clientBuffer)
+        } catch (e: Exception) {
+            logger.warn("Failed to parse client message, blocking it and closing the session", e)
+            auditUnparseableMessage(clientBuffer)
+            abortSession(
+                "Kviklet proxy could not parse the client message. The message was blocked and the session closed.",
+            )
+            return
+        }
+        try {
+            messages.forEach { auditMessage(it) }
+        } catch (e: Exception) {
+            logger.error("Failed to audit query, blocking it and closing the session", e)
+            abortSession(
+                "Kviklet could not record the query in the audit log. The query was blocked and the session closed.",
+            )
+            return
+        }
+        for (messageOrBytes in messages) {
+            terminationMessageReceived = terminationMessageReceived || messageOrBytes.isTermination()
             serverOutput.writeAndFlush(messageOrBytes.writableBytes())
         }
     }
@@ -55,15 +86,48 @@ class Connection(
         val buffer = ByteBuffer.wrap(byteArray)
         val messages = mutableListOf<MessageOrBytes>()
         while (buffer.remaining() > 0) {
-            val parsedMessage = ParsedMessage.fromBytes(buffer)
-            when (parsedMessage) {
-                is ParseMessage -> handleParseMessage(parsedMessage)
-                is BindMessage -> handleBindMessage(parsedMessage)
-                is ExecuteMessage -> handleExecute(parsedMessage)
-            }
-            messages.add(MessageOrBytes(parsedMessage, null))
+            messages.add(MessageOrBytes(ParsedMessage.fromBytes(buffer), null))
         }
         return messages
+    }
+
+    private fun auditMessage(messageOrBytes: MessageOrBytes) {
+        when (val message = messageOrBytes.message) {
+            is QueryMessage -> handleQuery(message)
+            is ParseMessage -> handleParseMessage(message)
+            is BindMessage -> handleBindMessage(message)
+            is ExecuteMessage -> handleExecute(message)
+            else -> {}
+        }
+    }
+
+    private fun auditUnparseableMessage(clientBuffer: ByteArray) {
+        try {
+            val decodedContent = String(clientBuffer, Charsets.UTF_8)
+                .map { if (it.isISOControl()) ' ' else it }
+                .joinToString("")
+            val executePayload = ExecutePayload(
+                query = "Blocked an unparseable message with the following raw content: $decodedContent",
+            )
+            eventService.saveEvent(executionRequest.id!!, userId, executePayload)
+        } catch (e: Exception) {
+            logger.error("Failed to record the blocked unparseable message in the audit log", e)
+        }
+    }
+
+    private fun abortSession(reason: String) {
+        try {
+            clientOutput.writeAndFlush(errorResponse(reason))
+            clientOutput.writeAndFlush(readyForQuery())
+        } catch (e: Exception) {
+            logger.warn("Failed to send error response to the client while aborting the session", e)
+        }
+        sessionAborted = true
+    }
+
+    private fun handleQuery(parsedMessage: QueryMessage) {
+        val executePayload = ExecutePayload(query = parsedMessage.query)
+        eventService.saveEvent(executionRequest.id!!, userId, executePayload)
     }
 
     private fun handleExecute(parsedMessage: ExecuteMessage) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
@@ -55,28 +55,35 @@ class Connection(
     }
 
     private fun handleClientData(clientBuffer: ByteArray) {
-        // Fail closed: nothing is forwarded to the server unless the whole chunk was parsed
-        // and every message in it was audited successfully.
+        // Fail closed: nothing is forwarded to the server unless the whole chunk was parsed,
+        // and each message is audited immediately before it is forwarded, so the audit log
+        // only ever contains queries that were at least attempted.
         val messages = try {
             parseDataToMessages(clientBuffer)
         } catch (e: Exception) {
             logger.warn("Failed to parse client message, blocking it and closing the session", e)
-            auditUnparseableMessage(clientBuffer)
             abortSession(
                 "Kviklet proxy could not parse the client message. The message was blocked and the session closed.",
             )
             return
         }
-        try {
-            messages.forEach { auditMessage(it) }
-        } catch (e: Exception) {
-            logger.error("Failed to audit query, blocking it and closing the session", e)
-            abortSession(
-                "Kviklet could not record the query in the audit log. The query was blocked and the session closed.",
-            )
-            return
-        }
         for (messageOrBytes in messages) {
+            try {
+                auditMessage(messageOrBytes)
+            } catch (e: UnknownStatementException) {
+                logger.warn("Client referenced a statement unknown to the proxy, closing the session", e)
+                abortSession(
+                    "Kviklet proxy does not know the prepared statement '${e.statementName}' and cannot audit " +
+                        "this execution. The query was blocked and the session closed.",
+                )
+                return
+            } catch (e: Exception) {
+                logger.error("Failed to audit query, blocking it and closing the session", e)
+                abortSession(
+                    "Kviklet could not record the query in the audit log. The query was blocked and the session closed.",
+                )
+                return
+            }
             terminationMessageReceived = terminationMessageReceived || messageOrBytes.isTermination()
             serverOutput.writeAndFlush(messageOrBytes.writableBytes())
         }
@@ -101,20 +108,6 @@ class Connection(
         }
     }
 
-    private fun auditUnparseableMessage(clientBuffer: ByteArray) {
-        try {
-            val decodedContent = String(clientBuffer, Charsets.UTF_8)
-                .map { if (it.isISOControl()) ' ' else it }
-                .joinToString("")
-            val executePayload = ExecutePayload(
-                query = "Blocked an unparseable message with the following raw content: $decodedContent",
-            )
-            eventService.saveEvent(executionRequest.id!!, userId, executePayload)
-        } catch (e: Exception) {
-            logger.error("Failed to record the blocked unparseable message in the audit log", e)
-        }
-    }
-
     private fun abortSession(reason: String) {
         try {
             clientOutput.writeAndFlush(errorResponse(reason))
@@ -131,7 +124,8 @@ class Connection(
     }
 
     private fun handleExecute(parsedMessage: ExecuteMessage) {
-        val statement = boundStatements[parsedMessage.statementName]!!
+        val statement = boundStatements[parsedMessage.statementName]
+            ?: throw UnknownStatementException(parsedMessage.statementName)
         val executePayload = ExecutePayload(query = statement.interpolateQuery())
         eventService.saveEvent(executionRequest.id!!, userId, executePayload)
     }
@@ -144,7 +138,8 @@ class Connection(
     }
 
     private fun handleBindMessage(parsedMessage: BindMessage) {
-        val statement = boundStatements[parsedMessage.statementName]!!
+        val statement = boundStatements[parsedMessage.statementName]
+            ?: throw UnknownStatementException(parsedMessage.statementName)
         boundStatements[parsedMessage.statementName] =
             Statement(
                 statement.query,
@@ -154,6 +149,9 @@ class Connection(
             )
     }
 }
+
+private class UnknownStatementException(val statementName: String) :
+    Exception("Client referenced the statement '$statementName' which the proxy has not seen a Parse message for")
 
 // Because SSLSocket available method always return zero, the code counts on short read timeout hack
 // Originally this was the case only for the server connections, now it is the case for both the client and the server

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/OutputStreamExtension.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/OutputStreamExtension.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.postgres
 
 import java.io.OutputStream

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/PostgresProxy.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/PostgresProxy.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.postgres
 
 import dev.kviklet.kviklet.service.EventService

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/SASLAuth.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/SASLAuth.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.postgres
 
 import dev.kviklet.kviklet.proxy.postgres.messages.SASLInitialResponse

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/TLSCertificate.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/TLSCertificate.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.postgres
 
 import org.slf4j.LoggerFactory

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/TargetPostgresServer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/TargetPostgresServer.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.postgres
 
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/AuthMessages.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/AuthMessages.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.postgres.messages
 
 import java.nio.ByteBuffer

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.postgres.messages
 
 import java.nio.ByteBuffer
@@ -312,6 +313,23 @@ fun paramMessage(key: String, value: String): ByteArray {
     responseBuffer.put(0.toByte())
     responseBuffer.put(value.toByteArray())
     responseBuffer.put(0.toByte())
+    return responseBuffer.array()
+}
+
+fun errorResponse(message: String): ByteArray {
+    val fields = listOf(
+        'S' to "ERROR",
+        'V' to "ERROR",
+        'C' to "08P01", // protocol_violation
+        'M' to message,
+    )
+    val fieldBytes = fields.flatMap { (type, value) ->
+        listOf(type.code.toByte()) + value.toByteArray().toList() + listOf(0.toByte())
+    } + listOf(0.toByte())
+    val responseBuffer = ByteBuffer.allocate(5 + fieldBytes.size)
+    responseBuffer.put('E'.code.toByte())
+    responseBuffer.putInt(4 + fieldBytes.size)
+    responseBuffer.put(fieldBytes.toByteArray())
     return responseBuffer.array()
 }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/ParseMessage.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/ParseMessage.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.postgres.messages
 
 import java.nio.ByteBuffer

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/TlsMessages.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/TlsMessages.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.postgres.messages
 
 fun tlsNotSupportedMessage(): ByteArray = "N".toByteArray()

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyAuthTest.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy
 
 import dev.kviklet.kviklet.db.EventAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyErrorHandlingTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyErrorHandlingTest.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy
 
 import dev.kviklet.kviklet.db.EventAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyParseFailureTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyParseFailureTest.kt
@@ -74,8 +74,8 @@ class PostgresProxyParseFailureTest {
             }
             assertEquals(-1, forwarded)
 
-            // The blocked message must be noted in the events, including its raw content
-            assertTrue(eventService.queries.any { it.contains("droptablesecret") })
+            // The blocked message must not produce an audit event, only executed queries are audited
+            assertTrue(eventService.queries.isEmpty())
         } finally {
             clientSide.close()
             proxyClientSocket.close()

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyParseFailureTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyParseFailureTest.kt
@@ -1,0 +1,87 @@
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.db.EventAdapter
+import dev.kviklet.kviklet.db.ExecutionRequestAdapter
+import dev.kviklet.kviklet.helper.ExecutionRequestFactory
+import dev.kviklet.kviklet.proxy.mocks.EventServiceMock
+import dev.kviklet.kviklet.proxy.postgres.Connection
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketTimeoutException
+import java.nio.ByteBuffer
+import kotlin.concurrent.thread
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PostgresProxyParseFailureTest {
+    @Autowired
+    lateinit var executionRequestAdapter: ExecutionRequestAdapter
+
+    @Autowired
+    lateinit var eventAdapter: EventAdapter
+
+    @Test
+    fun `unparseable client messages are not forwarded, produce an error and are noted in the events`() {
+        val request = ExecutionRequestFactory().createDatasourceExecutionRequest()
+        val eventService = EventServiceMock(executionRequestAdapter, eventAdapter, request)
+
+        val upstreamListener = ServerSocket(0)
+        val clientListener = ServerSocket(0)
+        val clientSide = Socket("localhost", clientListener.localPort)
+        val proxyClientSocket = clientListener.accept()
+        val proxyTargetSocket = Socket("localhost", upstreamListener.localPort)
+        val upstreamSide = upstreamListener.accept()
+        // Same socket configuration the proxy applies after connection setup
+        proxyClientSocket.soTimeout = 10
+        proxyTargetSocket.soTimeout = 10
+
+        try {
+            val connection = Connection(proxyClientSocket, proxyTargetSocket, eventService, request, "mock")
+            val handler = thread { connection.startHandling() }
+
+            // A 'Q' message that declares a 500 byte body but delivers only a fraction of it
+            val queryBytes = "DROP TABLE secret".toByteArray()
+            val message = ByteBuffer.allocate(5 + queryBytes.size)
+            message.put('Q'.code.toByte())
+            message.putInt(500)
+            message.put(queryBytes)
+            clientSide.getOutputStream().write(message.array())
+            clientSide.getOutputStream().flush()
+
+            // The client must receive an ErrorResponse ('E'), not a dead socket
+            clientSide.soTimeout = 5000
+            val firstByte = clientSide.getInputStream().read()
+            assertEquals('E'.code, firstByte)
+
+            // The session must terminate
+            handler.join(5000)
+            assertFalse(handler.isAlive)
+
+            // Nothing must have been forwarded to the target database
+            upstreamSide.soTimeout = 500
+            val forwarded = try {
+                upstreamSide.getInputStream().read()
+            } catch (e: SocketTimeoutException) {
+                -1
+            }
+            assertEquals(-1, forwarded)
+
+            // The blocked message must be noted in the events, including its raw content
+            assertTrue(eventService.queries.any { it.contains("droptablesecret") })
+        } finally {
+            clientSide.close()
+            proxyClientSocket.close()
+            proxyTargetSocket.close()
+            upstreamSide.close()
+            upstreamListener.close()
+            clientListener.close()
+        }
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyParseFailureTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyParseFailureTest.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy
 
 import dev.kviklet.kviklet.db.EventAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyQueriesSmokeTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyQueriesSmokeTest.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy
 
 import dev.kviklet.kviklet.db.EventAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxySimpleProtocolTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxySimpleProtocolTest.kt
@@ -1,0 +1,153 @@
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.db.EventAdapter
+import dev.kviklet.kviklet.db.ExecutionRequestAdapter
+import dev.kviklet.kviklet.helper.ExecutionRequestFactory
+import dev.kviklet.kviklet.proxy.helpers.ProxyInstance
+import dev.kviklet.kviklet.proxy.helpers.directConnectionFactory
+import dev.kviklet.kviklet.proxy.helpers.proxyServerFactory
+import dev.kviklet.kviklet.proxy.mocks.FailingEventServiceMock
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.postgresql.PGConnection
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.containers.PostgreSQLContainer
+import java.io.StringReader
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.util.Properties
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PostgresProxySimpleProtocolTest {
+    @Autowired
+    lateinit var executionRequestAdapter: ExecutionRequestAdapter
+
+    @Autowired
+    lateinit var eventAdapter: EventAdapter
+    private lateinit var directConnection: Connection
+    private lateinit var proxy: ProxyInstance
+    private lateinit var postgresContainer: PostgreSQLContainer<Nothing>
+
+    @BeforeEach
+    fun setup() {
+        postgresContainer = PostgreSQLContainer<Nothing>("postgres:13").apply {
+            withDatabaseName("testdb")
+            withUsername("test")
+            withPassword("test")
+        }
+        postgresContainer.start()
+        while (!postgresContainer.isRunning) {
+            Thread.sleep(1000)
+        }
+        this.directConnection = directConnectionFactory(postgresContainer)
+        this.proxy = proxyServerFactory(postgresContainer, executionRequestAdapter, eventAdapter)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        this.proxy.proxy.shutdownServer()
+        this.proxy.connection.close()
+        this.postgresContainer.stop()
+    }
+
+    private fun simpleProtocolConnection(connectionString: String): Connection {
+        val props = Properties()
+        props.setProperty("user", "proxyUser")
+        props.setProperty("password", "proxyPassword")
+        props.setProperty("preferQueryMode", "simple")
+        return DriverManager.getConnection(connectionString, props)
+    }
+
+    @Test
+    fun `simple protocol queries are executed and audited`() {
+        val createTableQuery = "CREATE TABLE IF NOT EXISTS proxy_test_simple (id INTEGER,random VARCHAR(32));"
+        val insertQuery = "INSERT INTO proxy_test_simple(id, random) VALUES (1, 'test');"
+        val selectQuery = "SELECT * FROM proxy_test_simple;"
+        val connection = simpleProtocolConnection(this.proxy.connectionString)
+        connection.createStatement().executeUpdate(createTableQuery)
+        connection.createStatement().executeUpdate(insertQuery)
+        val result = connection.createStatement().executeQuery(selectQuery)
+        var rows = 0
+        while (result.next()) {
+            rows++
+            assertEquals(1, result.getInt("id"))
+            assertEquals("test", result.getString("random"))
+        }
+        assertEquals(1, rows)
+        connection.close()
+
+        this.proxy.eventService.assertQueryIsAudited(createTableQuery)
+        this.proxy.eventService.assertQueryIsAudited(insertQuery)
+        this.proxy.eventService.assertQueryIsAudited(selectQuery)
+    }
+
+    @Test
+    fun `multi statement simple protocol strings are audited in full`() {
+        val multiStatement = "CREATE TABLE proxy_test_multi (id INTEGER); INSERT INTO proxy_test_multi(id) VALUES (7);"
+        val connection = simpleProtocolConnection(this.proxy.connectionString)
+        connection.createStatement().execute(multiStatement)
+        connection.close()
+
+        val result = directConnection.createStatement().executeQuery("SELECT id FROM proxy_test_multi;")
+        assertTrue(result.next())
+        assertEquals(7, result.getInt("id"))
+
+        this.proxy.eventService.assertQueryIsAudited(multiStatement)
+    }
+
+    @Test
+    fun `COPY FROM STDIN command is audited`() {
+        directConnection.createStatement()
+            .executeUpdate("CREATE TABLE proxy_test_copy (id INTEGER,random VARCHAR(32));")
+        val copyCommand = "COPY proxy_test_copy FROM STDIN WITH (FORMAT csv)"
+        val copyManager = this.proxy.connection.unwrap(PGConnection::class.java).copyAPI
+        val rows = copyManager.copyIn(copyCommand, StringReader("1,test\n2,foo\n"))
+        assertEquals(2L, rows)
+
+        val result = directConnection.createStatement().executeQuery("SELECT count(*) AS cnt FROM proxy_test_copy;")
+        assertTrue(result.next())
+        assertEquals(2, result.getInt("cnt"))
+
+        this.proxy.eventService.assertQueryIsAudited(copyCommand)
+    }
+
+    @Test
+    fun `queries are blocked when the audit event cannot be saved`() {
+        val failingEventService = FailingEventServiceMock(
+            executionRequestAdapter,
+            eventAdapter,
+            ExecutionRequestFactory().createDatasourceExecutionRequest(),
+        )
+        val failingProxy = proxyServerFactory(
+            postgresContainer,
+            executionRequestAdapter,
+            eventAdapter,
+            eventServiceOverride = failingEventService,
+        )
+        try {
+            val connection = simpleProtocolConnection(failingProxy.connectionString)
+            failingEventService.failing = true
+            val exception = assertThrows<SQLException> {
+                connection.createStatement().executeUpdate("CREATE TABLE proxy_test_audit_fail (id INTEGER);")
+            }
+            assertTrue(exception.message!!.contains("audit", ignoreCase = true))
+
+            // The query must never have reached the target database
+            val result = directConnection.createStatement().executeQuery(
+                "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'proxy_test_audit_fail');",
+            )
+            assertTrue(result.next())
+            assertEquals("f", result.getString("exists"))
+        } finally {
+            failingProxy.proxy.shutdownServer()
+        }
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxySimpleProtocolTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxySimpleProtocolTest.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy
 
 import dev.kviklet.kviklet.db.EventAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyTLSTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyTLSTest.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy
 
 import dev.kviklet.kviklet.db.EventAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/TLSCertificateTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/TLSCertificateTest.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy
 
 import dev.kviklet.kviklet.proxy.postgres.TLSCertificate

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/TemplatePostgresProxyTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/TemplatePostgresProxyTest.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy
 
 import dev.kviklet.kviklet.db.EventAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/PgFactories.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/PgFactories.kt
@@ -36,11 +36,12 @@ fun proxyServerFactory(
     executionRequestAdapter: ExecutionRequestAdapter,
     eventAdapter: EventAdapter,
     tlsCertificate: TLSCertificate? = null,
+    eventServiceOverride: EventServiceMock? = null,
 ): ProxyInstance {
     val connAuth = AuthenticationDetails.UserPassword("test", "test")
     val executionRequestFactory = ExecutionRequestFactory()
     val request = executionRequestFactory.createDatasourceExecutionRequest()
-    val eventService = EventServiceMock(executionRequestAdapter, eventAdapter, request)
+    val eventService = eventServiceOverride ?: EventServiceMock(executionRequestAdapter, eventAdapter, request)
     var proxy = PostgresProxy(
         postgresContainer.host,
         postgresContainer.getMappedPort(5432),

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/PgFactories.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/PgFactories.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.helpers
 
 import dev.kviklet.kviklet.db.EventAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/WaitForProxyStart.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/WaitForProxyStart.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.helpers
 
 import dev.kviklet.kviklet.proxy.postgres.PostgresProxy

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/EventServiceMock.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/EventServiceMock.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.mocks
 
 import dev.kviklet.kviklet.db.EventAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/EventServiceMock.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/EventServiceMock.kt
@@ -12,7 +12,7 @@ import dev.kviklet.kviklet.service.dto.ExecutionRequestId
 import org.junit.jupiter.api.Assertions.assertTrue
 import java.util.ArrayList
 
-class EventServiceMock(
+open class EventServiceMock(
     executionRequestAdapter: ExecutionRequestAdapter,
     eventAdapter: EventAdapter,
     var executionRequest: ExecutionRequest,

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/FailingEventServiceMock.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/FailingEventServiceMock.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.mocks
 
 import dev.kviklet.kviklet.db.EventAdapter

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/FailingEventServiceMock.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/FailingEventServiceMock.kt
@@ -1,0 +1,23 @@
+package dev.kviklet.kviklet.proxy.mocks
+
+import dev.kviklet.kviklet.db.EventAdapter
+import dev.kviklet.kviklet.db.ExecutionRequestAdapter
+import dev.kviklet.kviklet.db.Payload
+import dev.kviklet.kviklet.service.dto.Event
+import dev.kviklet.kviklet.service.dto.ExecutionRequest
+import dev.kviklet.kviklet.service.dto.ExecutionRequestId
+
+class FailingEventServiceMock(
+    executionRequestAdapter: ExecutionRequestAdapter,
+    eventAdapter: EventAdapter,
+    executionRequest: ExecutionRequest,
+) : EventServiceMock(executionRequestAdapter, eventAdapter, executionRequest) {
+    var failing = false
+
+    override fun saveEvent(id: ExecutionRequestId, authorId: String, payload: Payload): Event {
+        if (failing) {
+            throw RuntimeException("Simulated audit failure")
+        }
+        return super.saveEvent(id, authorId, payload)
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/GetShutdownDateTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/GetShutdownDateTest.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.mocks
 
 import dev.kviklet.kviklet.proxy.postgres.getShutdownDate

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/MockEvent.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/MockEvent.kt
@@ -1,3 +1,4 @@
+// This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.mocks
 
 import dev.kviklet.kviklet.db.User


### PR DESCRIPTION
Simple-protocol ('Q') queries — psql, JDBC with `preferQueryMode=simple`, COPY initiations — executed against the target database without any audit log entry.

The relay in `Connection` now parses the full client chunk first, then audits each message (including 'Q' and multi-statement strings) immediately before forwarding it, so the audit log only contains queries that were at least handed to the server. Failure handling is fail-closed:

- If a client message cannot be parsed, nothing is forwarded; the client gets a proper `ErrorResponse` and the session is closed. No audit event is written for messages that never executed.
- If the audit event cannot be saved, the query is likewise blocked and the session closed instead of executing unaudited.
- If the client references a prepared statement the proxy has not seen, it gets a dedicated error naming the statement instead of an opaque failure.

Also marks the Postgres proxy source and test files as not MIT licensed (enterprise).