### PR TITLE
Make the Postgres proxy relay loop robust against split messages, EOF and fast-path calls

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
@@ -5,9 +5,9 @@ import dev.kviklet.kviklet.db.ExecutePayload
 import dev.kviklet.kviklet.proxy.postgres.messages.BindMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.CloseMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.ExecuteMessage
+import dev.kviklet.kviklet.proxy.postgres.messages.MessageFramer
 import dev.kviklet.kviklet.proxy.postgres.messages.MessageOrBytes
 import dev.kviklet.kviklet.proxy.postgres.messages.ParseMessage
-import dev.kviklet.kviklet.proxy.postgres.messages.ParsedMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.QueryMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.Statement
 import dev.kviklet.kviklet.proxy.postgres.messages.errorResponse
@@ -21,7 +21,6 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
 import java.net.SocketTimeoutException
-import java.nio.ByteBuffer
 
 class Connection(
     clientSocket: Socket,
@@ -34,6 +33,7 @@ class Connection(
     private var clientOutput: OutputStream = clientSocket.getOutputStream()
     private var serverInput: InputStream = targetSocket.getInputStream()
     private var serverOutput: OutputStream = targetSocket.getOutputStream()
+    private val clientFramer = MessageFramer()
     private val preparedStatements: MutableMap<String, Statement> = mutableMapOf()
     private val portals: MutableMap<String, Portal> = mutableMapOf()
     private var terminationMessageReceived: Boolean = false
@@ -51,8 +51,12 @@ class Connection(
         // This basically transfers messages between the client and the server sockets.
         // NOTE: At this point the client connection is set up. SSL, Auth etc... are handled in ClientConnectionSetup.kt
         while (!terminationMessageReceived && !serverTerminating && !sessionAborted) {
-            readFromAnyStream(clientInput) { handleClientData(it) }
-            readFromAnyStream(serverInput) { clientOutput.writeAndFlush(it) }
+            val clientOpen = readFromAnyStream(clientInput) { handleClientData(it) }
+            val serverOpen = readFromAnyStream(serverInput) { clientOutput.writeAndFlush(it) }
+            if (!clientOpen || !serverOpen) {
+                logger.info("The {} closed the connection, ending the session", if (clientOpen) "server" else "client")
+                break
+            }
         }
     }
 
@@ -61,7 +65,7 @@ class Connection(
         // and each message is audited immediately before it is forwarded, so the audit log
         // only ever contains queries that were at least attempted.
         val messages = try {
-            parseDataToMessages(clientBuffer)
+            clientFramer.feed(clientBuffer).map { MessageOrBytes(it, null) }
         } catch (e: Exception) {
             logger.warn("Failed to parse client message, blocking it and closing the session", e)
             abortSession(
@@ -70,6 +74,14 @@ class Connection(
             return
         }
         for (messageOrBytes in messages) {
+            if (messageOrBytes.message?.header == 'F') {
+                logger.warn("Client sent a fast-path FunctionCall message, blocking it and closing the session")
+                abortSession(
+                    "Kviklet proxy does not support fast-path function calls because they bypass the audit log. " +
+                        "The call was blocked and the session closed.",
+                )
+                return
+            }
             try {
                 auditMessage(messageOrBytes)
             } catch (e: UnknownStatementException) {
@@ -89,15 +101,6 @@ class Connection(
             terminationMessageReceived = terminationMessageReceived || messageOrBytes.isTermination()
             serverOutput.writeAndFlush(messageOrBytes.writableBytes())
         }
-    }
-
-    private fun parseDataToMessages(byteArray: ByteArray): List<MessageOrBytes> {
-        val buffer = ByteBuffer.wrap(byteArray)
-        val messages = mutableListOf<MessageOrBytes>()
-        while (buffer.remaining() > 0) {
-            messages.add(MessageOrBytes(ParsedMessage.fromBytes(buffer), null))
-        }
-        return messages
     }
 
     private fun auditMessage(messageOrBytes: MessageOrBytes) {
@@ -177,17 +180,29 @@ private class UnknownStatementException(val name: String) :
 // Because SSLSocket available method always return zero, the code counts on short read timeout hack
 // Originally this was the case only for the server connections, now it is the case for both the client and the server
 // More info about the hack: https://stackoverflow.com/a/29386157
-fun readFromAnyStream(input: InputStream, onInputAvailable: (input: ByteArray) -> Unit) {
+// Returns false once the stream has reached EOF and no more data will ever arrive
+fun readFromAnyStream(input: InputStream, onInputAvailable: (input: ByteArray) -> Unit): Boolean {
     val singleByte = ByteArray(1)
     val bytesRead: Int = try {
         input.read(singleByte, 0, 1)
     } catch (e: SocketTimeoutException) {
-        0
+        return true
+    }
+    if (bytesRead == -1) {
+        return false
     }
 
-    if (bytesRead > 0) {
-        val buff = ByteArray(8192)
-        val read = input.read(buff)
-        onInputAvailable(singleByte + buff.copyOfRange(0, read))
+    val buff = ByteArray(8192)
+    val read = try {
+        input.read(buff)
+    } catch (e: SocketTimeoutException) {
+        // Only the single polled byte was available before the socket timeout kicked in
+        0
     }
+    if (read == -1) {
+        onInputAvailable(singleByte)
+        return false
+    }
+    onInputAvailable(singleByte + buff.copyOfRange(0, read))
+    return true
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/PostgresProxy.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/PostgresProxy.kt
@@ -32,7 +32,11 @@ class PostgresProxy(
     private var proxyUsername = "postgres"
     private var proxyPassword = "postgres"
     private val maxConnections = 15
-    private var currentConnections = 0
+
+    // Volatile so tests and monitoring see slot releases done by the connection handler threads
+    @Volatile
+    var currentConnections = 0
+        private set
     private var targetPostgres: TargetPostgresSocketFactory =
         TargetPostgresSocketFactory(authenticationDetails, databaseName, targetHost, targetPort)
     var isRunning: Boolean = false

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/MessageFramer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/MessageFramer.kt
@@ -1,0 +1,40 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy.postgres.messages
+
+import java.nio.ByteBuffer
+
+// Postgres rejects wire-protocol messages larger than 1GB, so a length beyond that can only be
+// garbage or an attack and waiting for the remaining bytes would buffer unbounded amounts of data
+private const val MAX_MESSAGE_LENGTH = 0x40000000
+
+// Reassembles wire-protocol messages from the raw chunks read off the client socket. A single
+// read can contain several messages and a single message can be split across several reads
+// (anything larger than the socket read buffer always is), so complete messages are extracted
+// and the trailing partial message is buffered until the next chunk arrives.
+class MessageFramer {
+    private var buffered: ByteArray = ByteArray(0)
+
+    fun feed(chunk: ByteArray): List<ParsedMessage> {
+        buffered += chunk
+        val messages = mutableListOf<ParsedMessage>()
+        var offset = 0
+        // A message is one header byte plus an int32 length that includes itself but not the header
+        while (buffered.size - offset >= 5) {
+            val length = ByteBuffer.wrap(buffered, offset + 1, 4).int
+            if (length < 4 || length > MAX_MESSAGE_LENGTH) {
+                throw Exception(
+                    "Invalid length $length for message of type '${buffered[offset].toInt().toChar()}'",
+                )
+            }
+            if (buffered.size - offset < 1 + length) {
+                break
+            }
+            val header = buffered[offset].toInt().toChar()
+            val content = buffered.copyOfRange(offset + 5, offset + 1 + length)
+            messages.add(ParsedMessage.fromBytes(header, length, content))
+            offset += 1 + length
+        }
+        buffered = buffered.copyOfRange(offset, buffered.size)
+        return messages
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
@@ -191,7 +191,7 @@ open class ParsedMessage(open val header: Char, open val length: Int, open val o
                 'E' -> ExecuteMessage.fromBytes(length, bytes)
                 'B' -> BindMessage.fromBytes(length, bytes)
                 'C' -> CloseMessage.fromBytes(length, bytes)
-                'S' -> SyncMessage.fromBytes(length)
+                'S' -> SyncMessage.fromBytes(length, bytes)
                 else -> ParsedMessage(header, length, bytes)
             }
         }
@@ -328,10 +328,15 @@ class CloseMessage(
     }
 }
 
-class SyncMessage(override val header: Char = 'S', override val length: Int) :
-    ParsedMessage(header, length, ByteArray(0)) {
+class SyncMessage(
+    override val header: Char = 'S',
+    override val length: Int,
+    originalContent: ByteArray = ByteArray(0),
+) : ParsedMessage(header, length, originalContent) {
     companion object {
-        fun fromBytes(length: Int): SyncMessage = SyncMessage('S', length)
+        // A well-behaved client always sends Sync with an empty body, but the body is preserved
+        // regardless so a nonstandard message is relayed faithfully instead of desyncing the stream
+        fun fromBytes(length: Int, bytes: ByteArray): SyncMessage = SyncMessage('S', length, bytes)
     }
 }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
@@ -179,16 +179,6 @@ open class ParsedMessage(open val header: Char, open val length: Int, open val o
     }
 
     companion object {
-        fun fromBytes(buffer: ByteBuffer): ParsedMessage {
-            // todo if check if length is < 4, funny things happen otherwise. The error is handled in the other fromBytes method
-            // but if the length is e.g. 1, the code will try to allocate array with negative size.
-            val header = buffer.get().toInt().toChar()
-            val length = buffer.int
-            val messageBytes = ByteArray(length - 4)
-            buffer.get(messageBytes)
-            return fromBytes(header, length, messageBytes)
-        }
-
         fun fromBytes(header: Char, length: Int, bytes: ByteArray): ParsedMessage {
             if (bytes.size < length - 4) {
                 throw Exception("Not enough bytes to parse message")

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyFramingTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyFramingTest.kt
@@ -89,6 +89,27 @@ class PostgresProxyFramingTest {
     }
 
     @Test
+    fun `every parsed message reserializes to exactly the bytes that were fed`() {
+        // The relay forwards ParsedMessage.toByteArray() to the server, so a faithful relay
+        // requires that reserializing a parsed message reproduces the original wire bytes.
+        // Sync ('S') in particular used to drop its body: a non-empty body would desync the
+        // server-bound stream because the declared length was still forwarded.
+        val framer = MessageFramer()
+        val sync = ByteBuffer.allocate(5 + 4)
+        sync.put('S'.code.toByte())
+        sync.putInt(8) // length includes the int and a 4 byte body
+        sync.put(byteArrayOf(1, 2, 3, 4))
+        val bytes = sync.array()
+
+        val messages = framer.feed(bytes)
+        assertEquals(1, messages.size)
+        assertTrue(
+            bytes.contentEquals(messages[0].toByteArray()),
+            "Reserialized message did not match the original bytes",
+        )
+    }
+
+    @Test
     fun `a message length below the protocol minimum fails the parse`() {
         val framer = MessageFramer()
         val buffer = ByteBuffer.allocate(5)

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyFramingTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyFramingTest.kt
@@ -1,0 +1,135 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.proxy.postgres.messages.MessageFramer
+import dev.kviklet.kviklet.proxy.postgres.messages.QueryMessage
+import dev.kviklet.kviklet.proxy.postgres.readFromAnyStream
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.ByteArrayInputStream
+import java.nio.ByteBuffer
+
+class PostgresProxyFramingTest {
+
+    // Builds a full wire-protocol Query message: 'Q', int32 length, query text, zero terminator
+    private fun queryMessageBytes(query: String): ByteArray {
+        val queryBytes = query.toByteArray() + byteArrayOf(0)
+        val buffer = ByteBuffer.allocate(5 + queryBytes.size)
+        buffer.put('Q'.code.toByte())
+        buffer.putInt(4 + queryBytes.size)
+        buffer.put(queryBytes)
+        return buffer.array()
+    }
+
+    @Test
+    fun `a complete message in a single chunk is parsed`() {
+        val framer = MessageFramer()
+        val messages = framer.feed(queryMessageBytes("SELECT 1"))
+        assertEquals(1, messages.size)
+        assertEquals("SELECT 1", (messages[0] as QueryMessage).query)
+    }
+
+    @Test
+    fun `multiple messages in a single chunk are all parsed`() {
+        val framer = MessageFramer()
+        val messages = framer.feed(queryMessageBytes("SELECT 1") + queryMessageBytes("SELECT 2"))
+        assertEquals(2, messages.size)
+        assertEquals("SELECT 1", (messages[0] as QueryMessage).query)
+        assertEquals("SELECT 2", (messages[1] as QueryMessage).query)
+    }
+
+    @Test
+    fun `a message split in the middle of its header is reassembled`() {
+        val framer = MessageFramer()
+        val bytes = queryMessageBytes("SELECT 1")
+        assertEquals(0, framer.feed(bytes.copyOfRange(0, 3)).size)
+        val messages = framer.feed(bytes.copyOfRange(3, bytes.size))
+        assertEquals(1, messages.size)
+        assertEquals("SELECT 1", (messages[0] as QueryMessage).query)
+    }
+
+    @Test
+    fun `a message split in the middle of its body is reassembled`() {
+        val framer = MessageFramer()
+        val bytes = queryMessageBytes("SELECT 'split right here'")
+        assertEquals(0, framer.feed(bytes.copyOfRange(0, 15)).size)
+        val messages = framer.feed(bytes.copyOfRange(15, bytes.size))
+        assertEquals(1, messages.size)
+        assertEquals("SELECT 'split right here'", (messages[0] as QueryMessage).query)
+    }
+
+    @Test
+    fun `a message larger than the socket read buffer is reassembled from many chunks`() {
+        val framer = MessageFramer()
+        val query = "SELECT '" + "x".repeat(100_000) + "'"
+        val bytes = queryMessageBytes(query)
+        val parsed = mutableListOf<QueryMessage>()
+        for (offset in bytes.indices step 8192) {
+            val chunk = bytes.copyOfRange(offset, minOf(offset + 8192, bytes.size))
+            framer.feed(chunk).forEach { parsed.add(it as QueryMessage) }
+        }
+        assertEquals(1, parsed.size)
+        assertEquals(query, parsed[0].query)
+    }
+
+    @Test
+    fun `a trailing partial message is buffered while complete messages are returned`() {
+        val framer = MessageFramer()
+        val second = queryMessageBytes("SELECT 2")
+        val firstChunk = queryMessageBytes("SELECT 1") + second.copyOfRange(0, 7)
+        val firstBatch = framer.feed(firstChunk)
+        assertEquals(1, firstBatch.size)
+        assertEquals("SELECT 1", (firstBatch[0] as QueryMessage).query)
+        val secondBatch = framer.feed(second.copyOfRange(7, second.size))
+        assertEquals(1, secondBatch.size)
+        assertEquals("SELECT 2", (secondBatch[0] as QueryMessage).query)
+    }
+
+    @Test
+    fun `a message length below the protocol minimum fails the parse`() {
+        val framer = MessageFramer()
+        val buffer = ByteBuffer.allocate(5)
+        buffer.put('Q'.code.toByte())
+        buffer.putInt(1) // the length includes itself, anything below 4 is invalid
+        assertThrows<Exception> { framer.feed(buffer.array()) }
+    }
+
+    @Test
+    fun `a message length above the protocol maximum fails the parse instead of buffering forever`() {
+        val framer = MessageFramer()
+        val buffer = ByteBuffer.allocate(5)
+        buffer.put('Q'.code.toByte())
+        buffer.putInt(Int.MAX_VALUE)
+        assertThrows<Exception> { framer.feed(buffer.array()) }
+    }
+
+    @Test
+    fun `reading from a stream at EOF reports the stream as closed`() {
+        val received = mutableListOf<ByteArray>()
+        val open = readFromAnyStream(ByteArrayInputStream(ByteArray(0))) { received.add(it) }
+        assertFalse(open)
+        assertTrue(received.isEmpty())
+    }
+
+    @Test
+    fun `reading a stream that ends after a single byte still delivers that byte`() {
+        val received = mutableListOf<ByteArray>()
+        val open = readFromAnyStream(ByteArrayInputStream(byteArrayOf(42))) { received.add(it) }
+        assertFalse(open)
+        assertEquals(1, received.size)
+        assertEquals(42, received[0][0].toInt())
+    }
+
+    @Test
+    fun `reading a stream with data delivers all of it and keeps the stream open`() {
+        val data = ByteArray(100) { it.toByte() }
+        val received = mutableListOf<ByteArray>()
+        val open = readFromAnyStream(ByteArrayInputStream(data)) { received.add(it) }
+        assertTrue(open)
+        assertEquals(1, received.size)
+        assertTrue(data.contentEquals(received[0]))
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyParseFailureTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyParseFailureTest.kt
@@ -28,61 +28,111 @@ class PostgresProxyParseFailureTest {
     @Autowired
     lateinit var eventAdapter: EventAdapter
 
-    @Test
-    fun `unparseable client messages are not forwarded, produce an error and are noted in the events`() {
+    // A relay session over raw sockets, bypassing connection setup, so tests can speak the wire
+    // protocol directly with the same socket configuration the proxy applies after setup
+    private class RelayHarness(executionRequestAdapter: ExecutionRequestAdapter, eventAdapter: EventAdapter) :
+        AutoCloseable {
         val request = ExecutionRequestFactory().createDatasourceExecutionRequest()
         val eventService = EventServiceMock(executionRequestAdapter, eventAdapter, request)
-
-        val upstreamListener = ServerSocket(0)
-        val clientListener = ServerSocket(0)
+        private val upstreamListener = ServerSocket(0)
+        private val clientListener = ServerSocket(0)
         val clientSide = Socket("localhost", clientListener.localPort)
-        val proxyClientSocket = clientListener.accept()
-        val proxyTargetSocket = Socket("localhost", upstreamListener.localPort)
-        val upstreamSide = upstreamListener.accept()
-        // Same socket configuration the proxy applies after connection setup
-        proxyClientSocket.soTimeout = 10
-        proxyTargetSocket.soTimeout = 10
+        private val proxyClientSocket = clientListener.accept()
+        private val proxyTargetSocket = Socket("localhost", upstreamListener.localPort)
+        val upstreamSide: Socket = upstreamListener.accept()
+        val handler: Thread
 
-        try {
+        init {
+            proxyClientSocket.soTimeout = 10
+            proxyTargetSocket.soTimeout = 10
             val connection = Connection(proxyClientSocket, proxyTargetSocket, eventService, request, "mock")
-            val handler = thread { connection.startHandling() }
+            handler = thread { connection.startHandling() }
+        }
 
-            // A 'Q' message that declares a 500 byte body but delivers only a fraction of it
-            val queryBytes = "DROP TABLE secret".toByteArray()
-            val message = ByteBuffer.allocate(5 + queryBytes.size)
-            message.put('Q'.code.toByte())
-            message.putInt(500)
-            message.put(queryBytes)
-            clientSide.getOutputStream().write(message.array())
+        fun sendToProxy(bytes: ByteArray) {
+            clientSide.getOutputStream().write(bytes)
             clientSide.getOutputStream().flush()
+        }
 
-            // The client must receive an ErrorResponse ('E'), not a dead socket
-            clientSide.soTimeout = 5000
-            val firstByte = clientSide.getInputStream().read()
-            assertEquals('E'.code, firstByte)
-
-            // The session must terminate
-            handler.join(5000)
-            assertFalse(handler.isAlive)
-
-            // Nothing must have been forwarded to the target database
-            upstreamSide.soTimeout = 500
-            val forwarded = try {
+        // Returns -1 if nothing arrives at the target database within the timeout
+        fun readByteForwardedUpstream(timeoutMillis: Int = 500): Int {
+            upstreamSide.soTimeout = timeoutMillis
+            return try {
                 upstreamSide.getInputStream().read()
             } catch (e: SocketTimeoutException) {
                 -1
             }
-            assertEquals(-1, forwarded)
+        }
 
-            // The blocked message must not produce an audit event, only executed queries are audited
-            assertTrue(eventService.queries.isEmpty())
-        } finally {
+        override fun close() {
             clientSide.close()
             proxyClientSocket.close()
             proxyTargetSocket.close()
             upstreamSide.close()
             upstreamListener.close()
             clientListener.close()
+        }
+    }
+
+    @Test
+    fun `unparseable client messages are not forwarded, produce an error and are noted in the events`() {
+        RelayHarness(executionRequestAdapter, eventAdapter).use { harness ->
+            // A message declaring a length below the protocol minimum of 4 can only be garbage
+            val message = ByteBuffer.allocate(5 + 4)
+            message.put('Q'.code.toByte())
+            message.putInt(2)
+            message.put("DROP".toByteArray())
+            harness.sendToProxy(message.array())
+
+            // The client must receive an ErrorResponse ('E'), not a dead socket
+            harness.clientSide.soTimeout = 5000
+            val firstByte = harness.clientSide.getInputStream().read()
+            assertEquals('E'.code, firstByte)
+
+            // The session must terminate
+            harness.handler.join(5000)
+            assertFalse(harness.handler.isAlive)
+
+            // Nothing must have been forwarded to the target database
+            assertEquals(-1, harness.readByteForwardedUpstream())
+
+            // The blocked message must not produce an audit event, only executed queries are audited
+            assertTrue(harness.eventService.queries.isEmpty())
+        }
+    }
+
+    @Test
+    fun `a partially delivered message is buffered and only forwarded once it is complete`() {
+        RelayHarness(executionRequestAdapter, eventAdapter).use { harness ->
+            val queryBytes = "SELECT 1;".toByteArray() + byteArrayOf(0)
+            val message = ByteBuffer.allocate(5 + queryBytes.size)
+            message.put('Q'.code.toByte())
+            message.putInt(4 + queryBytes.size)
+            message.put(queryBytes)
+            val bytes = message.array()
+
+            // A message arriving in pieces is normal TCP behavior, not a protocol violation:
+            // nothing may reach the server (or the audit log) until the message is complete
+            harness.sendToProxy(bytes.copyOfRange(0, 5))
+            assertEquals(-1, harness.readByteForwardedUpstream())
+            assertTrue(harness.eventService.queries.isEmpty())
+
+            harness.sendToProxy(bytes.copyOfRange(5, bytes.size))
+            val forwarded = ByteArray(bytes.size)
+            harness.upstreamSide.soTimeout = 5000
+            var readTotal = 0
+            while (readTotal < bytes.size) {
+                val read = harness.upstreamSide.getInputStream().read(forwarded, readTotal, bytes.size - readTotal)
+                assertTrue(read > 0, "The completed message never arrived at the target database")
+                readTotal += read
+            }
+            assertTrue(bytes.contentEquals(forwarded))
+            harness.eventService.assertQueryIsAudited("SELECT 1;")
+
+            // A client disconnect must end the session even without a Terminate message
+            harness.clientSide.close()
+            harness.handler.join(5000)
+            assertFalse(harness.handler.isAlive)
         }
     }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyRelayRobustnessTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyRelayRobustnessTest.kt
@@ -1,0 +1,195 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.db.EventAdapter
+import dev.kviklet.kviklet.db.ExecutionRequestAdapter
+import dev.kviklet.kviklet.proxy.helpers.ProxyInstance
+import dev.kviklet.kviklet.proxy.helpers.directConnectionFactory
+import dev.kviklet.kviklet.proxy.helpers.proxyServerFactory
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.postgresql.core.PGStream
+import org.postgresql.core.QueryExecutorBase
+import org.postgresql.jdbc.PgConnection
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.containers.PostgreSQLContainer
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.util.Properties
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PostgresProxyRelayRobustnessTest {
+    @Autowired
+    lateinit var executionRequestAdapter: ExecutionRequestAdapter
+
+    @Autowired
+    lateinit var eventAdapter: EventAdapter
+    private lateinit var directConnection: Connection
+    private lateinit var proxy: ProxyInstance
+    private lateinit var postgresContainer: PostgreSQLContainer<Nothing>
+
+    @BeforeEach
+    fun setup() {
+        postgresContainer = PostgreSQLContainer<Nothing>("postgres:13").apply {
+            withDatabaseName("testdb")
+            withUsername("test")
+            withPassword("test")
+        }
+        postgresContainer.start()
+        while (!postgresContainer.isRunning) {
+            Thread.sleep(1000)
+        }
+        this.directConnection = directConnectionFactory(postgresContainer)
+        this.proxy = proxyServerFactory(postgresContainer, executionRequestAdapter, eventAdapter)
+        directConnection.createStatement().executeUpdate(
+            "CREATE TABLE IF NOT EXISTS proxy_test_relay (id INTEGER, payload TEXT);",
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        this.proxy.proxy.shutdownServer()
+        // Some tests kill the proxied session on purpose, closing it afterwards may fail
+        runCatching { this.proxy.connection.close() }
+        this.postgresContainer.stop()
+    }
+
+    private fun proxyConnection(): Connection {
+        val props = Properties()
+        props.setProperty("user", "proxyUser")
+        props.setProperty("password", "proxyPassword")
+        return DriverManager.getConnection(this.proxy.connectionString, props)
+    }
+
+    // The pgjdbc API does not expose its socket, but the tests need it to simulate abrupt
+    // disconnects and raw protocol messages, so it is extracted the same way the proxy itself
+    // extracts the upstream socket in TargetPostgresSocketFactory
+    private fun clientSideSocketOf(connection: Connection): Socket {
+        val queryExecutor = connection.unwrap(PgConnection::class.java).queryExecutor as QueryExecutorBase
+        val pgStreamProperty = QueryExecutorBase::class.memberProperties.first { it.name == "pgStream" }
+        pgStreamProperty.isAccessible = true
+        return (pgStreamProperty.get(queryExecutor) as PGStream).socket
+    }
+
+    private fun awaitConnectionCount(expected: Int, timeoutMillis: Long = 15_000) {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+        while (System.currentTimeMillis() < deadline && proxy.proxy.currentConnections != expected) {
+            Thread.sleep(100)
+        }
+        assertEquals(
+            expected,
+            proxy.proxy.currentConnections,
+            "Expected the proxy to be handling $expected connection(s)",
+        )
+    }
+
+    @Test
+    fun `simple queries larger than the socket read buffer are executed and audited`() {
+        // A query above 8KB never arrives in a single socket read and must be reassembled
+        val payload = "x".repeat(20_000) + "-end-marker"
+        val connection = proxyConnection()
+        connection.createStatement().executeUpdate(
+            "INSERT INTO proxy_test_relay(id, payload) VALUES (1, '$payload');",
+        )
+        connection.close()
+
+        val result = directConnection.createStatement()
+            .executeQuery("SELECT payload FROM proxy_test_relay WHERE id = 1;")
+        assertTrue(result.next())
+        assertEquals(payload, result.getString("payload"))
+
+        this.proxy.eventService.assertAuditedQueryContains("-end-marker")
+    }
+
+    @Test
+    fun `prepared statement parameters larger than the socket read buffer are executed and audited`() {
+        val payload = "y".repeat(20_000) + "-bind-marker"
+        val connection = proxyConnection()
+        val statement = connection.prepareStatement("INSERT INTO proxy_test_relay(id, payload) VALUES (?, ?)")
+        statement.setInt(1, 2)
+        statement.setString(2, payload)
+        assertEquals(1, statement.executeUpdate())
+        connection.close()
+
+        val result = directConnection.createStatement()
+            .executeQuery("SELECT payload FROM proxy_test_relay WHERE id = 2;")
+        assertTrue(result.next())
+        assertEquals(payload, result.getString("payload"))
+
+        this.proxy.eventService.assertAuditedQueryContains("-bind-marker")
+    }
+
+    @Test
+    fun `a client disconnecting without a terminate message frees the connection slot`() {
+        val baseline = proxy.proxy.currentConnections
+        val connection = proxyConnection()
+        val result = connection.createStatement().executeQuery("SELECT 1;")
+        assertTrue(result.next())
+        awaitConnectionCount(baseline + 1)
+
+        // Closing the socket directly sends no Terminate message, the proxy only sees EOF
+        clientSideSocketOf(connection).close()
+
+        awaitConnectionCount(baseline)
+    }
+
+    @Test
+    fun `the server closing the connection frees the connection slot`() {
+        val connection = proxyConnection()
+        val result = connection.createStatement().executeQuery("SELECT 1;")
+        assertTrue(result.next())
+
+        // Kill every proxied upstream session server-side, the proxy sees EOF from the server
+        directConnection.createStatement().executeQuery(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity " +
+                "WHERE usename = 'test' AND pid <> pg_backend_pid();",
+        )
+
+        awaitConnectionCount(0)
+    }
+
+    @Test
+    fun `fast path function calls are blocked and close the session`() {
+        val baseline = proxy.proxy.currentConnections
+        val connection = proxyConnection()
+        val result = connection.createStatement().executeQuery("SELECT 1;")
+        assertTrue(result.next())
+        awaitConnectionCount(baseline + 1)
+        val auditedBefore = proxy.eventService.rawQueries.size
+
+        // A minimal FunctionCall message: function OID 0, no format codes, no arguments,
+        // text result format. It executes a function server-side without any Query/Parse/Bind,
+        // so the proxy cannot audit it and must reject it.
+        val functionCall = ByteBuffer.allocate(15)
+        functionCall.put('F'.code.toByte())
+        functionCall.putInt(14)
+        functionCall.putInt(0)
+        functionCall.putShort(0)
+        functionCall.putShort(0)
+        functionCall.putShort(0)
+        val socket = clientSideSocketOf(connection)
+        socket.getOutputStream().apply {
+            write(functionCall.array())
+            flush()
+        }
+
+        // The proxy must abort the session without forwarding the call, freeing the slot
+        awaitConnectionCount(baseline)
+        assertEquals(auditedBefore, proxy.eventService.rawQueries.size)
+        assertThrows<SQLException> {
+            connection.createStatement().executeQuery("SELECT 1;")
+        }
+    }
+}


### PR DESCRIPTION
The proxy relay loop previously assumed every socket read contains a whole number of protocol messages, never noticed a closed peer, and forwarded fast-path FunctionCall messages without auditing them. This PR fixes all three:

- **Message reassembly**: a new `MessageFramer` accumulates raw socket chunks and only yields complete wire-protocol messages. Queries or parameters larger than the 8KB read buffer (or simply split across TCP reads) previously failed to parse and killed the session; now they are reassembled and audited normally. The framer also validates the declared message length (minimum 4, maximum the 1GB protocol limit) before any allocation happens.
- **EOF handling**: `read()` returning -1 now ends the relay loop. Previously a client disconnecting without a Terminate message (or the server closing the connection) left the session thread spinning forever, permanently occupying one of the 15 connection slots.
- **Fast-path FunctionCall rejection**: `'F'` messages execute a server-side function without any Query/Parse/Bind, so they cannot be audited. They are now blocked fail-closed: the client gets an error response and the session is closed.

Covered by a new unit suite (`PostgresProxyFramingTest`) for the framing and EOF logic, and a new Testcontainers suite (`PostgresProxyRelayRobustnessTest`) for >8KB simple queries and prepared-statement parameters, abrupt client disconnects, server-side backend termination, and FunctionCall rejection.