### PR TITLE
Switch the Postgres proxy relay to a blocking thread-per-direction model

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
-import java.net.SocketTimeoutException
 
 class Connection(
     private val clientSocket: Socket,
@@ -33,6 +32,12 @@ class Connection(
     private var clientOutput: OutputStream = clientSocket.getOutputStream()
     private var serverInput: InputStream = targetSocket.getInputStream()
     private var serverOutput: OutputStream = targetSocket.getOutputStream()
+
+    // clientOutput has two writers once the relay runs on two threads: the server->client pump (normal
+    // server bytes) and the client->server thread's abortSession (an injected ErrorResponse). Without a
+    // lock those two could interleave and corrupt a frame on the wire. serverOutput has a single writer
+    // (the client->server thread) so it needs no lock.
+    private val clientWriteLock = Any()
     private val clientFramer = MessageFramer()
     private val preparedStatements: MutableMap<String, Statement> = mutableMapOf()
     private val portals: MutableMap<String, Portal> = mutableMapOf()
@@ -68,26 +73,58 @@ class Connection(
     }
 
     fun startHandling() {
-        // This basically transfers messages between the client and the server sockets.
+        // Two blocking threads per session. This (pool) thread drives client->server: it frames, audits
+        // and forwards, and it owns all the audit state (framer, prepared statements, portals) so none of
+        // that needs synchronization. A single spawned thread pumps server->client raw. Blocking reads
+        // replace the old 10ms-poll hack, so there is no idle CPU burn and no latency floor.
         // NOTE: At this point the client connection is set up. SSL, Auth etc... are handled in ClientConnectionSetup.kt
         // The finally is the single teardown path for every exit: clean Terminate, client/server EOF,
-        // an aborted session, a parse failure, or an exception. Without it the upstream connection and
-        // both sockets leak for the lifetime of the proxy (KVI-230).
+        // an aborted session, a parse failure, or an exception. It closes both sockets (freeing the
+        // upstream connection, KVI-230) which also unblocks the pump thread, then joins it.
+        val serverToClient = Thread({ pumpServerToClient() }, "pg-proxy-server-to-client")
+        serverToClient.start()
         try {
             while (!terminationMessageReceived && !serverTerminating && !sessionAborted) {
-                val clientOpen = readFromAnyStream(clientInput) { handleClientData(it) }
-                val serverOpen = readFromAnyStream(serverInput) { clientOutput.writeAndFlush(it) }
-                if (!clientOpen || !serverOpen) {
-                    logger.info(
-                        "The {} closed the connection, ending the session",
-                        if (clientOpen) "server" else "client",
-                    )
-                    break
-                }
+                val chunk = try {
+                    readChunk(clientInput)
+                } catch (e: Exception) {
+                    // A read failure during teardown (the socket was closed under us) is expected; only
+                    // an unexpected one is worth surfacing.
+                    if (serverTerminating || sessionAborted) break
+                    throw e
+                } ?: break // client reached EOF
+                handleClientData(chunk)
             }
         } finally {
-            closeSockets()
+            close()
+            serverToClient.join()
         }
+    }
+
+    // Raw server->client relay. No parsing or auditing happens on server responses, so this is a dumb
+    // byte pump. Writes go through clientWriteLock so they cannot interleave with an abort ErrorResponse.
+    private fun pumpServerToClient() {
+        try {
+            while (!serverTerminating) {
+                val chunk = readChunk(serverInput) ?: break // server reached EOF
+                synchronized(clientWriteLock) { clientOutput.writeAndFlush(chunk) }
+            }
+        } catch (e: Exception) {
+            // The client->server thread closing the sockets during teardown unblocks this read with an
+            // exception; that is the normal way this thread ends, so it is not an error.
+            logger.info("Server-to-client relay ended: {}", e.message)
+        } finally {
+            // Closing here unblocks the client->server thread if the server was the side that went away.
+            close()
+        }
+    }
+
+    // Blocking read of one chunk. Returns null at EOF. Throws if the socket is closed mid-read.
+    private fun readChunk(input: InputStream): ByteArray? {
+        val buff = ByteArray(8192)
+        val read = input.read(buff)
+        if (read == -1) return null
+        return buff.copyOfRange(0, read)
     }
 
     private fun handleClientData(clientBuffer: ByteArray) {
@@ -146,8 +183,12 @@ class Connection(
 
     private fun abortSession(reason: String) {
         try {
-            clientOutput.writeAndFlush(errorResponse(reason))
-            clientOutput.writeAndFlush(readyForQuery())
+            // Hold the lock across both writes so a server->client chunk cannot split the ErrorResponse
+            // and ReadyForQuery pair the client expects.
+            synchronized(clientWriteLock) {
+                clientOutput.writeAndFlush(errorResponse(reason))
+                clientOutput.writeAndFlush(readyForQuery())
+            }
         } catch (e: Exception) {
             logger.warn("Failed to send error response to the client while aborting the session", e)
         }
@@ -206,33 +247,3 @@ private class Portal(val statement: Statement) {
 
 private class UnknownStatementException(val name: String) :
     Exception("Client referenced the statement or portal '$name' which the proxy has not seen before")
-
-// Because SSLSocket available method always return zero, the code counts on short read timeout hack
-// Originally this was the case only for the server connections, now it is the case for both the client and the server
-// More info about the hack: https://stackoverflow.com/a/29386157
-// Returns false once the stream has reached EOF and no more data will ever arrive
-fun readFromAnyStream(input: InputStream, onInputAvailable: (input: ByteArray) -> Unit): Boolean {
-    val singleByte = ByteArray(1)
-    val bytesRead: Int = try {
-        input.read(singleByte, 0, 1)
-    } catch (e: SocketTimeoutException) {
-        return true
-    }
-    if (bytesRead == -1) {
-        return false
-    }
-
-    val buff = ByteArray(8192)
-    val read = try {
-        input.read(buff)
-    } catch (e: SocketTimeoutException) {
-        // Only the single polled byte was available before the socket timeout kicked in
-        0
-    }
-    if (read == -1) {
-        onInputAvailable(singleByte)
-        return false
-    }
-    onInputAvailable(singleByte + buff.copyOfRange(0, read))
-    return true
-}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
@@ -40,20 +40,28 @@ class Connection(
     private var serverOutput: OutputStream = targetSocket.getOutputStream()
 
     // clientOutput has two writers once the relay runs on two threads: the server->client pump (normal
-    // server bytes) and the client->server thread's abortSession (an injected ErrorResponse). Without a
-    // lock those two could interleave and corrupt a frame on the wire. serverOutput has a single writer
-    // (the client->server thread) so it needs no lock.
+    // server bytes) and the client->server thread's abortSession (an injected ErrorResponse pair).
+    // The lock serializes them so one write cannot be split by the other, and -- because both the pump's
+    // forward and abortSession's write consult sessionAborted while holding it -- guarantees no server
+    // chunk is forwarded after the abort pair. It does NOT align the abort pair to a server-message
+    // boundary: the proxy does not frame the server->client stream, so a pump chunk (a raw read) can end
+    // mid-message and the abort pair then follows a partial message. That is harmless here because the
+    // session is being torn down; the client errors out either way. serverOutput has a single writer (the
+    // client->server thread) so it needs no lock.
     private val clientWriteLock = Any()
     private val clientFramer = MessageFramer()
     private val preparedStatements: MutableMap<String, Statement> = mutableMapOf()
     private val portals: MutableMap<String, Portal> = mutableMapOf()
     private var terminationMessageReceived: Boolean = false
 
-    // Written by close() on the shutdown thread and read by the relay loop on a pool thread, so it needs
-    // a happens-before edge. terminationMessageReceived and sessionAborted are only ever touched on the
-    // relay thread, so they do not.
+    // Written by close() on the shutdown thread and read by both relay threads, so it needs a
+    // happens-before edge. terminationMessageReceived is only touched on the client->server thread.
     @Volatile
     private var serverTerminating: Boolean = false
+
+    // Set by abortSession on the client->server thread and read by the pump thread; every access happens
+    // under clientWriteLock, which supplies the happens-before edge (so no @Volatile is needed), and also
+    // makes "send the final error pair" and "stop forwarding server bytes" one atomic decision.
     private var sessionAborted: Boolean = false
 
     companion object {
@@ -120,7 +128,12 @@ class Connection(
         try {
             while (!serverTerminating) {
                 val chunk = readChunk(serverInput) ?: break // server reached EOF
-                synchronized(clientWriteLock) { clientOutput.writeAndFlush(chunk) }
+                synchronized(clientWriteLock) {
+                    // If an abort sent the final error pair while this chunk was being read, stop rather
+                    // than forwarding server bytes after the ReadyForQuery the client already saw.
+                    if (sessionAborted) break
+                    clientOutput.writeAndFlush(chunk)
+                }
             }
         } catch (e: Exception) {
             // The client->server thread closing the sockets during teardown unblocks this read with an
@@ -195,17 +208,21 @@ class Connection(
     }
 
     private fun abortSession(reason: String) {
-        try {
-            // Hold the lock across both writes so a server->client chunk cannot split the ErrorResponse
-            // and ReadyForQuery pair the client expects.
-            synchronized(clientWriteLock) {
+        // Hold the lock across both writes and the flag so a server->client chunk cannot split the
+        // ErrorResponse/ReadyForQuery pair, and so the pump (which re-checks sessionAborted under the same
+        // lock) forwards nothing after it. Setting the flag inside the lock is what makes the two atomic.
+        // Edge case left as-is because the session is dying anyway: if the pump is blocked writing to a
+        // client that has stopped reading, it holds the lock and this parks until teardown closes the
+        // socket. Bounded by the access window; only unbounded under INFINITE_ACCESS.
+        synchronized(clientWriteLock) {
+            try {
                 clientOutput.writeAndFlush(errorResponse(reason))
                 clientOutput.writeAndFlush(readyForQuery())
+            } catch (e: Exception) {
+                logger.warn("Failed to send error response to the client while aborting the session", e)
             }
-        } catch (e: Exception) {
-            logger.warn("Failed to send error response to the client while aborting the session", e)
+            sessionAborted = true
         }
-        sessionAborted = true
     }
 
     private fun handleQuery(parsedMessage: QueryMessage) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
@@ -27,6 +27,12 @@ class Connection(
     private val eventService: EventService,
     private val executionRequest: ExecutionRequest,
     private val userId: String,
+    // The raw accepted TCP socket underneath clientSocket. For a TLS client, clientSocket is an
+    // SSLSocket layered over this one with autoClose=false, so closing the SSLSocket leaves this fd (and
+    // the parked blocking read on it) open. Closing the underlying socket is what actually unblocks the
+    // relay threads and frees the fd, so teardown closes this rather than the SSL wrapper. Defaults to
+    // clientSocket for the plain (non-TLS) case, where they are the same socket.
+    private val rawClientSocket: Socket = clientSocket,
 ) {
     private var clientInput: InputStream = clientSocket.getInputStream()
     private var clientOutput: OutputStream = clientSocket.getOutputStream()
@@ -67,8 +73,15 @@ class Connection(
     // Closes both sockets. Closing the upstream socket is what actually frees the target database
     // connection, and closing the client socket unblocks a peer still waiting on it. Idempotent, so it
     // is safe to call from the relay loop's teardown and again from a concurrent shutdown.
+    //
+    // On the client side this closes the raw underlying TCP socket, not the SSLSocket wrapper. For a TLS
+    // client the wrapper is created with autoClose=false, so closing it would leave the underlying fd and
+    // its parked blocking read open (a leaked thread, fd and session per TLS access window). Closing the
+    // underlying socket reliably unblocks both the blocking read and a blocking SSL write; it also avoids
+    // SSLSocket.close(), which can block on the TLS output-record lock the pump holds during a write and
+    // would otherwise wedge shutdownServer() under the proxy monitor.
     private fun closeSockets() {
-        runCatching { if (!clientSocket.isClosed) clientSocket.close() }
+        runCatching { if (!rawClientSocket.isClosed) rawClientSocket.close() }
         runCatching { if (!targetSocket.isClosed) targetSocket.close() }
     }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/PostgresProxy.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/PostgresProxy.kt
@@ -172,8 +172,10 @@ class PostgresProxy(
 
         val clientConnection = try {
             finishClientStartup(authenticatedClient.socket, remotePgConn.getConnProps())
-            authenticatedClient.socket.soTimeout = 10
-            forwardSocket.soTimeout = 10
+            // Blocking relay: no read timeout. Each direction parks in a blocking read until data
+            // arrives or the socket is closed on teardown. (The old 10ms timeouts drove the poll loop.)
+            authenticatedClient.socket.soTimeout = 0
+            forwardSocket.soTimeout = 0
             Connection(authenticatedClient.socket, forwardSocket, eventService, executionRequest, userId)
         } catch (e: Exception) {
             // The upstream is open but the session never started, close it so it is not leaked.

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/PostgresProxy.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/PostgresProxy.kt
@@ -176,7 +176,17 @@ class PostgresProxy(
             // arrives or the socket is closed on teardown. (The old 10ms timeouts drove the poll loop.)
             authenticatedClient.socket.soTimeout = 0
             forwardSocket.soTimeout = 0
-            Connection(authenticatedClient.socket, forwardSocket, eventService, executionRequest, userId)
+            // Pass the raw accepted socket as rawClientSocket: for a TLS client authenticatedClient.socket
+            // is an SSLSocket layered over clientSocket with autoClose=false, and only closing the raw
+            // socket reliably unblocks the relay threads on teardown.
+            Connection(
+                authenticatedClient.socket,
+                forwardSocket,
+                eventService,
+                executionRequest,
+                userId,
+                rawClientSocket = clientSocket,
+            )
         } catch (e: Exception) {
             // The upstream is open but the session never started, close it so it is not leaked.
             runCatching { forwardSocket.close() }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyFramingTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyFramingTest.kt
@@ -3,13 +3,10 @@ package dev.kviklet.kviklet.proxy
 
 import dev.kviklet.kviklet.proxy.postgres.messages.MessageFramer
 import dev.kviklet.kviklet.proxy.postgres.messages.QueryMessage
-import dev.kviklet.kviklet.proxy.postgres.readFromAnyStream
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.io.ByteArrayInputStream
 import java.nio.ByteBuffer
 
 class PostgresProxyFramingTest {
@@ -125,32 +122,5 @@ class PostgresProxyFramingTest {
         buffer.put('Q'.code.toByte())
         buffer.putInt(Int.MAX_VALUE)
         assertThrows<Exception> { framer.feed(buffer.array()) }
-    }
-
-    @Test
-    fun `reading from a stream at EOF reports the stream as closed`() {
-        val received = mutableListOf<ByteArray>()
-        val open = readFromAnyStream(ByteArrayInputStream(ByteArray(0))) { received.add(it) }
-        assertFalse(open)
-        assertTrue(received.isEmpty())
-    }
-
-    @Test
-    fun `reading a stream that ends after a single byte still delivers that byte`() {
-        val received = mutableListOf<ByteArray>()
-        val open = readFromAnyStream(ByteArrayInputStream(byteArrayOf(42))) { received.add(it) }
-        assertFalse(open)
-        assertEquals(1, received.size)
-        assertEquals(42, received[0][0].toInt())
-    }
-
-    @Test
-    fun `reading a stream with data delivers all of it and keeps the stream open`() {
-        val data = ByteArray(100) { it.toByte() }
-        val received = mutableListOf<ByteArray>()
-        val open = readFromAnyStream(ByteArrayInputStream(data)) { received.add(it) }
-        assertTrue(open)
-        assertEquals(1, received.size)
-        assertTrue(data.contentEquals(received[0]))
     }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyParseFailureTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyParseFailureTest.kt
@@ -43,8 +43,11 @@ class PostgresProxyParseFailureTest {
         val handler: Thread
 
         init {
-            proxyClientSocket.soTimeout = 10
-            proxyTargetSocket.soTimeout = 10
+            // Match the socket configuration the proxy applies to the relay after setup: the blocking
+            // thread-per-direction relay uses no read timeout (soTimeout 0), parking in a read until data
+            // arrives or the socket is closed on teardown.
+            proxyClientSocket.soTimeout = 0
+            proxyTargetSocket.soTimeout = 0
             val connection = Connection(proxyClientSocket, proxyTargetSocket, eventService, request, "mock")
             handler = thread { connection.startHandling() }
         }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyTLSTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyTLSTest.kt
@@ -8,6 +8,7 @@ import dev.kviklet.kviklet.proxy.helpers.directConnectionFactory
 import dev.kviklet.kviklet.proxy.helpers.proxyServerFactory
 import dev.kviklet.kviklet.proxy.postgres.TLSCertificate
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -78,6 +79,43 @@ class PostgresProxyTLSTest {
             }
 
             this.proxy.eventService.assertQueryIsAudited("SELECT 1")
+        }
+    }
+
+    @Test
+    fun `an idle TLS session is torn down when the proxy shuts down`() {
+        // Regression: the client TLS socket is an SSLSocket layered over the accepted socket with
+        // autoClose=false, so closing only the SSL wrapper on teardown left the underlying fd and the
+        // relay thread parked on its blocking read forever -- a leaked slot, thread and upstream
+        // connection per TLS access window. Blocking socket reads also ignore the thread-pool interrupt
+        // from shutdownNow(), so only closing the raw socket can free the session. shutdownServer() must
+        // therefore bring the connection count back to zero.
+        val proxyProps = Properties()
+        proxyProps.setProperty("user", "proxyUser")
+        proxyProps.setProperty("password", "proxyPassword")
+        proxyProps.setProperty("ssl", "true")
+        proxyProps.setProperty("sslmode", "require")
+        val ignoreTLSIssuer = "&sslfactory=org.postgresql.ssl.NonValidatingFactory"
+
+        val conn = DriverManager.getConnection(this.proxy.connectionString + ignoreTLSIssuer, proxyProps)
+        try {
+            conn.createStatement().executeQuery("SELECT 1").close()
+            // The TLS session is established and now idle, with no traffic in flight.
+            assertTrue(this.proxy.proxy.currentConnections >= 1)
+
+            this.proxy.proxy.shutdownServer()
+
+            val deadline = System.currentTimeMillis() + 10_000
+            while (this.proxy.proxy.currentConnections != 0 && System.currentTimeMillis() < deadline) {
+                Thread.sleep(100)
+            }
+            assertEquals(
+                0,
+                this.proxy.proxy.currentConnections,
+                "The idle TLS session's slot was never freed; its relay thread is still parked on the read",
+            )
+        } finally {
+            runCatching { conn.close() }
         }
     }
 }


### PR DESCRIPTION
Replaces the single-threaded, 10ms-polling relay loop in the Postgres proxy with two blocking threads per session:

- the existing pool thread drives **client → server** (framing, auditing, forwarding), and
- one spawned thread pumps **server → client** raw.

This removes `readFromAnyStream` — the one-byte-poll hack that only existed to work around `SSLSocket.available()` always returning 0 — and with it the idle CPU burn and the 10ms latency floor. Blocking reads mean each direction parks until data arrives or the socket is closed on teardown.

Because the two directions are asymmetric (all audit state lives on the client→server side; server→client is a dumb byte pump), no audit state needs synchronization. The only shared resource is the client output stream — written by the pump in normal operation and by the abort path's injected `ErrorResponse` — so a single lock keeps those two from interleaving a frame on the wire. Teardown is unchanged in effect: closing the sockets unblocks whichever thread is parked in a read, and both paths converge on the idempotent `close()`.

Relay sockets no longer set a read timeout (the 10ms value only drove the poll loop). The handshake deadline is unaffected. The three unit tests covering the removed `readFromAnyStream` are dropped; the `MessageFramer` unit tests and the integration relay suites are untouched, so the existing end-to-end coverage stands as the proof the threaded model behaves identically.