### PR TITLE
Fix prepared statement auditing in the Postgres proxy

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
@@ -3,6 +3,7 @@ package dev.kviklet.kviklet.proxy.postgres
 
 import dev.kviklet.kviklet.db.ExecutePayload
 import dev.kviklet.kviklet.proxy.postgres.messages.BindMessage
+import dev.kviklet.kviklet.proxy.postgres.messages.CloseMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.ExecuteMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.MessageOrBytes
 import dev.kviklet.kviklet.proxy.postgres.messages.ParseMessage
@@ -33,7 +34,8 @@ class Connection(
     private var clientOutput: OutputStream = clientSocket.getOutputStream()
     private var serverInput: InputStream = targetSocket.getInputStream()
     private var serverOutput: OutputStream = targetSocket.getOutputStream()
-    private val boundStatements: MutableMap<String, Statement> = mutableMapOf()
+    private val preparedStatements: MutableMap<String, Statement> = mutableMapOf()
+    private val portals: MutableMap<String, Portal> = mutableMapOf()
     private var terminationMessageReceived: Boolean = false
     private var serverTerminating: Boolean = false
     private var sessionAborted: Boolean = false
@@ -71,9 +73,9 @@ class Connection(
             try {
                 auditMessage(messageOrBytes)
             } catch (e: UnknownStatementException) {
-                logger.warn("Client referenced a statement unknown to the proxy, closing the session", e)
+                logger.warn("Client referenced a statement or portal unknown to the proxy, closing the session", e)
                 abortSession(
-                    "Kviklet proxy does not know the prepared statement '${e.statementName}' and cannot audit " +
+                    "Kviklet proxy does not know the statement or portal '${e.name}' and cannot audit " +
                         "this execution. The query was blocked and the session closed.",
                 )
                 return
@@ -104,6 +106,7 @@ class Connection(
             is ParseMessage -> handleParseMessage(message)
             is BindMessage -> handleBindMessage(message)
             is ExecuteMessage -> handleExecute(message)
+            is CloseMessage -> handleClose(message)
             else -> {}
         }
     }
@@ -124,34 +127,52 @@ class Connection(
     }
 
     private fun handleExecute(parsedMessage: ExecuteMessage) {
-        val statement = boundStatements[parsedMessage.statementName]
-            ?: throw UnknownStatementException(parsedMessage.statementName)
-        val executePayload = ExecutePayload(query = statement.interpolateQuery())
+        val portal = portals[parsedMessage.portalName]
+            ?: throw UnknownStatementException(parsedMessage.portalName)
+        // A portal is executed repeatedly when the client pages through results (fetchSize),
+        // audit the query once per Bind rather than once per fetched batch
+        if (portal.audited) {
+            return
+        }
+        val executePayload = ExecutePayload(query = portal.statement.interpolateQuery())
         eventService.saveEvent(executionRequest.id!!, userId, executePayload)
+        portal.audited = true
     }
 
     private fun handleParseMessage(parsedMessage: ParseMessage) {
-        boundStatements[parsedMessage.statementName] = Statement(
+        preparedStatements[parsedMessage.statementName] = Statement(
             parsedMessage.query,
             parameterTypes = parsedMessage.parameterTypes,
         )
     }
 
     private fun handleBindMessage(parsedMessage: BindMessage) {
-        val statement = boundStatements[parsedMessage.statementName]
+        val statement = preparedStatements[parsedMessage.statementName]
             ?: throw UnknownStatementException(parsedMessage.statementName)
-        boundStatements[parsedMessage.statementName] =
+        portals[parsedMessage.portalName] = Portal(
             Statement(
                 statement.query,
                 parsedMessage.parameterFormatCodes,
                 statement.parameterTypes,
                 parsedMessage.parameters,
-            )
+            ),
+        )
+    }
+
+    private fun handleClose(parsedMessage: CloseMessage) {
+        when (parsedMessage.closeType) {
+            'S' -> preparedStatements.remove(parsedMessage.name)
+            'P' -> portals.remove(parsedMessage.name)
+        }
     }
 }
 
-private class UnknownStatementException(val statementName: String) :
-    Exception("Client referenced the statement '$statementName' which the proxy has not seen a Parse message for")
+private class Portal(val statement: Statement) {
+    var audited: Boolean = false
+}
+
+private class UnknownStatementException(val name: String) :
+    Exception("Client referenced the statement or portal '$name' which the proxy has not seen before")
 
 // Because SSLSocket available method always return zero, the code counts on short read timeout hack
 // Originally this was the case only for the server connections, now it is the case for both the client and the server

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
@@ -52,29 +52,31 @@ class PGTypeStringifier(
         791 to "_money",
         829 to "macaddr",
         869 to "inet",
-        650 to "_bool",
-        869 to "_bytea",
-        1000 to "_char",
-        1001 to "_name",
-        1002 to "_int2",
-        1003 to "_int2vector",
-        1005 to "_int4",
-        1006 to "_regproc",
-        1007 to "_text",
-        1008 to "_tid",
-        1009 to "_xid",
-        1010 to "_cid",
-        1011 to "_oidvector",
-        1012 to "_bpchar",
-        1013 to "_varchar",
-        1014 to "_int8",
+        1000 to "_bool",
+        1001 to "_bytea",
+        1002 to "_char",
+        1003 to "_name",
+        1005 to "_int2",
+        1006 to "_int2vector",
+        1007 to "_int4",
+        1008 to "_regproc",
+        1009 to "_text",
+        1010 to "_tid",
+        1011 to "_xid",
+        1012 to "_cid",
+        1013 to "_oidvector",
+        1014 to "_bpchar",
+        1015 to "_varchar",
+        1016 to "_int8",
+        1042 to "bpchar",
+        1043 to "varchar",
     ),
 ) {
     fun convertToHumanReadableString(typeObjectId: Int, bytes: ByteArray): String {
         val type = pgTypeMap[typeObjectId]
         return when (type) {
             "bool" -> {
-                (bytes[0] == 0x01.toByte()).toString()
+                (bytes[0].toInt() != 0).toString()
             }
 
             "char" -> {
@@ -97,7 +99,15 @@ class PGTypeStringifier(
                 ByteBuffer.wrap(bytes).int.toString()
             }
 
-            "text" -> {
+            "float4" -> {
+                ByteBuffer.wrap(bytes).float.toString()
+            }
+
+            "float8" -> {
+                ByteBuffer.wrap(bytes).double.toString()
+            }
+
+            "text", "varchar", "bpchar" -> {
                 String(bytes, Charset.forName("UTF-8"))
             }
 
@@ -146,6 +156,7 @@ open class ParsedMessage(open val header: Char, open val length: Int, open val o
                 'P' -> ParseMessage.fromBytes(length, bytes)
                 'E' -> ExecuteMessage.fromBytes(length, bytes)
                 'B' -> BindMessage.fromBytes(length, bytes)
+                'C' -> CloseMessage.fromBytes(length, bytes)
                 'S' -> SyncMessage.fromBytes(length)
                 else -> ParsedMessage(header, length, bytes)
             }
@@ -181,25 +192,30 @@ class QueryMessage(
     }
 }
 
+// Reads a zero-terminated string from the buffer, as used throughout the Postgres wire protocol
+fun readCString(buffer: ByteBuffer): String {
+    val stringBytes = mutableListOf<Byte>()
+    while (true) {
+        val byte = buffer.get()
+        if (byte == 0.toByte()) {
+            break
+        }
+        stringBytes.add(byte)
+    }
+    return String(stringBytes.toByteArray(), Charset.forName("UTF-8"))
+}
+
 class ExecuteMessage(
     override val header: Char = 'E',
     override val length: Int,
     originalContent: ByteArray,
-    val statementName: String,
+    val portalName: String,
 ) : ParsedMessage(header, length, originalContent) {
     companion object {
         fun fromBytes(length: Int, bytes: ByteArray): ExecuteMessage {
             val buffer = ByteBuffer.wrap(bytes)
-            val statementNameBytes = mutableListOf<Byte>()
-            while (true) {
-                val byte = buffer.get()
-                if (byte == 0.toByte()) {
-                    break
-                }
-                statementNameBytes.add(byte)
-            }
-            val statementName = String(statementNameBytes.toByteArray(), Charset.forName("UTF-8"))
-            return ExecuteMessage('E', length, bytes, statementName)
+            val portalName = readCString(buffer)
+            return ExecuteMessage('E', length, bytes, portalName)
         }
     }
 }
@@ -208,42 +224,34 @@ class BindMessage(
     override val header: Char = 'B',
     override val length: Int,
     override val originalContent: ByteArray,
+    val portalName: String,
     val statementName: String,
     val parameterFormatCodes: List<Int>,
-    val parameters: List<ByteArray>,
+    val parameters: List<ByteArray?>,
 ) : ParsedMessage(header, length, originalContent) {
     companion object {
         fun fromBytes(length: Int, bytes: ByteArray): BindMessage {
             val buffer = ByteBuffer.wrap(bytes)
-            val statementNameBytes = mutableListOf<Byte>()
-            while (true) {
-                val byte = buffer.get()
-                if (byte == 0.toByte()) {
-                    break
-                }
-                statementNameBytes.add(byte)
-            }
-            val statementName = String(statementNameBytes.toByteArray(), Charset.forName("UTF-8"))
-            val portalNameBytes = mutableListOf<Byte>()
-            while (true) {
-                val byte = buffer.get()
-                if (byte == 0.toByte()) {
-                    break
-                }
-                portalNameBytes.add(byte)
-            }
+            // The Bind message carries the destination portal name first and the source statement name second
+            val portalName = readCString(buffer)
+            val statementName = readCString(buffer)
             val parameterFormatCount = buffer.short.toInt()
             val parameterFormatCodes = mutableListOf<Int>()
             for (i in 0 until parameterFormatCount) {
                 parameterFormatCodes.add(buffer.short.toInt())
             }
             val parameterCount = buffer.short.toInt()
-            val parameterValues = mutableListOf<ByteArray>()
+            val parameterValues = mutableListOf<ByteArray?>()
             for (i in 0 until parameterCount) {
                 val parameterLength = buffer.int
-                val parameterBytes = ByteArray(parameterLength)
-                buffer.get(parameterBytes)
-                parameterValues.add(parameterBytes)
+                if (parameterLength == -1) {
+                    // -1 is the wire encoding of NULL, there are no value bytes to read
+                    parameterValues.add(null)
+                } else {
+                    val parameterBytes = ByteArray(parameterLength)
+                    buffer.get(parameterBytes)
+                    parameterValues.add(parameterBytes)
+                }
             }
             val resultFormatCount = buffer.short.toInt()
             val resultFormatCodes = mutableListOf<Int>()
@@ -254,10 +262,28 @@ class BindMessage(
                 'B',
                 length,
                 bytes,
+                portalName,
                 statementName,
                 parameterFormatCodes,
                 parameterValues,
             )
+        }
+    }
+}
+
+class CloseMessage(
+    override val header: Char = 'C',
+    override val length: Int,
+    originalContent: ByteArray,
+    val closeType: Char,
+    val name: String,
+) : ParsedMessage(header, length, originalContent) {
+    companion object {
+        fun fromBytes(length: Int, bytes: ByteArray): CloseMessage {
+            val buffer = ByteBuffer.wrap(bytes)
+            val closeType = buffer.get().toInt().toChar()
+            val name = readCString(buffer)
+            return CloseMessage('C', length, bytes, closeType, name)
         }
     }
 }
@@ -271,26 +297,41 @@ class SyncMessage(override val header: Char = 'S', override val length: Int) :
 
 class Statement(
     val query: String,
-    private val parameterFormatCodes: List<Int> = mutableListOf(),
-    val parameterTypes: List<Int> = mutableListOf(),
-    private val boundParams: List<ByteArray> = mutableListOf(),
+    private val parameterFormatCodes: List<Int> = listOf(),
+    val parameterTypes: List<Int> = listOf(),
+    private val boundParams: List<ByteArray?> = listOf(),
 ) {
-    override fun toString(): String =
-        "Statement(query='$query', parameterFormatCodes=$parameterFormatCodes, boundParams=$boundParams)," +
-            "interpolated query: ${interpolateQuery()}"
+    override fun toString(): String = "Statement(query='$query', parameterFormatCodes=$parameterFormatCodes)," +
+        "interpolated query: ${interpolateQuery()}"
 
-    fun interpolateQuery(): String {
-        var interpolatedQuery = query
-        for (i in boundParams.indices) {
-            val param = boundParams[i]
-            val paramType = parameterTypes[i]
-            val paramIndex = i + 1
-            interpolatedQuery = interpolatedQuery.replace(
-                "$$paramIndex",
-                "'${PGTypeStringifier().convertToHumanReadableString(paramType, param)}'",
-            )
+    // Replaces $1, $2, ... with the bound parameter values for the audit log. The replacement is done
+    // in a single pass so parameter values are never re-scanned for placeholders, and rendering a
+    // parameter must never throw: a value that cannot be decoded is rendered as hex instead.
+    fun interpolateQuery(): String = Regex("\\$(\\d+)").replace(query) { match ->
+        val index = match.groupValues[1].toInt() - 1
+        if (index in boundParams.indices) renderParameter(index) else match.value
+    }
+
+    private fun renderParameter(index: Int): String {
+        val param = boundParams[index] ?: return "NULL"
+        val text = try {
+            if (isTextFormat(index)) {
+                String(param, Charset.forName("UTF-8"))
+            } else {
+                PGTypeStringifier().convertToHumanReadableString(parameterTypes.getOrElse(index) { 0 }, param)
+            }
+        } catch (e: Exception) {
+            param.toHexString()
         }
-        return interpolatedQuery
+        return "'${text.replace("'", "''")}'"
+    }
+
+    // Per the protocol, no format codes means all-text, a single code applies to all parameters,
+    // otherwise there is one code per parameter. 0 is text, 1 is binary.
+    private fun isTextFormat(index: Int): Boolean = when (parameterFormatCodes.size) {
+        0 -> true
+        1 -> parameterFormatCodes[0] == 0
+        else -> parameterFormatCodes.getOrElse(index) { 0 } == 0
     }
 }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
@@ -3,6 +3,17 @@ package dev.kviklet.kviklet.proxy.postgres.messages
 
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+// Binary timestamps, dates and times are transferred relative to the Postgres epoch, 2000-01-01
+private val postgresEpochDateTime = LocalDateTime.of(2000, 1, 1, 0, 0)
+private val postgresEpochDate = LocalDate.of(2000, 1, 1)
+private val postgresEpochInstant = postgresEpochDateTime.toInstant(ZoneOffset.UTC)
 
 class PGTypeStringifier(
     private val pgTypeMap: Map<Int, String> = mapOf(
@@ -70,6 +81,13 @@ class PGTypeStringifier(
         1016 to "_int8",
         1042 to "bpchar",
         1043 to "varchar",
+        1082 to "date",
+        1083 to "time",
+        1114 to "timestamp",
+        1184 to "timestamptz",
+        1700 to "numeric",
+        2950 to "uuid",
+        3802 to "jsonb",
     ),
 ) {
     fun convertToHumanReadableString(typeObjectId: Int, bytes: ByteArray): String {
@@ -105,6 +123,32 @@ class PGTypeStringifier(
 
             "float8" -> {
                 ByteBuffer.wrap(bytes).double.toString()
+            }
+
+            "timestamp" -> {
+                postgresEpochDateTime.plus(ByteBuffer.wrap(bytes).long, ChronoUnit.MICROS).toString()
+            }
+
+            "timestamptz" -> {
+                postgresEpochInstant.plus(ByteBuffer.wrap(bytes).long, ChronoUnit.MICROS).toString()
+            }
+
+            "date" -> {
+                postgresEpochDate.plusDays(ByteBuffer.wrap(bytes).int.toLong()).toString()
+            }
+
+            "time" -> {
+                LocalTime.MIDNIGHT.plus(ByteBuffer.wrap(bytes).long, ChronoUnit.MICROS).toString()
+            }
+
+            "uuid" -> {
+                val buffer = ByteBuffer.wrap(bytes)
+                UUID(buffer.long, buffer.long).toString()
+            }
+
+            "jsonb" -> {
+                // The first byte is the jsonb wire format version, the rest is the JSON text
+                String(bytes.copyOfRange(1, bytes.size), Charset.forName("UTF-8"))
             }
 
             "text", "varchar", "bpchar" -> {
@@ -235,12 +279,13 @@ class BindMessage(
             // The Bind message carries the destination portal name first and the source statement name second
             val portalName = readCString(buffer)
             val statementName = readCString(buffer)
-            val parameterFormatCount = buffer.short.toInt()
+            // The counts are unsigned int16 on the wire
+            val parameterFormatCount = buffer.short.toInt() and 0xFFFF
             val parameterFormatCodes = mutableListOf<Int>()
             for (i in 0 until parameterFormatCount) {
                 parameterFormatCodes.add(buffer.short.toInt())
             }
-            val parameterCount = buffer.short.toInt()
+            val parameterCount = buffer.short.toInt() and 0xFFFF
             val parameterValues = mutableListOf<ByteArray?>()
             for (i in 0 until parameterCount) {
                 val parameterLength = buffer.int
@@ -248,12 +293,17 @@ class BindMessage(
                     // -1 is the wire encoding of NULL, there are no value bytes to read
                     parameterValues.add(null)
                 } else {
+                    if (parameterLength > buffer.remaining()) {
+                        throw Exception(
+                            "Bind message parameter length $parameterLength exceeds the message size",
+                        )
+                    }
                     val parameterBytes = ByteArray(parameterLength)
                     buffer.get(parameterBytes)
                     parameterValues.add(parameterBytes)
                 }
             }
-            val resultFormatCount = buffer.short.toInt()
+            val resultFormatCount = buffer.short.toInt() and 0xFFFF
             val resultFormatCodes = mutableListOf<Int>()
             for (i in 0 until resultFormatCount) {
                 resultFormatCodes.add(buffer.short.toInt())
@@ -308,8 +358,10 @@ class Statement(
     // in a single pass so parameter values are never re-scanned for placeholders, and rendering a
     // parameter must never throw: a value that cannot be decoded is rendered as hex instead.
     fun interpolateQuery(): String = Regex("\\$(\\d+)").replace(query) { match ->
-        val index = match.groupValues[1].toInt() - 1
-        if (index in boundParams.indices) renderParameter(index) else match.value
+        // toIntOrNull: the regex also matches dollar-digit sequences inside string literals,
+        // which can be too long to be an int and are no placeholder in the first place
+        val index = match.groupValues[1].toIntOrNull()?.minus(1)
+        if (index != null && index in boundParams.indices) renderParameter(index) else match.value
     }
 
     private fun renderParameter(index: Int): String {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/ParseMessage.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/ParseMessage.kt
@@ -2,7 +2,6 @@
 package dev.kviklet.kviklet.proxy.postgres.messages
 
 import java.nio.ByteBuffer
-import java.nio.charset.Charset
 
 class ParseMessage(
     override val header: Char = 'P',
@@ -13,30 +12,10 @@ class ParseMessage(
     val parameterTypes: List<Int>,
 ) : ParsedMessage(header, length, originalContent) {
     companion object {
-        // Strings are denoted with a zero byte at the end
         fun fromBytes(length: Int, bytes: ByteArray): ParseMessage {
             val buffer = ByteBuffer.wrap(bytes)
-            // read the query string until the first zero byte
-            val statementNameBytes = mutableListOf<Byte>()
-            while (true) {
-                val byte = buffer.get()
-                if (byte == 0.toByte()) {
-                    break
-                }
-                statementNameBytes.add(byte)
-            }
-            val statementName = String(statementNameBytes.toByteArray(), Charset.forName("UTF-8"))
-            // read the statement name until the first zero byte // TODO: ?
-            val query = mutableListOf<Byte>()
-            while (true) {
-                val byte = buffer.get()
-                if (byte == 0.toByte()) {
-                    break
-                }
-                query.add(byte)
-            }
-            val queryString = String(query.toByteArray(), Charset.forName("UTF-8"))
-            // read the parameter types
+            val statementName = readCString(buffer)
+            val queryString = readCString(buffer)
             val parameterCount = buffer.short.toInt()
             val parameterTypes = mutableListOf<Int>()
             for (i in 0 until parameterCount) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/ParseMessage.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/ParseMessage.kt
@@ -16,7 +16,8 @@ class ParseMessage(
             val buffer = ByteBuffer.wrap(bytes)
             val statementName = readCString(buffer)
             val queryString = readCString(buffer)
-            val parameterCount = buffer.short.toInt()
+            // The count is an unsigned int16 on the wire
+            val parameterCount = buffer.short.toInt() and 0xFFFF
             val parameterTypes = mutableListOf<Int>()
             for (i in 0 until parameterCount) {
                 parameterTypes.add(buffer.int)

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyMessagesTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyMessagesTest.kt
@@ -1,0 +1,146 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.proxy.postgres.messages.BindMessage
+import dev.kviklet.kviklet.proxy.postgres.messages.Statement
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+
+class PostgresProxyMessagesTest {
+
+    // Builds the content of a Bind message (without the 'B' header and the length int),
+    // as laid out in the Postgres wire protocol: portal name first, statement name second.
+    private fun bindMessageContent(
+        portal: String,
+        statement: String,
+        parameters: List<ByteArray?> = emptyList(),
+        parameterFormatCodes: List<Int> = emptyList(),
+    ): ByteArray {
+        val portalBytes = portal.toByteArray() + byteArrayOf(0)
+        val statementBytes = statement.toByteArray() + byteArrayOf(0)
+        val paramsSize = parameters.sumOf { 4 + (it?.size ?: 0) }
+        val buffer = ByteBuffer.allocate(
+            portalBytes.size + statementBytes.size + 2 + parameterFormatCodes.size * 2 + 2 + paramsSize + 2,
+        )
+        buffer.put(portalBytes)
+        buffer.put(statementBytes)
+        buffer.putShort(parameterFormatCodes.size.toShort())
+        parameterFormatCodes.forEach { buffer.putShort(it.toShort()) }
+        buffer.putShort(parameters.size.toShort())
+        parameters.forEach { param ->
+            if (param == null) {
+                buffer.putInt(-1)
+            } else {
+                buffer.putInt(param.size)
+                buffer.put(param)
+            }
+        }
+        buffer.putShort(0) // result format codes
+        return buffer.array()
+    }
+
+    private fun bindMessageFromContent(content: ByteArray): BindMessage =
+        BindMessage.fromBytes(content.size + 4, content)
+
+    @Test
+    fun `bind message reads the portal name first and the statement name second`() {
+        val content = bindMessageContent(portal = "myportal", statement = "S_1")
+        val message = bindMessageFromContent(content)
+        assertEquals("S_1", message.statementName)
+        assertEquals("myportal", message.portalName)
+    }
+
+    @Test
+    fun `bind message parses NULL parameters instead of throwing`() {
+        val content = bindMessageContent(portal = "", statement = "", parameters = listOf(null))
+        val message = bindMessageFromContent(content)
+        assertEquals(1, message.parameters.size)
+        assertNull(message.parameters[0])
+    }
+
+    @Test
+    fun `interpolation substitutes parameters beyond number nine correctly`() {
+        val query = "SELECT " + (1..10).joinToString(", ") { "\$$it" }
+        val statement = Statement(
+            query,
+            parameterFormatCodes = emptyList(),
+            parameterTypes = List(10) { 25 },
+            boundParams = (1..10).map { "v$it".toByteArray() },
+        )
+        val interpolated = statement.interpolateQuery()
+        assertTrue(interpolated.endsWith("'v10'"), "Expected \$10 to become 'v10' but got: $interpolated")
+        assertFalse(interpolated.contains("'v1'0"), "\$10 was corrupted by the \$1 substitution: $interpolated")
+    }
+
+    @Test
+    fun `interpolation renders null parameters as unquoted NULL`() {
+        val statement = Statement(
+            "SELECT \$1",
+            parameterFormatCodes = emptyList(),
+            parameterTypes = listOf(25),
+            boundParams = listOf(null),
+        )
+        assertEquals("SELECT NULL", statement.interpolateQuery())
+    }
+
+    @Test
+    fun `interpolation escapes single quotes in parameter values`() {
+        val statement = Statement(
+            "SELECT \$1",
+            parameterFormatCodes = emptyList(),
+            parameterTypes = listOf(25),
+            boundParams = listOf("O'Brien".toByteArray()),
+        )
+        assertEquals("SELECT 'O''Brien'", statement.interpolateQuery())
+    }
+
+    @Test
+    fun `interpolation does not resubstitute placeholders contained in parameter values`() {
+        val statement = Statement(
+            "SELECT \$1, \$2",
+            parameterFormatCodes = emptyList(),
+            parameterTypes = listOf(25, 25),
+            boundParams = listOf("costs \$2".toByteArray(), "x".toByteArray()),
+        )
+        assertEquals("SELECT 'costs \$2', 'x'", statement.interpolateQuery())
+    }
+
+    @Test
+    fun `interpolation audits text format integers as their text value`() {
+        val statement = Statement(
+            "SELECT \$1",
+            parameterFormatCodes = emptyList(),
+            parameterTypes = listOf(23),
+            boundParams = listOf("1234".toByteArray()),
+        )
+        val interpolated = statement.interpolateQuery()
+        assertTrue(interpolated.contains("1234"), "Expected the text value 1234 but got: $interpolated")
+        assertFalse(interpolated.contains("825373492"), "Text bytes were decoded as a binary int: $interpolated")
+    }
+
+    @Test
+    fun `interpolation decodes binary format integers per their type`() {
+        val statement = Statement(
+            "SELECT \$1",
+            parameterFormatCodes = listOf(1),
+            parameterTypes = listOf(23),
+            boundParams = listOf(ByteBuffer.allocate(4).putInt(1234).array()),
+        )
+        assertTrue(statement.interpolateQuery().contains("1234"))
+    }
+
+    @Test
+    fun `interpolation does not throw when bind supplies more parameters than declared types`() {
+        val statement = Statement(
+            "SELECT \$1",
+            parameterFormatCodes = emptyList(),
+            parameterTypes = emptyList(),
+            boundParams = listOf("a".toByteArray()),
+        )
+        assertEquals("SELECT 'a'", statement.interpolateQuery())
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyMessagesTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyMessagesTest.kt
@@ -2,13 +2,18 @@
 package dev.kviklet.kviklet.proxy
 
 import dev.kviklet.kviklet.proxy.postgres.messages.BindMessage
+import dev.kviklet.kviklet.proxy.postgres.messages.PGTypeStringifier
 import dev.kviklet.kviklet.proxy.postgres.messages.Statement
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.nio.ByteBuffer
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import java.util.UUID
 
 class PostgresProxyMessagesTest {
 
@@ -131,6 +136,60 @@ class PostgresProxyMessagesTest {
             boundParams = listOf(ByteBuffer.allocate(4).putInt(1234).array()),
         )
         assertTrue(statement.interpolateQuery().contains("1234"))
+    }
+
+    @Test
+    fun `interpolation leaves dollar digit literals that are no valid placeholder untouched`() {
+        val query = "INSERT INTO t(note) VALUES ('\$99999999999')"
+        val statement = Statement(query)
+        assertEquals(query, statement.interpolateQuery())
+    }
+
+    @Test
+    fun `bind message reads parameter counts as unsigned int16`() {
+        val content = bindMessageContent(portal = "", statement = "", parameters = List(33000) { null })
+        val message = bindMessageFromContent(content)
+        assertEquals(33000, message.parameters.size)
+    }
+
+    @Test
+    fun `bind message rejects parameter lengths larger than the message`() {
+        val buffer = ByteBuffer.allocate(2 + 2 + 2 + 4)
+        buffer.put(0) // portal name
+        buffer.put(0) // statement name
+        buffer.putShort(0) // parameter format codes
+        buffer.putShort(1) // parameter count
+        buffer.putInt(999_999_999) // claimed parameter length, no value bytes follow
+        assertThrows<Exception> { bindMessageFromContent(buffer.array()) }
+    }
+
+    @Test
+    fun `binary timestamps dates uuids and jsonb decode to readable values`() {
+        val stringifier = PGTypeStringifier()
+        val micros = ChronoUnit.MICROS.between(
+            LocalDateTime.of(2000, 1, 1, 0, 0),
+            LocalDateTime.of(2024, 5, 1, 10, 30, 45),
+        )
+        assertEquals(
+            "2024-05-01T10:30:45",
+            stringifier.convertToHumanReadableString(1114, ByteBuffer.allocate(8).putLong(micros).array()),
+        )
+        assertEquals(
+            "2024-05-01T10:30:45Z",
+            stringifier.convertToHumanReadableString(1184, ByteBuffer.allocate(8).putLong(micros).array()),
+        )
+        assertEquals(
+            "2000-01-10",
+            stringifier.convertToHumanReadableString(1082, ByteBuffer.allocate(4).putInt(9).array()),
+        )
+        val uuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+        val uuidBytes = ByteBuffer.allocate(16)
+            .putLong(uuid.mostSignificantBits)
+            .putLong(uuid.leastSignificantBits)
+            .array()
+        assertEquals(uuid.toString(), stringifier.convertToHumanReadableString(2950, uuidBytes))
+        val jsonbBytes = byteArrayOf(1) + """{"a": 1}""".toByteArray()
+        assertEquals("""{"a": 1}""", stringifier.convertToHumanReadableString(3802, jsonbBytes))
     }
 
     @Test

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyPreparedStatementTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyPreparedStatementTest.kt
@@ -18,6 +18,7 @@ import org.testcontainers.containers.PostgreSQLContainer
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.Types
+import java.time.LocalDateTime
 import java.util.Properties
 
 @SpringBootTest
@@ -46,7 +47,8 @@ class PostgresProxyPreparedStatementTest {
         this.directConnection = directConnectionFactory(postgresContainer)
         this.proxy = proxyServerFactory(postgresContainer, executionRequestAdapter, eventAdapter)
         directConnection.createStatement().executeUpdate(
-            "CREATE TABLE IF NOT EXISTS proxy_test_params (id INTEGER, name VARCHAR(64), active BOOLEAN);",
+            "CREATE TABLE IF NOT EXISTS proxy_test_params " +
+                "(id INTEGER, name VARCHAR(64), active BOOLEAN, created TIMESTAMP);",
         )
     }
 
@@ -57,12 +59,12 @@ class PostgresProxyPreparedStatementTest {
         this.postgresContainer.stop()
     }
 
-    private fun proxyConnection(prepareThreshold: Int? = null): Connection {
+    private fun proxyConnection(prepareThreshold: Int? = null, binaryTransfer: Boolean = false): Connection {
         val props = Properties()
         props.setProperty("user", "proxyUser")
         props.setProperty("password", "proxyPassword")
-        // Pin parameters to the text wire format so the assertions below are deterministic
-        props.setProperty("binaryTransfer", "false")
+        // Most tests pin parameters to the text wire format so the assertions are deterministic
+        props.setProperty("binaryTransfer", binaryTransfer.toString())
         prepareThreshold?.let { props.setProperty("prepareThreshold", it.toString()) }
         return DriverManager.getConnection(this.proxy.connectionString, props)
     }
@@ -151,6 +153,30 @@ class PostgresProxyPreparedStatementTest {
         connection.close()
 
         this.proxy.eventService.assertAuditedQueryContains("'value10'")
+    }
+
+    @Test
+    fun `binary format parameters are audited human readable`() {
+        // Named server-side statements with binary transfer, like Npgsql or pgx use by default
+        val connection = proxyConnection(prepareThreshold = 1, binaryTransfer = true)
+        val statement = connection.prepareStatement(
+            "INSERT INTO proxy_test_params(id, name, created) VALUES (?, ?, ?)",
+        )
+        val timestamp = LocalDateTime.of(2024, 5, 1, 10, 30, 45)
+        for (id in listOf(20, 21)) {
+            statement.setInt(1, id)
+            statement.setString(2, "binary")
+            statement.setObject(3, timestamp)
+            assertEquals(1, statement.executeUpdate())
+        }
+        connection.close()
+
+        val result = directConnection.createStatement()
+            .executeQuery("SELECT created FROM proxy_test_params WHERE id = 21;")
+        assertTrue(result.next())
+        assertEquals(timestamp, result.getTimestamp("created").toLocalDateTime())
+
+        this.proxy.eventService.assertAuditedQueryContains("VALUES ('21', 'binary', '2024-05-01T10:30:45')")
     }
 
     @Test

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyPreparedStatementTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyPreparedStatementTest.kt
@@ -1,0 +1,196 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.db.EventAdapter
+import dev.kviklet.kviklet.db.ExecutionRequestAdapter
+import dev.kviklet.kviklet.proxy.helpers.ProxyInstance
+import dev.kviklet.kviklet.proxy.helpers.directConnectionFactory
+import dev.kviklet.kviklet.proxy.helpers.proxyServerFactory
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.containers.PostgreSQLContainer
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.Types
+import java.util.Properties
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PostgresProxyPreparedStatementTest {
+    @Autowired
+    lateinit var executionRequestAdapter: ExecutionRequestAdapter
+
+    @Autowired
+    lateinit var eventAdapter: EventAdapter
+    private lateinit var directConnection: Connection
+    private lateinit var proxy: ProxyInstance
+    private lateinit var postgresContainer: PostgreSQLContainer<Nothing>
+
+    @BeforeEach
+    fun setup() {
+        postgresContainer = PostgreSQLContainer<Nothing>("postgres:13").apply {
+            withDatabaseName("testdb")
+            withUsername("test")
+            withPassword("test")
+        }
+        postgresContainer.start()
+        while (!postgresContainer.isRunning) {
+            Thread.sleep(1000)
+        }
+        this.directConnection = directConnectionFactory(postgresContainer)
+        this.proxy = proxyServerFactory(postgresContainer, executionRequestAdapter, eventAdapter)
+        directConnection.createStatement().executeUpdate(
+            "CREATE TABLE IF NOT EXISTS proxy_test_params (id INTEGER, name VARCHAR(64), active BOOLEAN);",
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        this.proxy.proxy.shutdownServer()
+        this.proxy.connection.close()
+        this.postgresContainer.stop()
+    }
+
+    private fun proxyConnection(prepareThreshold: Int? = null): Connection {
+        val props = Properties()
+        props.setProperty("user", "proxyUser")
+        props.setProperty("password", "proxyPassword")
+        // Pin parameters to the text wire format so the assertions below are deterministic
+        props.setProperty("binaryTransfer", "false")
+        prepareThreshold?.let { props.setProperty("prepareThreshold", it.toString()) }
+        return DriverManager.getConnection(this.proxy.connectionString, props)
+    }
+
+    @Test
+    fun `prepared statement parameters are executed and audited with their values`() {
+        val connection = proxyConnection()
+        val statement = connection.prepareStatement("INSERT INTO proxy_test_params(id, name) VALUES (?, ?)")
+        statement.setInt(1, 5)
+        statement.setString(2, "test")
+        assertEquals(1, statement.executeUpdate())
+        connection.close()
+
+        val result = directConnection.createStatement()
+            .executeQuery("SELECT name FROM proxy_test_params WHERE id = 5;")
+        assertTrue(result.next())
+        assertEquals("test", result.getString("name"))
+
+        this.proxy.eventService.assertAuditedQueryContains("VALUES ('5', 'test')")
+    }
+
+    @Test
+    fun `NULL parameters do not kill the session and are audited as NULL`() {
+        val connection = proxyConnection()
+        val statement = connection.prepareStatement("INSERT INTO proxy_test_params(id, name) VALUES (?, ?)")
+        statement.setInt(1, 6)
+        statement.setNull(2, Types.VARCHAR)
+        assertEquals(1, statement.executeUpdate())
+        connection.close()
+
+        val result = directConnection.createStatement()
+            .executeQuery("SELECT name FROM proxy_test_params WHERE id = 6;")
+        assertTrue(result.next())
+        assertEquals(null, result.getString("name"))
+
+        this.proxy.eventService.assertAuditedQueryContains("VALUES ('6', NULL)")
+    }
+
+    @Test
+    fun `boolean parameters are audited with their text value`() {
+        val connection = proxyConnection()
+        val statement = connection.prepareStatement(
+            "INSERT INTO proxy_test_params(id, name, active) VALUES (?, ?, ?)",
+        )
+        statement.setInt(1, 7)
+        statement.setString(2, "bool-test")
+        statement.setBoolean(3, true)
+        assertEquals(1, statement.executeUpdate())
+        connection.close()
+
+        val result = directConnection.createStatement()
+            .executeQuery("SELECT active FROM proxy_test_params WHERE id = 7;")
+        assertTrue(result.next())
+        assertEquals(true, result.getBoolean("active"))
+
+        this.proxy.eventService.assertAuditedQueryContains("VALUES ('7', 'bool-test', 'TRUE')")
+    }
+
+    @Test
+    fun `parameter values with quotes and placeholders are audited escaped and unmodified`() {
+        val connection = proxyConnection()
+        val statement = connection.prepareStatement("INSERT INTO proxy_test_params(id, name) VALUES (?, ?)")
+        statement.setInt(1, 8)
+        statement.setString(2, "O'Brien costs \$2")
+        assertEquals(1, statement.executeUpdate())
+        connection.close()
+
+        val result = directConnection.createStatement()
+            .executeQuery("SELECT name FROM proxy_test_params WHERE id = 8;")
+        assertTrue(result.next())
+        assertEquals("O'Brien costs \$2", result.getString("name"))
+
+        this.proxy.eventService.assertAuditedQueryContains("'O''Brien costs \$2'")
+    }
+
+    @Test
+    fun `queries with ten or more parameters are audited correctly`() {
+        val placeholders = (1..10).joinToString(", ") { "?" }
+        val connection = proxyConnection()
+        val statement = connection.prepareStatement("SELECT ARRAY[$placeholders]::text[]")
+        for (i in 1..10) {
+            statement.setString(i, "value$i")
+        }
+        val result = statement.executeQuery()
+        assertTrue(result.next())
+        connection.close()
+
+        this.proxy.eventService.assertAuditedQueryContains("'value10'")
+    }
+
+    @Test
+    fun `named server side prepared statements are executed and audited`() {
+        // prepareThreshold=1 makes pgjdbc use a named server-side statement from the first execution,
+        // like Npgsql or pgx do by default.
+        val connection = proxyConnection(prepareThreshold = 1)
+        val statement = connection.prepareStatement("SELECT 41 + 1")
+        repeat(3) {
+            val result = statement.executeQuery()
+            assertTrue(result.next())
+            assertEquals(42, result.getInt(1))
+        }
+        connection.close()
+
+        assertEquals(3, this.proxy.eventService.queries.count { it == "select41+1" })
+    }
+
+    @Test
+    fun `interleaved prepared statements audit the query that was actually executed`() {
+        // After prepareThreshold (default 5) executions pgjdbc switches to a named server statement
+        // and stops sending Parse. The audit log must still attribute executions to the right query.
+        val connection = proxyConnection()
+        val statementA = connection.prepareStatement("SELECT 1")
+        val statementB = connection.prepareStatement("SELECT 2")
+        repeat(5) {
+            val result = statementA.executeQuery()
+            assertTrue(result.next())
+            assertEquals(1, result.getInt(1))
+        }
+        val resultB = statementB.executeQuery()
+        assertTrue(resultB.next())
+        assertEquals(2, resultB.getInt(1))
+        // Sixth execution of A: named statement, no Parse is sent anymore
+        val resultA = statementA.executeQuery()
+        assertTrue(resultA.next())
+        assertEquals(1, resultA.getInt(1))
+        connection.close()
+
+        assertEquals(6, this.proxy.eventService.queries.count { it == "select1" })
+        assertEquals(1, this.proxy.eventService.queries.count { it == "select2" })
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyPreparedStatementTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyPreparedStatementTest.kt
@@ -157,7 +157,9 @@ class PostgresProxyPreparedStatementTest {
 
     @Test
     fun `binary format parameters are audited human readable`() {
-        // Named server-side statements with binary transfer, like Npgsql or pgx use by default
+        // Named server-side statements with binary transfer, like Npgsql or pgx use by default.
+        // pgjdbc still sends timestamps as text even in this mode, so the timestamp assertion is
+        // separator-agnostic; the binary decoders themselves are covered by PostgresProxyMessagesTest.
         val connection = proxyConnection(prepareThreshold = 1, binaryTransfer = true)
         val statement = connection.prepareStatement(
             "INSERT INTO proxy_test_params(id, name, created) VALUES (?, ?, ?)",
@@ -176,7 +178,8 @@ class PostgresProxyPreparedStatementTest {
         assertTrue(result.next())
         assertEquals(timestamp, result.getTimestamp("created").toLocalDateTime())
 
-        this.proxy.eventService.assertAuditedQueryContains("VALUES ('21', 'binary', '2024-05-01T10:30:45')")
+        this.proxy.eventService.assertAuditedQueryContains("VALUES ('21', 'binary', '2024-05-01")
+        this.proxy.eventService.assertAuditedQueryContains("10:30:45')")
     }
 
     @Test

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/EventServiceMock.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/mocks/EventServiceMock.kt
@@ -19,6 +19,13 @@ open class EventServiceMock(
     var executionRequest: ExecutionRequest,
 ) : EventService(executionRequestAdapter, eventAdapter) {
     var queries: ArrayList<String> = ArrayList<String>()
+    var rawQueries: ArrayList<String> = ArrayList<String>()
+    fun assertAuditedQueryContains(fragment: String) {
+        assertTrue(
+            this.rawQueries.any { it.contains(fragment) },
+            "No audited query contains \"$fragment\". Audited queries: $rawQueries",
+        )
+    }
     fun assertQueryIsAudited(query: String) {
         var processedQuery = query.lowercase().replace(" ", "").replace("\n".toRegex(), "")
         if (processedQuery.last() == ';') {
@@ -30,6 +37,7 @@ open class EventServiceMock(
     override fun saveEvent(id: ExecutionRequestId, authorId: String, payload: Payload): Event {
         if (payload.type.compareTo(EventType.EXECUTE) == 0) {
             val executePayload = payload as ExecutePayload
+            executePayload.query?.let { rawQueries.add(it) }
             if (executePayload.query?.last() == ';') {
                 executePayload.query?.let {
                     queries.add(it.lowercase().replace(" ", "").replace("\n".toRegex(), "").dropLast(1))


### PR DESCRIPTION
The proxy's extended-protocol handling parsed the Bind message's portal and statement names in the wrong order, which only worked for clients that use the unnamed statement and portal. Once pgjdbc switched to named server-side statements (after `prepareThreshold` executions), interleaved prepared statements got attributed to the wrong query in the audit log, and drivers that use named statements from the start (Npgsql, pgx) lost their session entirely.

Parameter decoding was also broken: NULL parameters and text-format values crashed the session, and the interpolated audit text could be corrupted (`$10+` placeholders, unescaped quotes, parameter values being re-scanned for placeholders).

Changes:
- Parse Bind fields in protocol order and track prepared statements and portals in separate maps, resolving Execute through its portal. Unknown statements or portals block the query and close the session, consistent with the existing fail-closed behavior.
- Handle Close messages so closed statements and portals are dropped, and audit a portal once per Bind instead of once per fetched batch when a client pages with `fetchSize`.
- Decode parameters per their wire format code (text as UTF-8, binary by type OID) instead of assuming binary, render NULL as `NULL`, escape quotes, and substitute placeholders in a single pass. A value that cannot be decoded is rendered as hex instead of killing the session.

Covered by a new unit test suite for the message parsing/interpolation and a new Testcontainers suite exercising parameterized, named, and interleaved prepared statements through the proxy.