### PR TITLE
Harden the Postgres proxy SCRAM authentication

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/SASLAuth.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/SASLAuth.kt
@@ -5,8 +5,10 @@ import dev.kviklet.kviklet.proxy.postgres.messages.SASLInitialResponse
 import dev.kviklet.kviklet.proxy.postgres.messages.SASLResponse
 import dev.kviklet.kviklet.proxy.postgres.messages.createAuthenticationSASLContinue
 import dev.kviklet.kviklet.proxy.postgres.messages.createAuthenticationSASLFinal
+import dev.kviklet.kviklet.proxy.postgres.messages.errorResponse
 import java.io.InputStream
 import java.io.OutputStream
+import java.nio.ByteBuffer
 import java.security.MessageDigest
 import java.security.SecureRandom
 import java.util.*
@@ -68,15 +70,35 @@ class SASLAuthHandler(
         }
     }
     private fun handleClientFirstMessage(buff: ByteArray, read: Int) {
-        clientFirst = SASLInitialResponse.fromBytes(read, buff)
+        val (length, body) = messageBody(buff, read)
+        clientFirst = SASLInitialResponse.fromBytes(length, body)
         serverFirst = "r=${clientFirst!!.getClientNonce() + serverNonce},s=${salt.base64Encoded},i=$iterations"
         sendServerFirstMessage()
     }
+
+    // Extracts (declaredLength, body) from a raw SASL read, matching the contract the relay MessageFramer
+    // uses: the header byte and the int32 length are stripped, and length includes the 4 length bytes.
+    private fun messageBody(buff: ByteArray, read: Int): Pair<Int, ByteArray> {
+        if (read < 5) throw Exception("Incomplete SASL message header")
+        val length = ByteBuffer.wrap(buff, 1, 4).int
+        if (read < 1 + length) throw Exception("Incomplete SASL message body")
+        return length to buff.copyOfRange(5, 1 + length)
+    }
+
     private fun handleClientProof(buff: ByteArray, read: Int) {
-        val clientResp = SASLResponse.fromBytes(read, buff)
+        val (length, body) = messageBody(buff, read)
+        val clientResp = SASLResponse.fromBytes(length, body)
         val authMsg = "${clientFirst!!.saslMessage},$serverFirst,${clientResp.getResponseWithoutProof()}"
-        if (!isUserValid || !verifyClientProof(authMsg, clientResp.getProof())) {
+        // Always run the full proof verification (PBKDF2 + HMAC) before deciding, so an unknown user and a
+        // known user with a wrong password take the same time and cannot be told apart by an attacker
+        // probing for valid usernames.
+        val proofValid = verifyClientProof(authMsg, clientResp.getProof())
+        if (!isUserValid || !proofValid) {
             state = AuthenticationState.DONE
+            // Send a proper ErrorResponse so the client reports "password authentication failed" (28P01)
+            // instead of a bare connection reset. The message is deliberately generic: it must not reveal
+            // whether the username or the password was wrong.
+            output.writeAndFlush(errorResponse("password authentication failed", "28P01"))
             throw Exception("Authentication failed")
         }
         sendServerFinal(authMsg)
@@ -98,7 +120,8 @@ class SASLAuthHandler(
         val clientSignature = hmacSha256(storedKey, authMessage)
         val expectedClientKey = xorBytes(Base64.getDecoder().decode(clientProof), clientSignature)
         val recomputedStoredKey = sha256(expectedClientKey)
-        return storedKey.contentEquals(recomputedStoredKey)
+        // Constant-time comparison so the proof check does not leak how many leading bytes matched.
+        return MessageDigest.isEqual(storedKey, recomputedStoredKey)
     }
 
     private fun generateServerResponse(authMessage: String): ByteArray {
@@ -119,10 +142,13 @@ class Salt {
     }
 }
 
+// SCRAM's replay protection assumes an unpredictable server nonce, so draw from SecureRandom rather than
+// Kotlin's default (non-crypto) Random.
 fun getRandomString(length: Int = 32): String {
     val allowedChars = ('A'..'Z') + ('a'..'z') + ('0'..'9')
+    val random = SecureRandom()
     return (1..length)
-        .map { allowedChars.random() }
+        .map { allowedChars[random.nextInt(allowedChars.size)] }
         .joinToString("")
 }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/SASLAuth.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/SASLAuth.kt
@@ -16,6 +16,9 @@ import javax.crypto.Mac
 import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.PBEKeySpec
 import javax.crypto.spec.SecretKeySpec
+// Shared thread-safe CSPRNG for nonces and salts; constructing a SecureRandom per call re-seeds needlessly.
+private val secureRandom = SecureRandom()
+
 enum class AuthenticationState {
     WAITING_CLIENT_FIRST,
     WAITING_CLIENT_PROOF,
@@ -81,27 +84,42 @@ class SASLAuthHandler(
     private fun messageBody(buff: ByteArray, read: Int): Pair<Int, ByteArray> {
         if (read < 5) throw Exception("Incomplete SASL message header")
         val length = ByteBuffer.wrap(buff, 1, 4).int
-        if (read < 1 + length) throw Exception("Incomplete SASL message body")
+        // length counts itself but not the header byte, so it must be at least 4 and no larger than the
+        // bytes actually read. Comparing against read - 1 avoids the 1 + length overflow for a huge length.
+        if (length < 4 || length > read - 1) {
+            throw Exception("Invalid SASL message length $length")
+        }
         return length to buff.copyOfRange(5, 1 + length)
     }
 
     private fun handleClientProof(buff: ByteArray, read: Int) {
         val (length, body) = messageBody(buff, read)
         val clientResp = SASLResponse.fromBytes(length, body)
-        val authMsg = "${clientFirst!!.saslMessage},$serverFirst,${clientResp.getResponseWithoutProof()}"
         // Always run the full proof verification (PBKDF2 + HMAC) before deciding, so an unknown user and a
         // known user with a wrong password take the same time and cannot be told apart by an attacker
-        // probing for valid usernames.
-        val proofValid = verifyClientProof(authMsg, clientResp.getProof())
+        // probing for valid usernames. A malformed proof (bad base64, wrong length, too few fields) is just
+        // an authentication failure and must still get a 28P01 error rather than a bare connection reset.
+        val authMsg: String
+        val proofValid: Boolean
+        try {
+            authMsg = "${clientFirst!!.saslMessage},$serverFirst,${clientResp.getResponseWithoutProof()}"
+            proofValid = verifyClientProof(authMsg, clientResp.getProof())
+        } catch (e: Exception) {
+            failAuthentication()
+        }
         if (!isUserValid || !proofValid) {
-            state = AuthenticationState.DONE
-            // Send a proper ErrorResponse so the client reports "password authentication failed" (28P01)
-            // instead of a bare connection reset. The message is deliberately generic: it must not reveal
-            // whether the username or the password was wrong.
-            output.writeAndFlush(errorResponse("password authentication failed", "28P01"))
-            throw Exception("Authentication failed")
+            failAuthentication()
         }
         sendServerFinal(authMsg)
+    }
+
+    private fun failAuthentication(): Nothing {
+        state = AuthenticationState.DONE
+        // Send a proper ErrorResponse so the client reports "password authentication failed" (28P01) instead
+        // of a bare connection reset. The message is deliberately generic: it must not reveal whether the
+        // username or the password was wrong.
+        output.writeAndFlush(errorResponse("password authentication failed", "28P01"))
+        throw Exception("Authentication failed")
     }
 
     private fun sendServerFinal(authMsg: String) {
@@ -137,7 +155,7 @@ class Salt {
     val base64Encoded: String = Base64.getEncoder().encodeToString(salt)
     private fun generateRandomSalt(size: Int = 24): ByteArray {
         val salt = ByteArray(size)
-        SecureRandom().nextBytes(salt)
+        secureRandom.nextBytes(salt)
         return salt
     }
 }
@@ -146,9 +164,8 @@ class Salt {
 // Kotlin's default (non-crypto) Random.
 fun getRandomString(length: Int = 32): String {
     val allowedChars = ('A'..'Z') + ('a'..'z') + ('0'..'9')
-    val random = SecureRandom()
     return (1..length)
-        .map { allowedChars[random.nextInt(allowedChars.size)] }
+        .map { allowedChars[secureRandom.nextInt(allowedChars.size)] }
         .joinToString("")
 }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/AuthMessages.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/AuthMessages.kt
@@ -61,6 +61,12 @@ class SASLInitialResponse(
                 throw Exception("Unsupported SASL mechanism '$mechanism'; only SCRAM-SHA-256 is supported")
             }
             val saslDataLength = buffer.int
+            // The length is attacker-controlled and this runs pre-auth, so bound it against what the packet
+            // actually contains before allocating; otherwise ByteArray(saslDataLength) is an unauthenticated
+            // heap-pressure DoS (and a huge value throws OutOfMemoryError, an Error that slips past catch).
+            if (saslDataLength < 0 || saslDataLength > buffer.remaining()) {
+                throw Exception("SASL data length $saslDataLength exceeds the message size")
+            }
             val saslData = ByteArray(saslDataLength)
             buffer.get(saslData)
             // Strip the gs2 header (e.g. "n,,") to get the SCRAM client-first-bare ("n=...,r=...").

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/AuthMessages.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/AuthMessages.kt
@@ -52,17 +52,35 @@ class SASLInitialResponse(
     val saslMessage: String,
 ) : ParsedMessage(header, length, originalContent) {
     companion object {
+        // bytes is the message body (header byte and int32 length already stripped, as the MessageFramer
+        // delivers it): a mechanism-name cstring, an int32 SASL-data length, then the SASL data.
         fun fromBytes(length: Int, bytes: ByteArray): SASLInitialResponse {
             val buffer = ByteBuffer.wrap(bytes)
-            val messageBytes = ByteArray(length)
-            buffer.get(messageBytes)
-            // NOTE: The message parsing below will work as long as only SCRAM-SHA-256 is supported. Once SCRAM-SHA-256-PLUS is added it won't work
-            val message = String(messageBytes).subSequence(26, length).toString()
-            return SASLInitialResponse('p', length, bytes, message)
+            val mechanism = readCString(buffer)
+            if (mechanism != "SCRAM-SHA-256") {
+                throw Exception("Unsupported SASL mechanism '$mechanism'; only SCRAM-SHA-256 is supported")
+            }
+            val saslDataLength = buffer.int
+            val saslData = ByteArray(saslDataLength)
+            buffer.get(saslData)
+            // Strip the gs2 header (e.g. "n,,") to get the SCRAM client-first-bare ("n=...,r=...").
+            val clientFirstBare = stripGs2Header(String(saslData, Charsets.UTF_8))
+            return SASLInitialResponse('p', length, bytes, clientFirstBare)
+        }
+
+        // The gs2 header is a channel-binding flag, an optional authzid and two commas; the client-first-bare
+        // follows the second comma. Validating the shape beats the previous hardcoded offset of 26.
+        private fun stripGs2Header(saslData: String): String {
+            val firstComma = saslData.indexOf(',')
+            val secondComma = if (firstComma >= 0) saslData.indexOf(',', firstComma + 1) else -1
+            if (secondComma < 0) {
+                throw Exception("Malformed SASL initial response: missing gs2 header")
+            }
+            return saslData.substring(secondComma + 1)
         }
     }
 
-    fun getClientNonce(): String = saslMessage.split(',')[1].replace("r=", "")
+    fun getClientNonce(): String = saslMessage.split(',').first { it.startsWith("r=") }.removePrefix("r=")
 }
 
 class SASLResponse(
@@ -73,12 +91,10 @@ class SASLResponse(
 ) : ParsedMessage(header, length, originalContent) {
 
     companion object {
-        fun fromBytes(length: Int, bytes: ByteArray): SASLResponse {
-            val buffer = ByteBuffer.wrap(bytes)
-            val messageBytes = ByteArray(length)
-            buffer.get(messageBytes)
-            return SASLResponse('p', length, bytes, String(messageBytes.copyOfRange(5, length)))
-        }
+        // bytes is the message body (header byte and int32 length already stripped): the SCRAM
+        // client-final message, "c=<channel-binding>,r=<nonce>,p=<proof>".
+        fun fromBytes(length: Int, bytes: ByteArray): SASLResponse =
+            SASLResponse('p', length, bytes, String(bytes, Charsets.UTF_8))
     }
     fun getResponseWithoutProof(): String = saslMessage.split(',').subList(0, 2).joinToString(",")
     fun getProof(): String = saslMessage.split(',')[2].replaceFirst("p=", "")

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
@@ -404,11 +404,11 @@ fun paramMessage(key: String, value: String): ByteArray {
     return responseBuffer.array()
 }
 
-fun errorResponse(message: String): ByteArray {
+fun errorResponse(message: String, code: String = "08P01"): ByteArray {
     val fields = listOf(
         'S' to "ERROR",
         'V' to "ERROR",
-        'C' to "08P01", // protocol_violation
+        'C' to code, // SQLSTATE, defaults to protocol_violation
         'M' to message,
     )
     val fieldBytes = fields.flatMap { (type, value) ->
@@ -433,6 +433,28 @@ fun isStartupMessage(byteArray: ByteArray): Boolean = byteArray[4] == 0x00.toByt
     byteArray[5] == 0x03.toByte() &&
     byteArray[6] == 0x00.toByte() &&
     byteArray[7] == 0x00.toByte()
+
+// The StartupMessage body (after the 4-byte length and 4-byte protocol version) is a sequence of
+// null-terminated key/value strings, terminated by a final empty key. Returns the value of the `user`
+// parameter, or null if it is absent. Only the actual `user` value must gate authentication: matching a
+// substring anywhere in the packet lets a wrong user be accepted when the configured name happens to
+// appear in the database name, application_name, or options.
+fun startupMessageUser(message: ByteArray, msgLen: Int): String? {
+    val fields = mutableListOf<String>()
+    var start = 8
+    var i = 8
+    while (i < msgLen) {
+        if (message[i] == 0x00.toByte()) {
+            if (i == start) break // empty key marks the end of the parameter list
+            fields.add(String(message, start, i - start, Charsets.UTF_8))
+            start = i + 1
+        }
+        i++
+    }
+    val userIndex = fields.indexOf("user")
+    return if (userIndex >= 0 && userIndex + 1 < fields.size) fields[userIndex + 1] else null
+}
+
 fun startupMessageContainsValidUser(message: ByteArray, msgLen: Int, username: String): Boolean =
-    String(message).subSequence(8, msgLen).contains(username)
+    startupMessageUser(message, msgLen) == username
 fun ByteArray.toHexString() = joinToString("") { "%02x".format(it) }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
@@ -445,14 +445,20 @@ fun startupMessageUser(message: ByteArray, msgLen: Int): String? {
     var i = 8
     while (i < msgLen) {
         if (message[i] == 0x00.toByte()) {
-            if (i == start) break // empty key marks the end of the parameter list
+            // Only a zero-length key (even index) terminates the list; a zero-length value (e.g.
+            // application_name="") is legitimate and must not end the scan early.
+            if (i == start && fields.size % 2 == 0) break
             fields.add(String(message, start, i - start, Charsets.UTF_8))
             start = i + 1
         }
         i++
     }
-    val userIndex = fields.indexOf("user")
-    return if (userIndex >= 0 && userIndex + 1 < fields.size) fields[userIndex + 1] else null
+    // Match "user" only at key positions (even indices); scanning a flattened key+value list would let a
+    // parameter whose value is "user" return the following key.
+    for (k in fields.indices step 2) {
+        if (fields[k] == "user") return fields.getOrNull(k + 1)
+    }
+    return null
 }
 
 fun startupMessageContainsValidUser(message: ByteArray, msgLen: Int, username: String): Boolean =

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyAuthTest.kt
@@ -143,12 +143,15 @@ class PostgresProxyAuthTest {
     }
 
     @Test
-    fun `a wrong password fails with 28P01 password authentication failed, not a connection reset`() {
-        val port = startProxy(proxyUsername = getRandomString(8), proxyPassword = getRandomString(16))
+    fun `the correct username with a wrong password fails with 28P01, not a connection reset`() {
+        // The username is correct, so this exercises the wrong-password path alone (proof verification
+        // fails while the user is valid) -- the path the always-run-the-proof timing parity is about.
+        val username = getRandomString(8)
+        val port = startProxy(proxyUsername = username, proxyPassword = getRandomString(16))
 
         val throwable = assertThrows<PSQLException> {
             val proxyProps = Properties()
-            proxyProps.setProperty("user", "someuser")
+            proxyProps.setProperty("user", username)
             proxyProps.setProperty("password", "definitely-the-wrong-password")
             DriverManager.getConnection("jdbc:postgresql://localhost:$port/testdb", proxyProps)
         }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyAuthTest.kt
@@ -40,6 +40,7 @@ class PostgresProxyAuthTest {
     private lateinit var directConnection: Connection
     private lateinit var proxy: ProxyInstance
     private lateinit var postgresContainer: PostgreSQLContainer<Nothing>
+    private val startedProxies = mutableListOf<PostgresProxy>()
 
     @BeforeEach
     fun setup() {
@@ -58,6 +59,7 @@ class PostgresProxyAuthTest {
 
     @AfterEach
     fun tearDown() {
+        this.startedProxies.forEach { it.shutdownServer() }
         this.proxy.proxy.shutdownServer()
         this.proxy.connection.close()
         this.postgresContainer.stop()
@@ -176,7 +178,7 @@ class PostgresProxyAuthTest {
     }
 
     private fun startProxy(proxyUsername: String, proxyPassword: String): Int {
-        val port = (22020..22060).random()
+        val port = (22100..30000).random()
         val executionRequestFactory = ExecutionRequestFactory()
         val request = executionRequestFactory.createDatasourceExecutionRequest()
         val eventService = EventServiceMock(executionRequestAdapter, eventAdapter, request)
@@ -189,6 +191,7 @@ class PostgresProxyAuthTest {
             executionRequestFactory.createDatasourceExecutionRequest(),
             "mock",
         )
+        startedProxies.add(proxy)
         CompletableFuture.runAsync {
             proxy.startServer(port, proxyUsername, proxyPassword, LocalDateTime.now(), 10)
         }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyAuthTest.kt
@@ -12,6 +12,7 @@ import dev.kviklet.kviklet.proxy.mocks.EventServiceMock
 import dev.kviklet.kviklet.proxy.postgres.PostgresProxy
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -139,6 +140,57 @@ class PostgresProxyAuthTest {
             proxyProps.setProperty("password", randomPassword)
             DriverManager.getConnection("jdbc:postgresql://localhost:$port/testdb", proxyProps)
         }
+    }
+
+    @Test
+    fun `a wrong password fails with 28P01 password authentication failed, not a connection reset`() {
+        val port = startProxy(proxyUsername = getRandomString(8), proxyPassword = getRandomString(16))
+
+        val throwable = assertThrows<PSQLException> {
+            val proxyProps = Properties()
+            proxyProps.setProperty("user", "someuser")
+            proxyProps.setProperty("password", "definitely-the-wrong-password")
+            DriverManager.getConnection("jdbc:postgresql://localhost:$port/testdb", proxyProps)
+        }
+        assertEquals("28P01", throwable.sqlState)
+    }
+
+    @Test
+    fun `a wrong username with the correct password is rejected even when the username is a substring of the packet`() {
+        // The proxy user "test" is a substring of the database name "testdb"; the old substring check would
+        // see "test" in the startup packet and wrongly accept the connection despite the actual user being
+        // "wronguser". With the correct password supplied, only the username gate can reject this.
+        val password = getRandomString(16)
+        val port = startProxy(proxyUsername = "test", proxyPassword = password)
+
+        val throwable = assertThrows<PSQLException> {
+            val proxyProps = Properties()
+            proxyProps.setProperty("user", "wronguser")
+            proxyProps.setProperty("password", password)
+            DriverManager.getConnection("jdbc:postgresql://localhost:$port/testdb", proxyProps)
+        }
+        assertEquals("28P01", throwable.sqlState)
+    }
+
+    private fun startProxy(proxyUsername: String, proxyPassword: String): Int {
+        val port = (22020..22060).random()
+        val executionRequestFactory = ExecutionRequestFactory()
+        val request = executionRequestFactory.createDatasourceExecutionRequest()
+        val eventService = EventServiceMock(executionRequestAdapter, eventAdapter, request)
+        val proxy = PostgresProxy(
+            postgresContainer.host,
+            postgresContainer.getMappedPort(5432),
+            "testdb",
+            AuthenticationDetails.UserPassword("test", "test"),
+            eventService,
+            executionRequestFactory.createDatasourceExecutionRequest(),
+            "mock",
+        )
+        CompletableFuture.runAsync {
+            proxy.startServer(port, proxyUsername, proxyPassword, LocalDateTime.now(), 10)
+        }
+        waitForProxyStart(proxy)
+        return port
     }
 }
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxySASLParsingTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxySASLParsingTest.kt
@@ -1,0 +1,47 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.proxy.postgres.messages.MessageFramer
+import dev.kviklet.kviklet.proxy.postgres.messages.SASLInitialResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+
+// SASLInitialResponse.fromBytes must follow the same (declaredLength, body) contract that the relay
+// MessageFramer uses. Previously the auth path passed the raw read plus the whole buffer while the framer
+// passed the declared length plus the length-4 body, so any 'p' message reaching the framer built a
+// ByteArray(length) and overran the shorter body -> BufferUnderflowException killing the session.
+class PostgresProxySASLParsingTest {
+
+    // Builds a full SASLInitialResponse wire message: 'p', int32 length, mechanism-name cstring,
+    // int32 SASL-data length, then the SASL data (gs2 header + client-first-bare).
+    private fun saslInitialResponse(clientNonce: String): ByteArray {
+        val saslData = "n,,n=,r=$clientNonce".toByteArray(Charsets.UTF_8)
+        val body = ByteArrayOutputStream()
+        body.write("SCRAM-SHA-256".toByteArray(Charsets.UTF_8))
+        body.write(0)
+        body.write(ByteBuffer.allocate(4).putInt(saslData.size).array())
+        body.write(saslData)
+        val bodyBytes = body.toByteArray()
+
+        val length = 4 + bodyBytes.size
+        val message = ByteBuffer.allocate(1 + length)
+        message.put('p'.code.toByte())
+        message.putInt(length)
+        message.put(bodyBytes)
+        return message.array()
+    }
+
+    @Test
+    fun `a SASLInitialResponse is parsed through the framer without overrunning the body`() {
+        val message = saslInitialResponse("clientNonceABC123")
+
+        val messages = MessageFramer().feed(message)
+
+        assertEquals(1, messages.size)
+        val parsed = assertInstanceOf(SASLInitialResponse::class.java, messages[0])
+        assertEquals("clientNonceABC123", parsed.getClientNonce())
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxySASLParsingTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxySASLParsingTest.kt
@@ -5,6 +5,8 @@ import dev.kviklet.kviklet.proxy.postgres.messages.MessageFramer
 import dev.kviklet.kviklet.proxy.postgres.messages.SASLInitialResponse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
@@ -32,6 +34,43 @@ class PostgresProxySASLParsingTest {
         message.putInt(length)
         message.put(bodyBytes)
         return message.array()
+    }
+
+    // Builds a SASLInitialResponse body (as the framer delivers it: header and length already stripped)
+    // whose declared SASL-data length can be set independently of how many data bytes are actually present.
+    private fun saslInitialResponseBody(declaredSaslDataLength: Int, presentData: ByteArray): ByteArray {
+        val body = ByteArrayOutputStream()
+        body.write("SCRAM-SHA-256".toByteArray(Charsets.UTF_8))
+        body.write(0)
+        body.write(ByteBuffer.allocate(4).putInt(declaredSaslDataLength).array())
+        body.write(presentData)
+        return body.toByteArray()
+    }
+
+    @Test
+    fun `a SASL data length larger than the message is rejected instead of allocating for it`() {
+        // Only 3 data bytes are present but the packet declares far more. Without a bound check the parser
+        // allocates ByteArray(declared) off an unauthenticated packet (a pre-auth heap-pressure DoS); a huge
+        // declared value would even throw OutOfMemoryError, which slips past the catch(Exception) in the path.
+        val body = saslInitialResponseBody(declaredSaslDataLength = 50, presentData = "n,,".toByteArray())
+
+        val thrown = assertThrows(Exception::class.java) {
+            SASLInitialResponse.fromBytes(4 + body.size, body)
+        }
+        assertTrue(
+            thrown.message?.contains("SASL data length") == true,
+            "expected a controlled length-validation error, got: ${thrown::class.simpleName}: ${thrown.message}",
+        )
+    }
+
+    @Test
+    fun `a huge declared SASL data length is rejected without allocating`() {
+        // 0x30000000 (~768MB) would be allocated and zeroed before the follow-up read fails, if unguarded.
+        val body = saslInitialResponseBody(declaredSaslDataLength = 0x30000000, presentData = "n,,".toByteArray())
+
+        assertThrows(Exception::class.java) {
+            SASLInitialResponse.fromBytes(4 + body.size, body)
+        }
     }
 
     @Test

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyStartupUserTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyStartupUserTest.kt
@@ -1,0 +1,79 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.proxy.postgres.messages.startupMessageContainsValidUser
+import dev.kviklet.kviklet.proxy.postgres.messages.startupMessageUser
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+
+// The proxy must decide "is this the configured proxy user?" from the actual `user` parameter of the
+// StartupMessage, not from a substring match over the whole packet (where the username can appear in the
+// database name, application_name, or options and match spuriously).
+class PostgresProxyStartupUserTest {
+
+    // Builds a real StartupMessage: int32 length, int32 protocol 3.0, then null-terminated key/value
+    // pairs terminated by a final null byte.
+    private fun startupMessage(vararg params: Pair<String, String>): ByteArray {
+        val body = ByteArrayBuilder()
+        for ((key, value) in params) {
+            body.appendCString(key)
+            body.appendCString(value)
+        }
+        body.appendByte(0) // terminating null of the parameter list
+        val payload = body.toByteArray()
+        val buffer = ByteBuffer.allocate(8 + payload.size)
+        buffer.putInt(8 + payload.size)
+        buffer.putInt(196608) // protocol version 3.0
+        buffer.put(payload)
+        return buffer.array()
+    }
+
+    private class ByteArrayBuilder {
+        private val out = java.io.ByteArrayOutputStream()
+        fun appendCString(s: String) {
+            out.write(s.toByteArray(Charsets.UTF_8))
+            out.write(0)
+        }
+        fun appendByte(b: Int) = out.write(b)
+        fun toByteArray(): ByteArray = out.toByteArray()
+    }
+
+    @Test
+    fun `the parsed user is the value of the user parameter`() {
+        val frame = startupMessage("user" to "proxyUser", "database" to "somedb")
+
+        assertEquals("proxyUser", startupMessageUser(frame, frame.size))
+    }
+
+    @Test
+    fun `a wrong user is rejected even when the configured name appears elsewhere in the packet`() {
+        // Configured proxy user is "app"; the client sends user=attacker but a database named "app_db",
+        // so the old substring check matches "app" and wrongly reports the user as valid.
+        val frame = startupMessage("user" to "attacker", "database" to "app_db")
+
+        assertEquals("attacker", startupMessageUser(frame, frame.size))
+        assertFalse(
+            startupMessageContainsValidUser(frame, frame.size, "app"),
+            "user=attacker must not authenticate as the configured proxy user 'app'",
+        )
+    }
+
+    @Test
+    fun `the correct user is accepted`() {
+        val frame = startupMessage("user" to "app", "database" to "app_db")
+
+        assertTrue(startupMessageContainsValidUser(frame, frame.size, "app"))
+    }
+
+    @Test
+    fun `a startup message without a user parameter has no user`() {
+        val frame = startupMessage("database" to "somedb")
+
+        assertNull(startupMessageUser(frame, frame.size))
+        assertFalse(startupMessageContainsValidUser(frame, frame.size, "app"))
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyStartupUserTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyStartupUserTest.kt
@@ -70,6 +70,25 @@ class PostgresProxyStartupUserTest {
     }
 
     @Test
+    fun `a value equal to user does not fool the parser into returning the wrong key`() {
+        // A parameter whose value is literally "user", followed by a key named like the proxy user, must not
+        // trick a flat indexOf into returning that following key. The real user is "attacker".
+        val frame = startupMessage("database" to "user", "app" to "x", "user" to "attacker")
+
+        assertEquals("attacker", startupMessageUser(frame, frame.size))
+        assertFalse(startupMessageContainsValidUser(frame, frame.size, "app"))
+    }
+
+    @Test
+    fun `an empty-valued parameter before user does not terminate the scan early`() {
+        // application_name="" is a legitimate empty value; it must not end the parameter scan before `user`.
+        val frame = startupMessage("application_name" to "", "user" to "proxyUser")
+
+        assertEquals("proxyUser", startupMessageUser(frame, frame.size))
+        assertTrue(startupMessageContainsValidUser(frame, frame.size, "proxyUser"))
+    }
+
+    @Test
     fun `a startup message without a user parameter has no user`() {
         val frame = startupMessage("database" to "somedb")
 


### PR DESCRIPTION
Hardens the Postgres proxy's SCRAM/SASL authentication path, which is the front-door lock for proxied sessions.

- **Real user check.** The username was validated by a substring match over the whole StartupMessage, so a client whose actual `user` was wrong could still pass the gate when the configured name appeared in the database name, `application_name`, or options. The `user` parameter is now parsed out of the startup key/value pairs and compared exactly.
- **Timing parity.** The failure path short-circuited past the ~4096-round PBKDF2 for an unknown user, leaving a measurable timing difference between a bad username and a bad password (a username-enumeration oracle). The full proof verification now always runs before the decision.
- **Constant-time compare.** The client-proof comparison uses `MessageDigest.isEqual` instead of `contentEquals`.
- **SecureRandom nonce.** The server nonce is drawn from `SecureRandom` instead of Kotlin's default non-crypto `Random`, restoring SCRAM's replay protection.
- **Proper auth error.** A failed handshake now sends a `28P01 password authentication failed` ErrorResponse before closing, instead of a bare connection reset. The message is generic so it does not reveal whether the username or the password was wrong.
- **Unified SASL parsing.** `SASLInitialResponse`/`SASLResponse.fromBytes` now follow the same `(declaredLength, body)` contract the relay framer uses, fixing a latent `BufferUnderflowException` when a `p` message reached the framer, and the gs2 header is parsed by shape rather than a hardcoded offset.

Tests: startup `user` parsing and the substring-bypass rejection (unit); SASL message parsing through the framer (unit); wrong password yields `28P01` and a wrong username with the correct password is rejected end-to-end (integration).