### PR TITLE
Add MySQL/MariaDB support to the database access proxy

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/core/ProxySession.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/core/ProxySession.kt
@@ -2,6 +2,7 @@
 package dev.kviklet.kviklet.proxy.core
 
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.DatasourceType
 import dev.kviklet.kviklet.service.dto.ExecutionRequest
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ScheduledFuture
@@ -22,6 +23,10 @@ class ProxySession(
     val targetHost: String,
     val targetPort: Int,
     val databaseName: String,
+    // The upstream's datasource flavor. Kept neutral (an enum, not a protocol object) so the session stays
+    // protocol-agnostic: some wire protocols serve more than one flavor (MySQL and MariaDB share one
+    // listener), and the ProxyProtocol reads this to build the right upstream connection.
+    val datasourceType: DatasourceType,
     val authenticationDetails: AuthenticationDetails.UserPassword,
 ) {
     // Live relay connections for this session, closed when the session expires so an in-flight client cannot

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
@@ -1,0 +1,394 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy.mysql
+
+import dev.kviklet.kviklet.proxy.core.AuthenticatedClient
+import dev.kviklet.kviklet.proxy.core.ProxySession
+import dev.kviklet.kviklet.proxy.core.TLSCertificate
+import dev.kviklet.kviklet.proxy.core.enableSSL
+import java.io.ByteArrayOutputStream
+import java.io.EOFException
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.Socket
+import java.nio.BufferUnderflowException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+// The only auth plugin the proxy speaks on its client side. The client's password is a Kviklet-generated
+// temp credential, so the weaker (deprecated upstream) native scramble is acceptable here; the upstream
+// side negotiates whatever the real server offers (see TargetMySqlServer.kt).
+const val NATIVE_PASSWORD_PLUGIN = "mysql_native_password"
+
+private const val CLIENT_SSL = 0x0800
+private const val COM_QUIT = 0x01
+
+// Generous cap on any client packet during the handshake. A HandshakeResponse is far smaller; a declared
+// length beyond this can only be garbage or an attack, so it is rejected instead of buffered (the header
+// alone could otherwise make the proxy allocate 16MB per probe).
+private const val MAX_HANDSHAKE_PACKET_LENGTH = 10_000
+
+// Fallback total handshake budget used only if the caller left the socket timeout at 0 ("block forever").
+private const val DEFAULT_HANDSHAKE_BUDGET_MS = 10_000L
+
+// Runs the server-speaks-first MySQL handshake and client authentication, routing to a session by the
+// username in the client's HandshakeResponse. No upstream database connection is opened here, so an
+// unauthenticated, aborting or idle client can never leak a target connection or pin a slot: the caller's
+// handshake deadline (soTimeout) bounds every read below as a total budget, and EOF ends the handshake.
+//
+// resolveSession returns the session for a username, or null if there is none. An unknown username is not
+// short-circuited: the exact same scramble verification still runs (with unknownUserPassword) and fails
+// with the identical generic access-denied error a wrong password produces, so an attacker cannot
+// enumerate valid usernames.
+//
+// Returns null when the client goes away before authenticating (immediate close, or a COM_QUIT sent
+// instead of a HandshakeResponse -- a liveness probe with nothing to relay).
+fun authenticateClientMySql(
+    client: Socket,
+    tlsCert: TLSCertificate?,
+    unknownUserPassword: String,
+    resolveSession: (String) -> ProxySession?,
+): AuthenticatedClient? {
+    // The caller's soTimeout is the TOTAL handshake budget, not just a per-read timeout: the socket
+    // timeout is shrunk to the remaining budget before every packet read below, so a slow client dribbling
+    // one valid packet just under each timeout cannot outlast it and hold its slot forever.
+    val budgetMs = if (client.soTimeout > 0) client.soTimeout.toLong() else DEFAULT_HANDSHAKE_BUDGET_MS
+    val deadline = System.currentTimeMillis() + budgetMs
+    var socket = client
+    var input = socket.getInputStream()
+    var output = socket.getOutputStream()
+
+    // MySQL is server-speaks-first: send the initial handshake carrying a fresh scramble, advertising
+    // CLIENT_SSL only when a TLS certificate is configured.
+    val salt = generateRandomSalt()
+    writePacket(output, 0, buildInitialHandshake(1, salt, tlsCert != null))
+
+    var (seq, payload) = readHandshakePacket(socket, input, deadline) ?: return null
+
+    // An SSLRequest is a short HandshakeResponse prefix (capabilities but no username) with CLIENT_SSL
+    // set: upgrade to TLS via the shared core helper and read the real HandshakeResponse from the
+    // encrypted stream. The client can only legitimately ask when the initial handshake advertised SSL.
+    if (payload.size >= 4 && (readClientCapabilities(payload) and CLIENT_SSL) != 0) {
+        if (tlsCert == null) {
+            writePacket(
+                output,
+                seq + 1,
+                buildErrPacket(2000, "HY000", "SSL connection requested but SSL is not supported by proxy"),
+            )
+            throw IOException("Client requested SSL but SSL is not supported by proxy")
+        }
+        socket = enableSSL(client, tlsCert)
+        input = socket.getInputStream()
+        output = socket.getOutputStream()
+        val next = readHandshakePacket(socket, input, deadline) ?: return null
+        seq = next.first
+        payload = next.second
+    }
+
+    // A COM_QUIT instead of a HandshakeResponse is a throwaway connection (liveness probe) that never
+    // authenticates and has nothing to relay: drop it rather than failing it as malformed.
+    if (payload.size == 1 && (payload[0].toInt() and 0xFF) == COM_QUIT) {
+        return null
+    }
+
+    val response = HandshakeResponse.parse(payload)
+
+    // If the client answered for a different auth plugin than the advertised native one, ask it to switch
+    // and use the switched response. The switch depends only on the client's plugin choice, never on
+    // whether the username resolved, so it leaks nothing.
+    var authResponse = response.authResponse
+    if (response.authPluginName != null && response.authPluginName != NATIVE_PASSWORD_PLUGIN) {
+        seq += 1
+        writePacket(output, seq, buildAuthSwitchRequest(salt))
+        val switched = readHandshakePacket(socket, input, deadline) ?: return null
+        seq = switched.first
+        authResponse = switched.second
+    }
+
+    // Unknown username -> the same verification runs against a placeholder password, and the failure below
+    // is byte-identical to a wrong password, so a probe cannot tell the two apart.
+    val session = resolveSession(response.username)
+    val isPasswordValid = verifyPassword(salt, session?.password ?: unknownUserPassword, authResponse)
+    if (session == null || !isPasswordValid) {
+        // Echo the client-supplied username back in the wire-protocol error packet only; never log it or
+        // embed it in the server-side exception, to avoid leaking attempted usernames.
+        writePacket(
+            output,
+            seq + 1,
+            buildErrPacket(1045, "28000", "Access denied for user '${response.username}' (using password: YES)"),
+        )
+        throw IOException("Authentication failed: access denied")
+    }
+
+    writePacket(output, seq + 1, buildOkPacket())
+    // socket is the (possibly TLS-wrapped) stream the client now speaks on; client is the raw accepted TCP
+    // socket the relay must close to unblock its threads on teardown.
+    return AuthenticatedClient(socket, client, session)
+}
+
+// Reads one client packet within the total handshake budget: shrinks the socket timeout to the remaining
+// budget first, so the whole handshake cannot outlast the deadline. Returns null on EOF before a complete
+// packet (the client went away); throws when the deadline has already passed.
+private fun readHandshakePacket(socket: Socket, input: InputStream, deadline: Long): Pair<Int, ByteArray>? {
+    val remaining = deadline - System.currentTimeMillis()
+    if (remaining <= 0) {
+        throw IOException("Client handshake exceeded its deadline, aborting the connection")
+    }
+    socket.soTimeout = remaining.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+    return try {
+        readPacket(input, MAX_HANDSHAKE_PACKET_LENGTH)
+    } catch (e: EOFException) {
+        null
+    }
+}
+
+// The capability flags a client sends first in both an SSLRequest and a HandshakeResponse
+// (little-endian int32 at offset 0).
+private fun readClientCapabilities(payload: ByteArray): Int = (payload[0].toInt() and 0xFF) or
+    ((payload[1].toInt() and 0xFF) shl 8) or
+    ((payload[2].toInt() and 0xFF) shl 16) or
+    ((payload[3].toInt() and 0xFF) shl 24)
+
+// Reads one MySQL packet (3-byte little-endian length + 1-byte sequence id + payload), looping over
+// partial reads. Throws EOFException if the peer closes before a complete packet.
+fun readPacket(input: InputStream, maxPayloadLength: Int = 0xFFFFFF): Pair<Int, ByteArray> {
+    val header = ByteArray(4)
+    readFully(input, header, 4)
+    val length = (header[0].toInt() and 0xFF) or
+        ((header[1].toInt() and 0xFF) shl 8) or
+        ((header[2].toInt() and 0xFF) shl 16)
+    if (length > maxPayloadLength) {
+        throw IOException("MySQL packet payload of $length bytes exceeds the allowed $maxPayloadLength")
+    }
+    val sequenceId = header[3].toInt() and 0xFF
+    val payload = ByteArray(length)
+    readFully(input, payload, length)
+    return Pair(sequenceId, payload)
+}
+
+private fun readFully(input: InputStream, buffer: ByteArray, length: Int) {
+    var read = 0
+    while (read < length) {
+        val r = input.read(buffer, read, length - read)
+        if (r == -1) throw EOFException("EOF while reading a MySQL packet")
+        read += r
+    }
+}
+
+fun writePacket(output: OutputStream, sequenceId: Int, payload: ByteArray) {
+    val header = ByteArray(4)
+    val length = payload.size
+    header[0] = (length and 0xFF).toByte()
+    header[1] = ((length ushr 8) and 0xFF).toByte()
+    header[2] = ((length ushr 16) and 0xFF).toByte()
+    header[3] = (sequenceId and 0xFF).toByte()
+    output.write(header)
+    output.write(payload)
+    output.flush()
+}
+
+fun generateRandomSalt(): ByteArray {
+    val random = SecureRandom()
+    val salt = ByteArray(20)
+    for (i in 0 until 20) {
+        // Keep within safe ASCII printable range and non-zero
+        salt[i] = (random.nextInt(90) + 33).toByte()
+    }
+    return salt
+}
+
+fun buildInitialHandshake(connectionId: Int, salt: ByteArray, supportSsl: Boolean): ByteArray {
+    val serverVersion = "8.0.35-kviklet"
+    val bos = ByteArrayOutputStream()
+    bos.write(10) // Protocol version
+    bos.write(serverVersion.toByteArray(Charsets.US_ASCII))
+    bos.write(0) // Null terminator
+
+    // Connection ID
+    bos.write(connectionId and 0xFF)
+    bos.write((connectionId ushr 8) and 0xFF)
+    bos.write((connectionId ushr 16) and 0xFF)
+    bos.write((connectionId ushr 24) and 0xFF)
+
+    // Auth-plugin-data-part-1 (8 bytes)
+    bos.write(salt, 0, 8)
+    bos.write(0) // filler
+
+    // Capability flags lower 2 bytes (0x820c or 0x8a0c)
+    // CLIENT_LONG_PASSWORD | CLIENT_FOUND_ROWS | CLIENT_CONNECT_WITH_DB | CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION
+    bos.write(0x0c)
+    if (supportSsl) {
+        bos.write(0x8a) // 0x8a has CLIENT_SSL set! (0x82 | 0x08)
+    } else {
+        bos.write(0x82)
+    }
+
+    bos.write(45) // Character set: utf8mb4_general_ci
+
+    // Status flags: SERVER_STATUS_AUTOCOMMIT (0x0002)
+    bos.write(0x02)
+    bos.write(0x00)
+
+    // Capability flags upper 2 bytes (0x0008)
+    // CLIENT_PLUGIN_AUTH
+    bos.write(0x08)
+    bos.write(0x00)
+
+    bos.write(21) // Auth-plugin-data-len
+
+    // Reserved (10 bytes)
+    for (i in 0 until 10) bos.write(0)
+
+    // Auth-plugin-data-part-2 (12 bytes)
+    bos.write(salt, 8, 12)
+    bos.write(0) // filler
+
+    // Auth-plugin-name
+    bos.write(NATIVE_PASSWORD_PLUGIN.toByteArray(Charsets.US_ASCII))
+    bos.write(0) // Null terminator
+
+    return bos.toByteArray()
+}
+
+class HandshakeResponse(
+    val username: String,
+    val authResponse: ByteArray,
+    val database: String?,
+    val authPluginName: String?,
+) {
+    companion object {
+        fun parse(payload: ByteArray): HandshakeResponse {
+            try {
+                val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+                val capabilities = buffer.int
+                buffer.int // max packet size
+                buffer.get() // charset
+                // Skip 23 bytes of reserved/filler
+                for (i in 0 until 23) {
+                    buffer.get()
+                }
+                // Read null-terminated username
+                val usernameBytes = ByteArrayOutputStream()
+                while (true) {
+                    val b = buffer.get()
+                    if (b == 0.toByte()) break
+                    usernameBytes.write(b.toInt())
+                }
+                val username = String(usernameBytes.toByteArray(), Charsets.UTF_8)
+
+                // Reject lenenc-encoded auth data -- we don't advertise this capability
+                if ((capabilities and 0x00200000) != 0) {
+                    throw IOException("CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA is not supported by this proxy")
+                }
+
+                // Read auth response
+                val hasSecureConnection = (capabilities and 0x8000) != 0
+                val authResponse = if (hasSecureConnection) {
+                    val authResponseLen = buffer.get().toInt() and 0xFF
+                    val authBytes = ByteArray(authResponseLen)
+                    buffer.get(authBytes)
+                    authBytes
+                } else {
+                    val authBytesStream = ByteArrayOutputStream()
+                    while (true) {
+                        val b = buffer.get()
+                        if (b == 0.toByte()) break
+                        authBytesStream.write(b.toInt())
+                    }
+                    authBytesStream.toByteArray()
+                }
+
+                var database: String? = null
+                if ((capabilities and 0x0008) != 0) {
+                    val dbBytes = ByteArrayOutputStream()
+                    while (buffer.hasRemaining()) {
+                        val b = buffer.get()
+                        if (b == 0.toByte()) break
+                        dbBytes.write(b.toInt())
+                    }
+                    database = String(dbBytes.toByteArray(), Charsets.UTF_8)
+                }
+
+                var authPluginName: String? = null
+                if ((capabilities and 0x00080000) != 0) {
+                    val pluginBytes = ByteArrayOutputStream()
+                    while (buffer.hasRemaining()) {
+                        val b = buffer.get()
+                        if (b == 0.toByte()) break
+                        pluginBytes.write(b.toInt())
+                    }
+                    authPluginName = String(pluginBytes.toByteArray(), Charsets.UTF_8)
+                }
+
+                return HandshakeResponse(username, authResponse, database, authPluginName)
+            } catch (e: BufferUnderflowException) {
+                throw IOException("Malformed HandshakeResponse packet (truncated)", e)
+            }
+        }
+    }
+}
+
+fun sha1(data: ByteArray): ByteArray {
+    val md = MessageDigest.getInstance("SHA-1")
+    return md.digest(data)
+}
+
+fun xor(a: ByteArray, b: ByteArray): ByteArray {
+    val result = ByteArray(a.size)
+    for (i in a.indices) {
+        result[i] = (a[i].toInt() xor b[i].toInt()).toByte()
+    }
+    return result
+}
+
+fun verifyPassword(scramble: ByteArray, password: String, clientHash: ByteArray): Boolean {
+    val passwordBytes = password.toByteArray(Charsets.UTF_8)
+    val sha1Password = sha1(passwordBytes)
+    val sha1Sha1Password = sha1(sha1Password)
+
+    val concat = ByteArray(scramble.size + sha1Sha1Password.size)
+    System.arraycopy(scramble, 0, concat, 0, scramble.size)
+    System.arraycopy(sha1Sha1Password, 0, concat, scramble.size, sha1Sha1Password.size)
+
+    val sha1Concat = sha1(concat)
+    val expectedClientHash = xor(sha1Password, sha1Concat)
+
+    return MessageDigest.isEqual(expectedClientHash, clientHash)
+}
+
+fun buildOkPacket(): ByteArray {
+    val bos = ByteArrayOutputStream()
+    bos.write(0x00) // OK header
+    bos.write(0x00) // Affected rows (0)
+    bos.write(0x00) // Last insert ID (0)
+    bos.write(0x02) // Status flags lower byte (SERVER_STATUS_AUTOCOMMIT)
+    bos.write(0x00) // Status flags upper byte
+    bos.write(0x00) // Warnings lower byte (0)
+    bos.write(0x00) // Warnings upper byte
+    return bos.toByteArray()
+}
+
+fun buildErrPacket(errorCode: Int, sqlState: String, message: String): ByteArray {
+    val bos = ByteArrayOutputStream()
+    bos.write(0xFF)
+    bos.write(errorCode and 0xFF)
+    bos.write((errorCode ushr 8) and 0xFF)
+    bos.write('#'.code)
+    bos.write(sqlState.toByteArray(Charsets.US_ASCII))
+    bos.write(message.toByteArray(Charsets.UTF_8))
+    return bos.toByteArray()
+}
+
+// AuthSwitchRequest: asks a client that answered for another plugin to redo its response with the native
+// scramble over the same salt.
+fun buildAuthSwitchRequest(salt: ByteArray): ByteArray {
+    val bos = ByteArrayOutputStream()
+    bos.write(0xFE)
+    bos.write(NATIVE_PASSWORD_PLUGIN.toByteArray(Charsets.US_ASCII))
+    bos.write(0)
+    bos.write(salt)
+    bos.write(0)
+    return bos.toByteArray()
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -1,0 +1,320 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy.mysql
+
+import dev.kviklet.kviklet.db.ExecutePayload
+import dev.kviklet.kviklet.proxy.core.ProxyConnection
+import dev.kviklet.kviklet.proxy.core.writeAndFlush
+import dev.kviklet.kviklet.service.EventService
+import dev.kviklet.kviklet.service.dto.ExecutionRequest
+import org.slf4j.LoggerFactory
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.Socket
+import java.util.concurrent.ConcurrentHashMap
+
+private val logger = LoggerFactory.getLogger("MySqlConnection")
+
+class MySqlConnection(
+    private val clientSocket: Socket,
+    private val targetSocket: Socket,
+    private val eventService: EventService,
+    private val executionRequest: ExecutionRequest,
+    private val userId: String,
+    // The raw accepted TCP socket underneath clientSocket. For a TLS client, clientSocket is an SSLSocket
+    // layered over this one with autoClose=false, so closing the SSLSocket would leave this fd (and the
+    // parked blocking read on it) open. Closing the underlying socket is what actually unblocks the relay
+    // threads and frees the fd, so teardown closes this rather than the SSL wrapper. Defaults to
+    // clientSocket for the plain (non-TLS) case, where they are the same socket.
+    private val rawClientSocket: Socket = clientSocket,
+) : ProxyConnection {
+    private var clientInput: InputStream = clientSocket.getInputStream()
+    private var clientOutput: OutputStream = clientSocket.getOutputStream()
+    private var serverInput: InputStream = targetSocket.getInputStream()
+    private var serverOutput: OutputStream = targetSocket.getOutputStream()
+
+    // Only touched on the client->server thread; the loop exits after the COM_QUIT chunk was forwarded.
+    private var terminationMessageReceived: Boolean = false
+
+    // Written by close() on the shutdown thread and read by both relay threads, so it needs a
+    // happens-before edge.
+    @Volatile
+    private var serverTerminating: Boolean = false
+
+    @Volatile
+    private var awaitingPrepareResponse = false
+    private var lastPreparedQuery: String? = null
+    private val preparedQueries = ConcurrentHashMap<Int, String>()
+
+    private val clientParser = MySqlClientPacketParser(
+        onQuery = { query ->
+            auditQuery(query)
+        },
+        onPrepare = { query ->
+            synchronized(this) {
+                lastPreparedQuery = query
+                awaitingPrepareResponse = true
+            }
+        },
+        onExecute = { stmtId ->
+            val query = preparedQueries[stmtId]
+            if (query != null) {
+                auditQuery(query)
+            }
+        },
+        onClose = { stmtId ->
+            // Release the stored query when the client closes the prepared statement
+            preparedQueries.remove(stmtId)
+        },
+        onQuit = {
+            terminationMessageReceived = true
+        },
+    )
+
+    private val serverParser = MySqlServerPacketParser(
+        onPrepareOk = { stmtId ->
+            synchronized(this) {
+                if (awaitingPrepareResponse) {
+                    lastPreparedQuery?.let { preparedQueries[stmtId] = it }
+                    awaitingPrepareResponse = false
+                    lastPreparedQuery = null
+                }
+            }
+        },
+        onPrepareErr = {
+            // The server rejected the COM_STMT_PREPARE; drop the pending state so the
+            // next unrelated OK packet is not mistaken for this prepare's response.
+            synchronized(this) {
+                awaitingPrepareResponse = false
+                lastPreparedQuery = null
+            }
+        },
+    )
+
+    private fun auditQuery(query: String) {
+        try {
+            val executePayload = ExecutePayload(query = query)
+            eventService.saveEvent(executionRequest.id!!, userId, executePayload)
+        } catch (e: Exception) {
+            logger.error("Failed to audit query", e)
+        }
+    }
+
+    // Signals the relay loops to stop and closes both sockets. The flag gives a clean exit when a loop is
+    // between reads, and closing the sockets forces an exit when it is parked in blocking I/O. Idempotent:
+    // safe to call from either relay thread's teardown and again from a concurrent session expiry or
+    // server shutdown.
+    override fun close() {
+        serverTerminating = true
+        closeSockets()
+    }
+
+    // Closes both sockets. Closing the upstream socket is what actually frees the target database
+    // connection, and closing the client socket unblocks a peer still waiting on it. On the client side
+    // this closes the raw underlying TCP socket, not the SSLSocket wrapper: for a TLS client the wrapper
+    // would leave the underlying fd and its parked blocking read open, and SSLSocket.close() can also
+    // block on the TLS output-record lock a concurrent write holds (see the Postgres relay).
+    private fun closeSockets() {
+        runCatching { if (!rawClientSocket.isClosed) rawClientSocket.close() }
+        runCatching { if (!targetSocket.isClosed) targetSocket.close() }
+    }
+
+    override fun startHandling() {
+        // Two blocking threads per session. This (pool) thread drives client->server: it feeds the packet
+        // parser (which audits queries and tracks prepared statements) and forwards the raw bytes. A single
+        // spawned thread pumps server->client, feeding its parser only to match prepared-statement ids.
+        // The finally is the single teardown path for every exit: clean COM_QUIT, client/server EOF or an
+        // exception. It closes both sockets (freeing the upstream connection) which also unblocks the pump
+        // thread, then joins it.
+        val serverToClient = Thread({ pumpServerToClient() }, "mysql-proxy-server-to-client")
+        serverToClient.start()
+        try {
+            while (!terminationMessageReceived && !serverTerminating) {
+                val chunk = try {
+                    readChunk(clientInput)
+                } catch (e: Exception) {
+                    // A read failure during teardown (the socket was closed under us) is expected; only an
+                    // unexpected one is worth surfacing.
+                    if (serverTerminating) break
+                    throw e
+                } ?: break // client reached EOF
+                // Audit before forwarding: the parser callbacks run synchronously inside addBytes, so every
+                // query is recorded before its bytes reach the server.
+                clientParser.addBytes(chunk)
+                serverOutput.writeAndFlush(chunk)
+            }
+        } finally {
+            close()
+            serverToClient.join()
+        }
+    }
+
+    private fun pumpServerToClient() {
+        try {
+            while (!serverTerminating) {
+                val chunk = readChunk(serverInput) ?: break // server reached EOF
+                serverParser.addBytes(chunk)
+                clientOutput.writeAndFlush(chunk)
+            }
+        } catch (e: Exception) {
+            // The client->server thread closing the sockets during teardown unblocks this read with an
+            // exception; that is the normal way this thread ends, so it is not an error.
+            logger.info("Server-to-client relay ended: {}", e.message)
+        } finally {
+            // Closing here unblocks the client->server thread if the server was the side that went away.
+            close()
+        }
+    }
+
+    // Blocking read of one chunk. Returns null at EOF. Throws if the socket is closed mid-read.
+    private fun readChunk(input: InputStream): ByteArray? {
+        val buff = ByteArray(8192)
+        val read = input.read(buff)
+        if (read == -1) return null
+        return buff.copyOfRange(0, read)
+    }
+}
+
+class MySqlClientPacketParser(
+    private val onQuery: (String) -> Unit,
+    private val onPrepare: (String) -> Unit,
+    private val onExecute: (Int) -> Unit,
+    private val onClose: (Int) -> Unit = {},
+    private val onQuit: () -> Unit,
+) {
+    private val buffer = ByteArrayOutputStream()
+
+    fun addBytes(bytes: ByteArray) {
+        synchronized(this) {
+            buffer.write(bytes)
+            processBuffer()
+        }
+    }
+
+    private fun processBuffer() {
+        val data = buffer.toByteArray()
+        var offset = 0
+        while (data.size - offset >= 4) {
+            val length = (data[offset].toInt() and 0xFF) or
+                ((data[offset + 1].toInt() and 0xFF) shl 8) or
+                ((data[offset + 2].toInt() and 0xFF) shl 16)
+
+            if (data.size - offset < 4 + length) {
+                break // Need more data for a full packet
+            }
+
+            val payload = ByteArray(length)
+            System.arraycopy(data, offset + 4, payload, 0, length)
+
+            if (payload.isNotEmpty()) {
+                val cmd = payload[0].toInt() and 0xFF
+                try {
+                    when (cmd) {
+                        0x01 -> { // COM_QUIT
+                            onQuit()
+                        }
+
+                        0x03 -> { // COM_QUERY
+                            val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
+                            if (query.trim().isNotEmpty()) {
+                                onQuery(query)
+                            }
+                        }
+
+                        0x16 -> { // COM_STMT_PREPARE
+                            val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
+                            if (query.trim().isNotEmpty()) {
+                                onPrepare(query)
+                            }
+                        }
+
+                        0x17 -> { // COM_STMT_EXECUTE
+                            if (payload.size >= 5) {
+                                val stmtId = (payload[1].toInt() and 0xFF) or
+                                    ((payload[2].toInt() and 0xFF) shl 8) or
+                                    ((payload[3].toInt() and 0xFF) shl 16) or
+                                    ((payload[4].toInt() and 0xFF) shl 24)
+                                onExecute(stmtId)
+                            }
+                        }
+
+                        0x19 -> { // COM_STMT_CLOSE
+                            if (payload.size >= 5) {
+                                val stmtId = (payload[1].toInt() and 0xFF) or
+                                    ((payload[2].toInt() and 0xFF) shl 8) or
+                                    ((payload[3].toInt() and 0xFF) shl 16) or
+                                    ((payload[4].toInt() and 0xFF) shl 24)
+                                onClose(stmtId)
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    logger.error("Error parsing client packet", e)
+                }
+            }
+
+            offset += 4 + length
+        }
+
+        buffer.reset()
+        if (data.size > offset) {
+            buffer.write(data, offset, data.size - offset)
+        }
+    }
+}
+
+class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit, private val onPrepareErr: () -> Unit = {}) {
+    private val buffer = ByteArrayOutputStream()
+
+    fun addBytes(bytes: ByteArray) {
+        synchronized(this) {
+            buffer.write(bytes)
+            processBuffer()
+        }
+    }
+
+    private fun processBuffer() {
+        val data = buffer.toByteArray()
+        var offset = 0
+        while (data.size - offset >= 4) {
+            val length = (data[offset].toInt() and 0xFF) or
+                ((data[offset + 1].toInt() and 0xFF) shl 8) or
+                ((data[offset + 2].toInt() and 0xFF) shl 16)
+
+            if (data.size - offset < 4 + length) {
+                break // Need more data for a full packet
+            }
+
+            val payload = ByteArray(length)
+            System.arraycopy(data, offset + 4, payload, 0, length)
+
+            if (payload.isNotEmpty()) {
+                val status = payload[0].toInt() and 0xFF
+                // COM_STMT_PREPARE_OK has a fixed 12-byte payload (0x00 status + 4 stmt_id
+                // + 2 columns + 2 params + 1 reserved + 2 warnings). Requiring the exact
+                // length avoids mistaking a generic OK packet (also 0x00) for a prepare-ok.
+                // ERR packets (0xFF) clear any pending prepare so a later OK is not misread.
+                if (status == 0xFF) {
+                    onPrepareErr()
+                } else if (status == 0x00 && payload.size == 12) {
+                    try {
+                        val stmtId = (payload[1].toInt() and 0xFF) or
+                            ((payload[2].toInt() and 0xFF) shl 8) or
+                            ((payload[3].toInt() and 0xFF) shl 16) or
+                            ((payload[4].toInt() and 0xFF) shl 24)
+                        onPrepareOk(stmtId)
+                    } catch (e: Exception) {
+                        logger.error("Error parsing server prepare-ok packet", e)
+                    }
+                }
+            }
+
+            offset += 4 + length
+        }
+
+        buffer.reset()
+        if (data.size > offset) {
+            buffer.write(data, offset, data.size - offset)
+        }
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -27,6 +27,10 @@ class MySqlConnection(
     // threads and frees the fd, so teardown closes this rather than the SSL wrapper. Defaults to
     // clientSocket for the plain (non-TLS) case, where they are the same socket.
     private val rawClientSocket: Socket = clientSocket,
+    // The JDBC connection targetSocket was extracted from. Held here so it stays strongly referenced for
+    // the relay's lifetime (a driver may reap the network resources of a connection object that is
+    // garbage-collected without close()) and closed quietly on teardown to release driver bookkeeping.
+    private val upstreamJdbcConnection: AutoCloseable? = null,
 ) : ProxyConnection {
     private var clientInput: InputStream = clientSocket.getInputStream()
     private var clientOutput: OutputStream = clientSocket.getOutputStream()
@@ -117,6 +121,9 @@ class MySqlConnection(
     private fun closeSockets() {
         runCatching { if (!rawClientSocket.isClosed) rawClientSocket.close() }
         runCatching { if (!targetSocket.isClosed) targetSocket.close() }
+        // After the sockets: the driver's own close (a Quit attempt on the already-closed socket) may
+        // fail, which is fine -- this is only about releasing its bookkeeping. JDBC close is idempotent.
+        upstreamJdbcConnection?.let { runCatching { it.close() } }
     }
 
     override fun startHandling() {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProtocol.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProtocol.kt
@@ -68,10 +68,12 @@ class MySqlProtocol(
                 session.executionRequest,
                 session.userId,
                 rawClientSocket = authenticatedClient.rawClientSocket,
+                upstreamJdbcConnection = targetConnection.jdbcConnection,
             )
         } catch (e: Exception) {
             // The upstream is open but the session never started, close it so it is not leaked.
             runCatching { forwardSocket.close() }
+            runCatching { targetConnection.jdbcConnection.close() }
             throw e
         }
     }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProtocol.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProtocol.kt
@@ -1,0 +1,78 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy.mysql
+
+import dev.kviklet.kviklet.proxy.core.AuthenticatedClient
+import dev.kviklet.kviklet.proxy.core.ProxyConnection
+import dev.kviklet.kviklet.proxy.core.ProxyProtocol
+import dev.kviklet.kviklet.proxy.core.ProxySession
+import dev.kviklet.kviklet.proxy.core.TLSCertificate
+import dev.kviklet.kviklet.proxy.core.tlsCertificateFactory
+import dev.kviklet.kviklet.service.EventService
+import java.net.Socket
+
+// The MySQL/MariaDB wire-protocol half of the proxy, plugged into a generic ProxyServer. It knows how to
+// run the MySQL handshake and how to open a MySQL or MariaDB upstream (the two share one wire protocol, so
+// one listener serves both; the session's datasourceType records which flavor the target is); the
+// ProxyServer owns everything else (listener, session registry, back-pressure, lifecycle).
+class MySqlProtocol(
+    private val eventService: EventService,
+    private val tlsCertificate: TLSCertificate? = tlsCertificateFactory(),
+) : ProxyProtocol {
+
+    companion object {
+        // The password used for an unknown username, so an unauthenticated probe runs the exact same
+        // scramble verification path and fails identically to a wrong password -- no user enumeration.
+        private const val UNKNOWN_USER_PLACEHOLDER_PASSWORD = "kviklet-no-such-session"
+    }
+
+    // Routes by the username in the client's HandshakeResponse. The resolver returns null for an unknown
+    // username; authenticateClientMySql still runs the full verification with a placeholder password so a
+    // probe cannot tell an unknown user from a wrong password. Returns null when the client goes away
+    // before authenticating.
+    override fun handshake(clientSocket: Socket, resolve: (String) -> ProxySession?): AuthenticatedClient? =
+        authenticateClientMySql(
+            clientSocket,
+            this.tlsCertificate,
+            UNKNOWN_USER_PLACEHOLDER_PASSWORD,
+            resolve,
+        )
+
+    // Opens the MySQL/MariaDB upstream for the authenticated session and hands both sockets to the relay.
+    // The client already received its OK packet during the handshake (MySQL has no post-auth parameter
+    // phase like Postgres), so all that remains is the upstream connect. Closes the upstream if anything
+    // after the connect throws, so a half-set-up session never leaks a target connection.
+    override fun connect(authenticatedClient: AuthenticatedClient): ProxyConnection {
+        val session = authenticatedClient.session
+        val targetFactory = TargetMySqlSocketFactory(
+            session.datasourceType,
+            session.authenticationDetails,
+            session.databaseName,
+            session.targetHost,
+            session.targetPort,
+        )
+        val targetConnection = targetFactory.createTargetMySqlConnection()
+        val forwardSocket = targetConnection.socket
+
+        return try {
+            // Blocking relay: no read timeout. Each direction parks in a blocking read until data arrives
+            // or the socket is closed on teardown.
+            authenticatedClient.socket.soTimeout = 0
+            forwardSocket.soTimeout = 0
+            // Pass the raw accepted socket as rawClientSocket: for a TLS client authenticatedClient.socket
+            // is an SSLSocket layered over it, and only closing the raw socket reliably unblocks the relay
+            // threads on teardown.
+            MySqlConnection(
+                authenticatedClient.socket,
+                forwardSocket,
+                eventService,
+                session.executionRequest,
+                session.userId,
+                rawClientSocket = authenticatedClient.rawClientSocket,
+            )
+        } catch (e: Exception) {
+            // The upstream is open but the session never started, close it so it is not leaked.
+            runCatching { forwardSocket.close() }
+            throw e
+        }
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProxyServerConfig.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProxyServerConfig.kt
@@ -1,0 +1,35 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy.mysql
+
+import dev.kviklet.kviklet.proxy.core.ProxyServer
+import dev.kviklet.kviklet.proxy.core.TlsCertEnvConfig
+import dev.kviklet.kviklet.proxy.core.tlsCertificateFactory
+import dev.kviklet.kviklet.service.EventService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Lazy
+
+@Configuration
+class MySqlProxyServerConfig {
+    // A single long-lived MySQL/MariaDB proxy listener, bound at application startup on the configured
+    // stable port (default 3306). One listener serves both flavors: they share a wire protocol, and each
+    // session's datasourceType picks the upstream. destroyMethod closes it on context shutdown. A port
+    // <= 0 disables the listener (start() is a no-op); the test profile sets -1 so the bean never binds a
+    // real port during the Spring integration tests, which spin up their own ProxyServer instances on
+    // random ports instead.
+    //
+    // @Lazy(false) forces eager creation so the port really binds at boot: the app sets
+    // spring.main.lazy-initialization=true globally, which would otherwise defer the bind until first use.
+    @Bean(destroyMethod = "shutdownServer")
+    @Lazy(false)
+    fun mysqlProxyServer(
+        eventService: EventService,
+        tlsCertConfig: TlsCertEnvConfig,
+        @Value("\${kviklet.proxy.mysql.port:3306}") port: Int,
+    ): ProxyServer {
+        val server = ProxyServer(port, MySqlProtocol(eventService, tlsCertificateFactory(tlsCertConfig)))
+        server.start()
+        return server
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
@@ -3,22 +3,30 @@ package dev.kviklet.kviklet.proxy.mysql
 
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
 import dev.kviklet.kviklet.service.dto.DatasourceType
-import java.io.ByteArrayOutputStream
-import java.io.IOException
 import java.net.Socket
-import java.security.KeyFactory
-import java.security.MessageDigest
-import java.security.PublicKey
-import java.security.spec.X509EncodedKeySpec
-import java.util.Base64
-import javax.crypto.Cipher
+import java.sql.Connection
+import java.sql.DriverManager
+import java.util.Properties
+import org.mariadb.jdbc.Connection as MariaDbConnection
 
-class TargetMySqlConnection(val socket: Socket)
+// The authenticated upstream: the raw socket the relay pumps bytes through, plus the JDBC connection it
+// was extracted from. The JDBC connection MUST stay referenced (and be closed on teardown) for as long as
+// the socket is in use -- an abandoned driver connection object is exactly the resource leak that got the
+// previous driver-extraction attempt removed, and some drivers reap the network resources of connections
+// that are garbage-collected without close().
+class TargetMySqlConnection(val socket: Socket, val jdbcConnection: Connection)
 
-// Opens and authenticates the upstream connection for a proxied session. MySQL and MariaDB share the same
-// wire protocol, and the handshake below follows whatever auth plugin the server advertises
-// (mysql_native_password or caching_sha2_password, including an AuthSwitchRequest), so one factory serves
-// both flavors; the session's datasourceType records which one the target is.
+// Opens and authenticates the upstream connection for a proxied session by letting the JDBC driver do the
+// full handshake, then extracting the underlying socket for the byte relay -- the same approach the
+// Postgres proxy takes with pgjdbc, so auth-plugin negotiation (native, caching_sha2 incl. RSA full auth,
+// AuthSwitch) is maintained by the driver instead of hand-rolled crypto.
+//
+// The MariaDB driver is used for BOTH MySQL and MariaDB targets, deliberately: the relay is a transparent
+// byte pump after the handshakes, so the capabilities the upstream negotiates must produce the same wire
+// format the proxy's own client-facing handshake advertised (fixed minimal capabilities, EOF-style result
+// sets). Connector/J enables CLIENT_DEPRECATE_EOF unconditionally -- which changes result-set framing and
+// would desync every downstream client -- while the MariaDB driver exposes toggles for every
+// format-changing capability; those are pinned off below. It speaks to MySQL servers natively.
 class TargetMySqlSocketFactory(
     private val datasourceType: DatasourceType,
     private val authenticationDetails: AuthenticationDetails.UserPassword,
@@ -27,264 +35,58 @@ class TargetMySqlSocketFactory(
     private val targetPort: Int,
 ) {
     fun createTargetMySqlConnection(): TargetMySqlConnection {
-        val socket = Socket(targetHost, targetPort)
-        try {
-            performHandshake(socket)
-            return TargetMySqlConnection(socket)
+        val props = Properties()
+        props.setProperty("user", authenticationDetails.username)
+        props.setProperty("password", authenticationDetails.password)
+        // The relay hands the client's plaintext bytes straight to this socket, so it must be the plain
+        // TCP socket, never a TLS-wrapped one.
+        props.setProperty("sslMode", "disable")
+        // caching_sha2_password full auth over a plaintext connection needs the server's RSA public key.
+        props.setProperty("allowPublicKeyRetrieval", "true")
+        // Pin every capability that changes the response wire format to what the proxy's client-facing
+        // handshake advertises (no DEPRECATE_EOF, no MariaDB extended metadata), so any downstream client
+        // parses the relayed responses correctly. These are the driver's non-mapped options; their
+        // defaults are all true.
+        props.setProperty("deprecateEof", "false")
+        props.setProperty("extendedTypeInfo", "false")
+        props.setProperty("enableBulkUnitResult", "false")
+        props.setProperty("enableSkipMeta", "false")
+        props.setProperty("useServerPrepStmts", "false")
+
+        val database = if (databaseName.isNotEmpty()) "/$databaseName" else ""
+        val conn = try {
+            DriverManager.getConnection("jdbc:mariadb://$targetHost:$targetPort$database", props)
         } catch (e: Exception) {
-            socket.close()
-            throw e
+            throw IllegalStateException("Could not open the $datasourceType upstream connection", e)
+        }
+        try {
+            return TargetMySqlConnection(extractSocket(conn), conn)
+        } catch (e: Exception) {
+            runCatching { conn.close() }
+            throw IllegalStateException(
+                "Could not extract the upstream socket from the $datasourceType driver connection",
+                e,
+            )
         }
     }
 
-    private fun performHandshake(socket: Socket) {
-        val input = socket.getInputStream()
-        val output = socket.getOutputStream()
-
-        // Read the server's Initial Handshake (Protocol Version 10)
-        val (handshakeSeq, handshake) = readPacket(input)
-        if (handshake.isEmpty() || handshake[0] != 10.toByte()) {
-            throw IOException("Unsupported MySQL protocol version (expected 10, got ${handshake.getOrNull(0)})")
-        }
-
-        val server = parseServerHandshake(handshake)
-        var plugin = server.authPlugin
-        var nonce = server.nonce
-
-        // Send the HandshakeResponse using the plugin the server advertised
-        var seq = handshakeSeq
-        val authToken = computeAuthToken(plugin, authenticationDetails.password, nonce)
-        val response = buildHandshakeResponse(authenticationDetails.username, authToken, databaseName, plugin)
-        seq += 1
-        writePacket(output, seq, response)
-
-        // Drive the post-handshake exchange until we reach an OK or ERR packet
-        while (true) {
-            val (replySeq, reply) = readPacket(input)
-            seq = replySeq
-            if (reply.isEmpty()) throw IOException("Empty response from MySQL server during authentication")
-
-            when (reply[0].toInt() and 0xFF) {
-                // OK -- authenticated
-                0x00 -> return
-
-                0xFF -> throw IOException("MySQL server rejected credentials: ${parseErrMessage(reply)}")
-
-                0xFE -> {
-                    // AuthSwitchRequest: 0xFE + plugin name (null-terminated) + auth data
-                    val (newPlugin, newNonce) = parseAuthSwitch(reply)
-                    plugin = newPlugin
-                    nonce = newNonce
-                    seq += 1
-                    writePacket(output, seq, computeAuthToken(plugin, authenticationDetails.password, nonce))
-                }
-
-                0x01 -> {
-                    // AuthMoreData -- currently only used by caching_sha2_password
-                    if (plugin != "caching_sha2_password") {
-                        throw IOException("Unexpected AuthMoreData for auth plugin '$plugin'")
-                    }
-                    when (reply.getOrNull(1)?.toInt()?.and(0xFF)) {
-                        0x03 -> { /* fast_auth_success -- server will send OK next */ }
-
-                        0x04 -> {
-                            // perform_full_authentication: over a plaintext socket we must
-                            // request the server's RSA public key and send the encrypted password.
-                            seq += 1
-                            writePacket(output, seq, byteArrayOf(0x02)) // request_public_key
-                            val (keySeq, keyReply) = readPacket(input)
-                            seq = keySeq
-                            if (keyReply.isEmpty() || (keyReply[0].toInt() and 0xFF) != 0x01) {
-                                throw IOException(
-                                    "Expected RSA public key from server, got 0x${(
-                                        keyReply.getOrNull(
-                                            0,
-                                        )?.toInt()?.and(0xFF) ?: -1
-                                        ).toString(16)}",
-                                )
-                            }
-                            val pem = String(keyReply, 1, keyReply.size - 1, Charsets.US_ASCII)
-                            val encrypted = encryptPasswordRsa(authenticationDetails.password, nonce, pem)
-                            seq += 1
-                            writePacket(output, seq, encrypted)
-                        }
-
-                        else -> throw IOException(
-                            "Unexpected caching_sha2_password more-data byte: " +
-                                "0x${(reply.getOrNull(1)?.toInt()?.and(0xFF) ?: -1).toString(16)}",
-                        )
-                    }
-                }
-
-                else -> throw IOException(
-                    "Unexpected server response byte: 0x${(reply[0].toInt() and 0xFF).toString(16)}",
-                )
+    // The driver has no public accessor for its socket, so it is read reflectively from the client
+    // implementation, walking up the class hierarchy so a driver refactor that moves the field to a
+    // superclass keeps working. Extraction is safe at this point: the protocol is synchronous and the
+    // driver has fully consumed the responses to its own setup commands, so no stray bytes sit in its
+    // buffers.
+    private fun extractSocket(conn: Connection): Socket {
+        val client = conn.unwrap(MariaDbConnection::class.java).client
+        var currentClass: Class<*>? = client.javaClass
+        while (currentClass != null) {
+            try {
+                val socketField = currentClass.getDeclaredField("socket")
+                socketField.isAccessible = true
+                return socketField.get(client) as Socket
+            } catch (e: NoSuchFieldException) {
+                currentClass = currentClass.superclass
             }
         }
-    }
-
-    private data class ServerHandshake(val nonce: ByteArray, val authPlugin: String)
-
-    // MySQL Protocol v10 Initial Handshake layout:
-    //   1  protocol version
-    //   N+1  server version (null-terminated)
-    //   4  connection id
-    //   8  auth-plugin-data-part-1
-    //   1  filler
-    //   2  capability flags (lower)
-    //   1  charset
-    //   2  status flags
-    //   2  capability flags (upper)
-    //   1  auth-plugin-data length
-    //   10 reserved
-    //   [CLIENT_SECURE_CONNECTION] auth-plugin-data-part-2 (max(13, len-8) bytes)
-    //   [CLIENT_PLUGIN_AUTH] auth plugin name (null-terminated)
-    private fun parseServerHandshake(handshake: ByteArray): ServerHandshake {
-        var pos = 1
-        while (pos < handshake.size && handshake[pos] != 0.toByte()) pos++
-        pos++ // null terminator of server version
-        pos += 4 // connection id
-        val saltPart1 = handshake.copyOfRange(pos, pos + 8)
-        pos += 8
-        pos += 1 // filler
-        val capLower = (handshake[pos].toInt() and 0xFF) or ((handshake[pos + 1].toInt() and 0xFF) shl 8)
-        pos += 2
-        pos += 1 // charset
-        pos += 2 // status flags
-        val capUpper = (handshake[pos].toInt() and 0xFF) or ((handshake[pos + 1].toInt() and 0xFF) shl 8)
-        pos += 2
-        val capabilities = capLower or (capUpper shl 16)
-        val authPluginDataLen = handshake[pos].toInt() and 0xFF
-        pos += 1
-        pos += 10 // reserved
-
-        var saltPart2 = ByteArray(0)
-        if ((capabilities and 0x8000) != 0) { // CLIENT_SECURE_CONNECTION
-            val len2 = maxOf(13, authPluginDataLen - 8)
-            saltPart2 = handshake.copyOfRange(pos, pos + minOf(12, len2)) // first 12 bytes are the nonce tail
-            pos += len2
-        }
-
-        var plugin = NATIVE_PASSWORD_PLUGIN
-        if ((capabilities and 0x00080000) != 0) { // CLIENT_PLUGIN_AUTH
-            val sb = ByteArrayOutputStream()
-            while (pos < handshake.size && handshake[pos] != 0.toByte()) {
-                sb.write(handshake[pos].toInt())
-                pos++
-            }
-            plugin = String(sb.toByteArray(), Charsets.US_ASCII)
-        }
-
-        return ServerHandshake(saltPart1 + saltPart2, plugin)
-    }
-
-    private fun parseAuthSwitch(packet: ByteArray): Pair<String, ByteArray> {
-        var pos = 1 // skip 0xFE
-        val sb = ByteArrayOutputStream()
-        while (pos < packet.size && packet[pos] != 0.toByte()) {
-            sb.write(packet[pos].toInt())
-            pos++
-        }
-        pos++ // null terminator
-        val plugin = String(sb.toByteArray(), Charsets.US_ASCII)
-        // Remaining auth data; trim a single trailing null if present
-        var end = packet.size
-        if (end > pos && packet[end - 1] == 0.toByte()) end--
-        val nonce = packet.copyOfRange(pos, end)
-        return plugin to nonce
-    }
-
-    private fun parseErrMessage(packet: ByteArray): String {
-        // 0xFF + 2-byte error code + (optional '#' + 5-byte sqlstate) + message
-        if (packet.size <= 3) return "unknown error"
-        var pos = 3
-        if (packet.size > 3 && packet[3] == '#'.code.toByte()) pos = 9
-        if (pos >= packet.size) return "unknown error"
-        return String(packet, pos, packet.size - pos, Charsets.UTF_8)
-    }
-
-    private fun computeAuthToken(plugin: String, password: String, nonce: ByteArray): ByteArray = when (plugin) {
-        NATIVE_PASSWORD_PLUGIN -> computeNativePasswordToken(password, nonce)
-        "caching_sha2_password" -> computeCachingSha2Token(password, nonce)
-        else -> throw IOException("Unsupported target auth plugin '$plugin'")
-    }
-
-    private fun computeNativePasswordToken(password: String, nonce: ByteArray): ByteArray {
-        if (password.isEmpty()) return ByteArray(0)
-        val sha1Password = sha1(password.toByteArray(Charsets.UTF_8))
-        val sha1Sha1Password = sha1(sha1Password)
-        return xor(sha1Password, sha1(nonce + sha1Sha1Password))
-    }
-
-    // caching_sha2_password scramble: SHA256(pw) XOR SHA256(SHA256(SHA256(pw)) || nonce)
-    private fun computeCachingSha2Token(password: String, nonce: ByteArray): ByteArray {
-        if (password.isEmpty()) return ByteArray(0)
-        val h1 = sha256(password.toByteArray(Charsets.UTF_8))
-        val h2 = sha256(h1)
-        val h3 = sha256(h2 + nonce)
-        return xor(h1, h3)
-    }
-
-    private fun encryptPasswordRsa(password: String, nonce: ByteArray, pemPublicKey: String): ByteArray {
-        // Obfuscate (password + null terminator) by XOR with the nonce cycled over its length
-        val pw = password.toByteArray(Charsets.UTF_8) + byteArrayOf(0)
-        val obfuscated = ByteArray(pw.size)
-        for (i in pw.indices) {
-            obfuscated[i] = (pw[i].toInt() xor nonce[i % nonce.size].toInt()).toByte()
-        }
-        val cipher = Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding")
-        cipher.init(Cipher.ENCRYPT_MODE, parsePublicKey(pemPublicKey))
-        return cipher.doFinal(obfuscated)
-    }
-
-    private fun parsePublicKey(pem: String): PublicKey {
-        val base64 = pem
-            .replace("-----BEGIN PUBLIC KEY-----", "")
-            .replace("-----END PUBLIC KEY-----", "")
-            .replace("\\s".toRegex(), "")
-        val der = Base64.getDecoder().decode(base64)
-        return KeyFactory.getInstance("RSA").generatePublic(X509EncodedKeySpec(der))
-    }
-
-    private fun sha256(data: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(data)
-
-    private fun buildHandshakeResponse(
-        username: String,
-        authToken: ByteArray,
-        database: String,
-        authPlugin: String,
-    ): ByteArray {
-        val bos = ByteArrayOutputStream()
-
-        // CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH | CLIENT_LONG_FLAG | CLIENT_TRANSACTIONS
-        var caps = 0x0200 or 0x8000 or 0x00080000 or 0x0004 or 0x2000
-        if (database.isNotEmpty()) caps = caps or 0x0008 // CLIENT_CONNECT_WITH_DB
-
-        bos.write(caps and 0xFF)
-        bos.write((caps ushr 8) and 0xFF)
-        bos.write((caps ushr 16) and 0xFF)
-        bos.write((caps ushr 24) and 0xFF)
-        // Max packet size (16 MB)
-        bos.write(byteArrayOf(0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0x00))
-        // Character set (utf8mb4_general_ci = 45)
-        bos.write(45)
-        // 23 reserved bytes
-        repeat(23) { bos.write(0) }
-        // Username (null-terminated)
-        bos.write(username.toByteArray(Charsets.UTF_8))
-        bos.write(0)
-        // Auth token (length-prefixed, CLIENT_SECURE_CONNECTION style)
-        bos.write(authToken.size)
-        if (authToken.isNotEmpty()) bos.write(authToken)
-        // Database (null-terminated, only when CLIENT_CONNECT_WITH_DB is set)
-        if (database.isNotEmpty()) {
-            bos.write(database.toByteArray(Charsets.UTF_8))
-            bos.write(0)
-        }
-        // Auth plugin name (null-terminated)
-        bos.write(authPlugin.toByteArray(Charsets.US_ASCII))
-        bos.write(0)
-
-        return bos.toByteArray()
+        throw NoSuchFieldException("Could not find the 'socket' field on the driver client class ${client.javaClass}")
     }
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/TargetMySqlServer.kt
@@ -1,0 +1,290 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy.mysql
+
+import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.DatasourceType
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.net.Socket
+import java.security.KeyFactory
+import java.security.MessageDigest
+import java.security.PublicKey
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
+import javax.crypto.Cipher
+
+class TargetMySqlConnection(val socket: Socket)
+
+// Opens and authenticates the upstream connection for a proxied session. MySQL and MariaDB share the same
+// wire protocol, and the handshake below follows whatever auth plugin the server advertises
+// (mysql_native_password or caching_sha2_password, including an AuthSwitchRequest), so one factory serves
+// both flavors; the session's datasourceType records which one the target is.
+class TargetMySqlSocketFactory(
+    private val datasourceType: DatasourceType,
+    private val authenticationDetails: AuthenticationDetails.UserPassword,
+    private val databaseName: String,
+    private val targetHost: String,
+    private val targetPort: Int,
+) {
+    fun createTargetMySqlConnection(): TargetMySqlConnection {
+        val socket = Socket(targetHost, targetPort)
+        try {
+            performHandshake(socket)
+            return TargetMySqlConnection(socket)
+        } catch (e: Exception) {
+            socket.close()
+            throw e
+        }
+    }
+
+    private fun performHandshake(socket: Socket) {
+        val input = socket.getInputStream()
+        val output = socket.getOutputStream()
+
+        // Read the server's Initial Handshake (Protocol Version 10)
+        val (handshakeSeq, handshake) = readPacket(input)
+        if (handshake.isEmpty() || handshake[0] != 10.toByte()) {
+            throw IOException("Unsupported MySQL protocol version (expected 10, got ${handshake.getOrNull(0)})")
+        }
+
+        val server = parseServerHandshake(handshake)
+        var plugin = server.authPlugin
+        var nonce = server.nonce
+
+        // Send the HandshakeResponse using the plugin the server advertised
+        var seq = handshakeSeq
+        val authToken = computeAuthToken(plugin, authenticationDetails.password, nonce)
+        val response = buildHandshakeResponse(authenticationDetails.username, authToken, databaseName, plugin)
+        seq += 1
+        writePacket(output, seq, response)
+
+        // Drive the post-handshake exchange until we reach an OK or ERR packet
+        while (true) {
+            val (replySeq, reply) = readPacket(input)
+            seq = replySeq
+            if (reply.isEmpty()) throw IOException("Empty response from MySQL server during authentication")
+
+            when (reply[0].toInt() and 0xFF) {
+                // OK -- authenticated
+                0x00 -> return
+
+                0xFF -> throw IOException("MySQL server rejected credentials: ${parseErrMessage(reply)}")
+
+                0xFE -> {
+                    // AuthSwitchRequest: 0xFE + plugin name (null-terminated) + auth data
+                    val (newPlugin, newNonce) = parseAuthSwitch(reply)
+                    plugin = newPlugin
+                    nonce = newNonce
+                    seq += 1
+                    writePacket(output, seq, computeAuthToken(plugin, authenticationDetails.password, nonce))
+                }
+
+                0x01 -> {
+                    // AuthMoreData -- currently only used by caching_sha2_password
+                    if (plugin != "caching_sha2_password") {
+                        throw IOException("Unexpected AuthMoreData for auth plugin '$plugin'")
+                    }
+                    when (reply.getOrNull(1)?.toInt()?.and(0xFF)) {
+                        0x03 -> { /* fast_auth_success -- server will send OK next */ }
+
+                        0x04 -> {
+                            // perform_full_authentication: over a plaintext socket we must
+                            // request the server's RSA public key and send the encrypted password.
+                            seq += 1
+                            writePacket(output, seq, byteArrayOf(0x02)) // request_public_key
+                            val (keySeq, keyReply) = readPacket(input)
+                            seq = keySeq
+                            if (keyReply.isEmpty() || (keyReply[0].toInt() and 0xFF) != 0x01) {
+                                throw IOException(
+                                    "Expected RSA public key from server, got 0x${(
+                                        keyReply.getOrNull(
+                                            0,
+                                        )?.toInt()?.and(0xFF) ?: -1
+                                        ).toString(16)}",
+                                )
+                            }
+                            val pem = String(keyReply, 1, keyReply.size - 1, Charsets.US_ASCII)
+                            val encrypted = encryptPasswordRsa(authenticationDetails.password, nonce, pem)
+                            seq += 1
+                            writePacket(output, seq, encrypted)
+                        }
+
+                        else -> throw IOException(
+                            "Unexpected caching_sha2_password more-data byte: " +
+                                "0x${(reply.getOrNull(1)?.toInt()?.and(0xFF) ?: -1).toString(16)}",
+                        )
+                    }
+                }
+
+                else -> throw IOException(
+                    "Unexpected server response byte: 0x${(reply[0].toInt() and 0xFF).toString(16)}",
+                )
+            }
+        }
+    }
+
+    private data class ServerHandshake(val nonce: ByteArray, val authPlugin: String)
+
+    // MySQL Protocol v10 Initial Handshake layout:
+    //   1  protocol version
+    //   N+1  server version (null-terminated)
+    //   4  connection id
+    //   8  auth-plugin-data-part-1
+    //   1  filler
+    //   2  capability flags (lower)
+    //   1  charset
+    //   2  status flags
+    //   2  capability flags (upper)
+    //   1  auth-plugin-data length
+    //   10 reserved
+    //   [CLIENT_SECURE_CONNECTION] auth-plugin-data-part-2 (max(13, len-8) bytes)
+    //   [CLIENT_PLUGIN_AUTH] auth plugin name (null-terminated)
+    private fun parseServerHandshake(handshake: ByteArray): ServerHandshake {
+        var pos = 1
+        while (pos < handshake.size && handshake[pos] != 0.toByte()) pos++
+        pos++ // null terminator of server version
+        pos += 4 // connection id
+        val saltPart1 = handshake.copyOfRange(pos, pos + 8)
+        pos += 8
+        pos += 1 // filler
+        val capLower = (handshake[pos].toInt() and 0xFF) or ((handshake[pos + 1].toInt() and 0xFF) shl 8)
+        pos += 2
+        pos += 1 // charset
+        pos += 2 // status flags
+        val capUpper = (handshake[pos].toInt() and 0xFF) or ((handshake[pos + 1].toInt() and 0xFF) shl 8)
+        pos += 2
+        val capabilities = capLower or (capUpper shl 16)
+        val authPluginDataLen = handshake[pos].toInt() and 0xFF
+        pos += 1
+        pos += 10 // reserved
+
+        var saltPart2 = ByteArray(0)
+        if ((capabilities and 0x8000) != 0) { // CLIENT_SECURE_CONNECTION
+            val len2 = maxOf(13, authPluginDataLen - 8)
+            saltPart2 = handshake.copyOfRange(pos, pos + minOf(12, len2)) // first 12 bytes are the nonce tail
+            pos += len2
+        }
+
+        var plugin = NATIVE_PASSWORD_PLUGIN
+        if ((capabilities and 0x00080000) != 0) { // CLIENT_PLUGIN_AUTH
+            val sb = ByteArrayOutputStream()
+            while (pos < handshake.size && handshake[pos] != 0.toByte()) {
+                sb.write(handshake[pos].toInt())
+                pos++
+            }
+            plugin = String(sb.toByteArray(), Charsets.US_ASCII)
+        }
+
+        return ServerHandshake(saltPart1 + saltPart2, plugin)
+    }
+
+    private fun parseAuthSwitch(packet: ByteArray): Pair<String, ByteArray> {
+        var pos = 1 // skip 0xFE
+        val sb = ByteArrayOutputStream()
+        while (pos < packet.size && packet[pos] != 0.toByte()) {
+            sb.write(packet[pos].toInt())
+            pos++
+        }
+        pos++ // null terminator
+        val plugin = String(sb.toByteArray(), Charsets.US_ASCII)
+        // Remaining auth data; trim a single trailing null if present
+        var end = packet.size
+        if (end > pos && packet[end - 1] == 0.toByte()) end--
+        val nonce = packet.copyOfRange(pos, end)
+        return plugin to nonce
+    }
+
+    private fun parseErrMessage(packet: ByteArray): String {
+        // 0xFF + 2-byte error code + (optional '#' + 5-byte sqlstate) + message
+        if (packet.size <= 3) return "unknown error"
+        var pos = 3
+        if (packet.size > 3 && packet[3] == '#'.code.toByte()) pos = 9
+        if (pos >= packet.size) return "unknown error"
+        return String(packet, pos, packet.size - pos, Charsets.UTF_8)
+    }
+
+    private fun computeAuthToken(plugin: String, password: String, nonce: ByteArray): ByteArray = when (plugin) {
+        NATIVE_PASSWORD_PLUGIN -> computeNativePasswordToken(password, nonce)
+        "caching_sha2_password" -> computeCachingSha2Token(password, nonce)
+        else -> throw IOException("Unsupported target auth plugin '$plugin'")
+    }
+
+    private fun computeNativePasswordToken(password: String, nonce: ByteArray): ByteArray {
+        if (password.isEmpty()) return ByteArray(0)
+        val sha1Password = sha1(password.toByteArray(Charsets.UTF_8))
+        val sha1Sha1Password = sha1(sha1Password)
+        return xor(sha1Password, sha1(nonce + sha1Sha1Password))
+    }
+
+    // caching_sha2_password scramble: SHA256(pw) XOR SHA256(SHA256(SHA256(pw)) || nonce)
+    private fun computeCachingSha2Token(password: String, nonce: ByteArray): ByteArray {
+        if (password.isEmpty()) return ByteArray(0)
+        val h1 = sha256(password.toByteArray(Charsets.UTF_8))
+        val h2 = sha256(h1)
+        val h3 = sha256(h2 + nonce)
+        return xor(h1, h3)
+    }
+
+    private fun encryptPasswordRsa(password: String, nonce: ByteArray, pemPublicKey: String): ByteArray {
+        // Obfuscate (password + null terminator) by XOR with the nonce cycled over its length
+        val pw = password.toByteArray(Charsets.UTF_8) + byteArrayOf(0)
+        val obfuscated = ByteArray(pw.size)
+        for (i in pw.indices) {
+            obfuscated[i] = (pw[i].toInt() xor nonce[i % nonce.size].toInt()).toByte()
+        }
+        val cipher = Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding")
+        cipher.init(Cipher.ENCRYPT_MODE, parsePublicKey(pemPublicKey))
+        return cipher.doFinal(obfuscated)
+    }
+
+    private fun parsePublicKey(pem: String): PublicKey {
+        val base64 = pem
+            .replace("-----BEGIN PUBLIC KEY-----", "")
+            .replace("-----END PUBLIC KEY-----", "")
+            .replace("\\s".toRegex(), "")
+        val der = Base64.getDecoder().decode(base64)
+        return KeyFactory.getInstance("RSA").generatePublic(X509EncodedKeySpec(der))
+    }
+
+    private fun sha256(data: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(data)
+
+    private fun buildHandshakeResponse(
+        username: String,
+        authToken: ByteArray,
+        database: String,
+        authPlugin: String,
+    ): ByteArray {
+        val bos = ByteArrayOutputStream()
+
+        // CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH | CLIENT_LONG_FLAG | CLIENT_TRANSACTIONS
+        var caps = 0x0200 or 0x8000 or 0x00080000 or 0x0004 or 0x2000
+        if (database.isNotEmpty()) caps = caps or 0x0008 // CLIENT_CONNECT_WITH_DB
+
+        bos.write(caps and 0xFF)
+        bos.write((caps ushr 8) and 0xFF)
+        bos.write((caps ushr 16) and 0xFF)
+        bos.write((caps ushr 24) and 0xFF)
+        // Max packet size (16 MB)
+        bos.write(byteArrayOf(0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0x00))
+        // Character set (utf8mb4_general_ci = 45)
+        bos.write(45)
+        // 23 reserved bytes
+        repeat(23) { bos.write(0) }
+        // Username (null-terminated)
+        bos.write(username.toByteArray(Charsets.UTF_8))
+        bos.write(0)
+        // Auth token (length-prefixed, CLIENT_SECURE_CONNECTION style)
+        bos.write(authToken.size)
+        if (authToken.isNotEmpty()) bos.write(authToken)
+        // Database (null-terminated, only when CLIENT_CONNECT_WITH_DB is set)
+        if (database.isNotEmpty()) {
+            bos.write(database.toByteArray(Charsets.UTF_8))
+            bos.write(0)
+        }
+        // Auth plugin name (null-terminated)
+        bos.write(authPlugin.toByteArray(Charsets.US_ASCII))
+        bos.write(0)
+
+        return bos.toByteArray()
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -79,6 +79,7 @@ class ExecutionRequestService(
     private val connectionService: ConnectionService,
     private val userAdapter: UserAdapter,
     private val postgresProxyServer: ProxyServer,
+    private val mysqlProxyServer: ProxyServer,
     private val dryRunValidator: DryRunValidator,
     private val roleAdapter: dev.kviklet.kviklet.db.RoleAdapter,
     private val permissionResolver: PermissionResolver,
@@ -958,15 +959,24 @@ class ExecutionRequestService(
         if (reviewStatus != ReviewStatus.APPROVED) {
             throw InvalidReviewException("This request has not been approved yet!")
         }
-        if (connection.type != DatasourceType.POSTGRESQL) {
-            throw RuntimeException("Only Postgres is supported for proxying!")
+        // One long-lived listener per wire protocol: Postgres on its own port, MySQL and MariaDB sharing
+        // one (they speak the same protocol; the session's datasourceType picks the upstream flavor).
+        val proxyServer = when (connection.type) {
+            DatasourceType.POSTGRESQL -> postgresProxyServer
+            DatasourceType.MYSQL, DatasourceType.MARIADB -> mysqlProxyServer
+            else -> throw RuntimeException("Only Postgres, MySQL and MariaDB are supported for proxying!")
         }
         if (connection.auth !is AuthenticationDetails.UserPassword) {
             throw RuntimeException("Only UserPassword authentication is supported for proxying!")
         }
-        if (!postgresProxyServer.isRunning) {
+        if (!proxyServer.isRunning) {
+            val portProperty = if (connection.type == DatasourceType.POSTGRESQL) {
+                "kviklet.proxy.postgres.port"
+            } else {
+                "kviklet.proxy.mysql.port"
+            }
             throw RuntimeException(
-                "The Postgres proxy listener is not available. Set kviklet.proxy.postgres.port to a free port.",
+                "The ${connection.type} proxy listener is not available. Set $portProperty to a free port.",
             )
         }
 
@@ -988,7 +998,7 @@ class ExecutionRequestService(
         // request already has a live session -- the existing one, whose credentials are handed out again.
         // That makes repeated proxy calls idempotent (re-opening the page keeps a running psql connected)
         // instead of accumulating never-expiring registry entries.
-        val session = postgresProxyServer.registerSession(
+        val session = proxyServer.registerSession(
             ProxySession(
                 username = username,
                 password = password,
@@ -997,6 +1007,7 @@ class ExecutionRequestService(
                 targetHost = connection.hostname,
                 targetPort = connection.port,
                 databaseName = connection.databaseName ?: "",
+                datasourceType = connection.type,
                 authenticationDetails = connection.auth,
             ),
             expiresAt = executionRequest.request.temporaryAccessDuration?.let {
@@ -1004,16 +1015,16 @@ class ExecutionRequestService(
             },
         )
         if (session.username == username) {
-            logger.info("Registered proxy session $username on port ${postgresProxyServer.listenPort}")
+            logger.info("Registered proxy session $username on port ${proxyServer.listenPort}")
         } else {
             logger.info(
-                "Reusing existing proxy session ${session.username} on port ${postgresProxyServer.listenPort}",
+                "Reusing existing proxy session ${session.username} on port ${proxyServer.listenPort}",
             )
         }
 
         return ExecutionProxy(
             request = executionRequest.request,
-            port = postgresProxyServer.listenPort,
+            port = proxyServer.listenPort,
             username = session.username,
             password = session.password,
             startTime = firstEventTime,

--- a/backend/src/main/resources/application-test.properties
+++ b/backend/src/main/resources/application-test.properties
@@ -33,6 +33,7 @@ spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDri
 server.tomcat.accesslog.enabled=true
 server.tomcat.accesslog.pattern=%t %a "%r" %s (%D ms)
 app.in-docker=false
-# Disable the boot-bound proxy listener in tests; the proxy suites start their own ProxyServer
+# Disable the boot-bound proxy listeners in tests; the proxy suites start their own ProxyServer
 # instances on random ports instead.
 kviklet.proxy.postgres.port=-1
+kviklet.proxy.mysql.port=-1

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -18,3 +18,8 @@ server.tomcat.accesslog.pattern=%t %a "%r" %s (%D ms)
 # username. Set to <= 0 to disable the listener. If the port is already taken the app still boots; the
 # proxy is simply unavailable (a bind error is logged).
 kviklet.proxy.postgres.port=5432
+# Stable port for the MySQL/MariaDB access proxy. The two share one wire protocol, so a single listener
+# serves both; each session is routed by temp username and carries its upstream flavor. Set to <= 0 to
+# disable the listener. If the port is already taken the app still boots; the proxy is simply
+# unavailable (a bind error is logged).
+kviklet.proxy.mysql.port=3306

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyAuthTest.kt
@@ -1,0 +1,182 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.db.EventAdapter
+import dev.kviklet.kviklet.db.ExecutionRequestAdapter
+import dev.kviklet.kviklet.proxy.core.ProxyServer
+import dev.kviklet.kviklet.proxy.helpers.MySqlProxyInstance
+import dev.kviklet.kviklet.proxy.helpers.mysqlProxyServerFactory
+import dev.kviklet.kviklet.service.dto.DatasourceType
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.containers.JdbcDatabaseContainer
+import org.testcontainers.containers.MariaDBContainer
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.lifecycle.Startables
+import org.testcontainers.utility.DockerImageName
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.util.Properties
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MySqlProxyAuthTest {
+    @Autowired
+    lateinit var executionRequestAdapter: ExecutionRequestAdapter
+
+    @Autowired
+    lateinit var eventAdapter: EventAdapter
+    private val startedProxies = mutableListOf<ProxyServer>()
+
+    companion object {
+        private val mysqlContainer: MySQLContainer<*> = MySQLContainer(DockerImageName.parse("mysql:8.2")).apply {
+            withDatabaseName("testdb")
+            withUsername("test")
+            withPassword("test")
+        }
+        private val mariadbContainer: MariaDBContainer<*> = MariaDBContainer(DockerImageName.parse("mariadb:11.4"))
+            .apply {
+                withDatabaseName("testdb")
+                withUsername("test")
+                withPassword("test")
+            }
+
+        @JvmStatic
+        @BeforeAll
+        fun startContainers() {
+            Startables.deepStart(listOf(mysqlContainer, mariadbContainer)).join()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopContainers() {
+            mysqlContainer.stop()
+            mariadbContainer.stop()
+        }
+
+        @JvmStatic
+        fun datasourceTypes() = listOf(DatasourceType.MYSQL, DatasourceType.MARIADB)
+
+        private fun container(type: DatasourceType): JdbcDatabaseContainer<*> = when (type) {
+            DatasourceType.MYSQL -> mysqlContainer
+            DatasourceType.MARIADB -> mariadbContainer
+            else -> throw IllegalArgumentException("$type is not served by the MySQL proxy")
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        startedProxies.forEach { it.shutdownServer() }
+        startedProxies.clear()
+    }
+
+    private fun startProxy(
+        type: DatasourceType,
+        username: String = "proxyUser",
+        password: String = "proxyPassword",
+    ): MySqlProxyInstance {
+        val instance = mysqlProxyServerFactory(
+            container(type),
+            type,
+            executionRequestAdapter,
+            eventAdapter,
+            username = username,
+            password = password,
+        )
+        startedProxies.add(instance.proxy)
+        return instance
+    }
+
+    private fun connectWith(proxy: MySqlProxyInstance, user: String, password: String?): SQLException =
+        assertThrows<SQLException> {
+            val props = Properties()
+            props.setProperty("user", user)
+            password?.let { props.setProperty("password", it) }
+            DriverManager.getConnection(proxy.connectionString, props)
+        }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `MySQL proxy must require password-based authentication`(type: DatasourceType) {
+        val proxy = startProxy(type)
+        val throwable = connectWith(proxy, proxy.username, null)
+        assertEquals(1045, throwable.errorCode)
+        assertEquals("28000", throwable.sqlState)
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `MySQL proxy must use externally injected username and password`(type: DatasourceType) {
+        val randomUsername = getRandomString(8)
+        val randomPassword = getRandomString(16)
+        val proxy = startProxy(type, username = randomUsername, password = randomPassword)
+        assertDoesNotThrow {
+            proxy.connect(randomUsername, randomPassword).use { conn ->
+                conn.createStatement().executeQuery("SELECT 1").close()
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `MySQL proxy must reject bad username and password`(type: DatasourceType) {
+        val proxy = startProxy(type, username = "notuser", password = "notpass")
+        val throwable = connectWith(proxy, getRandomString(8), getRandomString(16))
+        assertEquals(1045, throwable.errorCode)
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `the correct username with a wrong password fails with 1045, not a connection reset`(type: DatasourceType) {
+        val username = getRandomString(8)
+        val proxy = startProxy(type, username = username, password = getRandomString(16))
+        val throwable = connectWith(proxy, username, "definitely-the-wrong-password")
+        assertEquals(1045, throwable.errorCode)
+        assertEquals("28000", throwable.sqlState)
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `a wrong username with the correct password is rejected`(type: DatasourceType) {
+        val password = getRandomString(16)
+        val proxy = startProxy(type, username = getRandomString(8), password = password)
+        val throwable = connectWith(proxy, "wronguser", password)
+        assertEquals(1045, throwable.errorCode)
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `an unknown username is indistinguishable from a wrong password`(type: DatasourceType) {
+        val validUsername = getRandomString(8)
+        val proxy = startProxy(type, username = validUsername, password = getRandomString(16))
+
+        val unknownUsername = getRandomString(8)
+        val unknownUserFailure = connectWith(proxy, unknownUsername, "some-password")
+        val wrongPasswordFailure = connectWith(proxy, validUsername, "some-password")
+
+        // Same error code, SQL state and message shape: a probe cannot tell an unknown user from a wrong
+        // password, so valid temp usernames cannot be enumerated.
+        assertEquals(wrongPasswordFailure.errorCode, unknownUserFailure.errorCode)
+        assertEquals(wrongPasswordFailure.sqlState, unknownUserFailure.sqlState)
+        assertEquals(
+            normalizeAccessDeniedMessage(wrongPasswordFailure.message!!, validUsername),
+            normalizeAccessDeniedMessage(unknownUserFailure.message!!, unknownUsername),
+        )
+    }
+
+    // Strips the parts of an access-denied message that legitimately differ per attempt: the echoed
+    // username and the driver's connection id prefix (the MariaDB driver prepends "(conn=N)").
+    private fun normalizeAccessDeniedMessage(message: String, username: String): String = message
+        .replace(username, "<user>")
+        .replace(Regex("\\(conn=-?\\d+\\)"), "")
+        .trim()
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyConnectionLifecycleTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyConnectionLifecycleTest.kt
@@ -1,0 +1,256 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.db.EventAdapter
+import dev.kviklet.kviklet.db.ExecutionRequestAdapter
+import dev.kviklet.kviklet.proxy.core.ProxyServer
+import dev.kviklet.kviklet.proxy.helpers.MySqlProxyInstance
+import dev.kviklet.kviklet.proxy.helpers.mysqlClientJdbcUrl
+import dev.kviklet.kviklet.proxy.helpers.mysqlDirectConnectionFactory
+import dev.kviklet.kviklet.proxy.helpers.mysqlProxyServerFactory
+import dev.kviklet.kviklet.proxy.mysql.TargetMySqlSocketFactory
+import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.DatasourceType
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.containers.JdbcDatabaseContainer
+import org.testcontainers.containers.MariaDBContainer
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.lifecycle.Startables
+import org.testcontainers.utility.DockerImageName
+import java.net.Socket
+import java.sql.Connection
+import java.sql.DriverManager
+import java.util.Properties
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MySqlProxyConnectionLifecycleTest {
+    @Autowired
+    lateinit var executionRequestAdapter: ExecutionRequestAdapter
+
+    @Autowired
+    lateinit var eventAdapter: EventAdapter
+    private val startedProxies = mutableListOf<ProxyServer>()
+    private val openedConnections = mutableListOf<Connection>()
+
+    companion object {
+        private val mysqlContainer: MySQLContainer<*> = MySQLContainer(DockerImageName.parse("mysql:8.2")).apply {
+            withDatabaseName("testdb")
+            withUsername("test")
+            withPassword("test")
+        }
+        private val mariadbContainer: MariaDBContainer<*> = MariaDBContainer(DockerImageName.parse("mariadb:11.4"))
+            .apply {
+                withDatabaseName("testdb")
+                withUsername("test")
+                withPassword("test")
+            }
+
+        @JvmStatic
+        @BeforeAll
+        fun startContainers() {
+            Startables.deepStart(listOf(mysqlContainer, mariadbContainer)).join()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopContainers() {
+            mysqlContainer.stop()
+            mariadbContainer.stop()
+        }
+
+        @JvmStatic
+        fun datasourceTypes() = listOf(DatasourceType.MYSQL, DatasourceType.MARIADB)
+
+        private fun container(type: DatasourceType): JdbcDatabaseContainer<*> = when (type) {
+            DatasourceType.MYSQL -> mysqlContainer
+            DatasourceType.MARIADB -> mariadbContainer
+            else -> throw IllegalArgumentException("$type is not served by the MySQL proxy")
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        openedConnections.forEach { runCatching { it.close() } }
+        openedConnections.clear()
+        startedProxies.forEach { it.shutdownServer() }
+        startedProxies.clear()
+    }
+
+    private fun startProxy(type: DatasourceType, handshakeTimeoutMs: Int = 10_000): MySqlProxyInstance {
+        val instance = mysqlProxyServerFactory(
+            container(type),
+            type,
+            executionRequestAdapter,
+            eventAdapter,
+            handshakeTimeoutMs = handshakeTimeoutMs,
+        )
+        startedProxies.add(instance.proxy)
+        return instance
+    }
+
+    private fun directConnection(type: DatasourceType): Connection =
+        mysqlDirectConnectionFactory(container(type)).also { openedConnections.add(it) }
+
+    // Counts upstream connections opened by the proxy (all use the target user 'test'), excluding the
+    // connection running this very query. Both MySQL and MariaDB expose them in
+    // information_schema.processlist, and without the PROCESS privilege the 'test' account sees exactly
+    // its own account's threads, which is all the proxy ever opens.
+    private fun upstreamConnectionCount(direct: Connection): Int {
+        direct.createStatement().executeQuery(
+            "SELECT count(*) FROM information_schema.processlist WHERE user = 'test' AND id <> CONNECTION_ID()",
+        ).use { rs ->
+            rs.next()
+            return rs.getInt(1)
+        }
+    }
+
+    private fun awaitUpstreamCount(direct: Connection, expected: Int, timeoutMillis: Long = 20_000) {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+        var last = -1
+        while (System.currentTimeMillis() < deadline) {
+            last = upstreamConnectionCount(direct)
+            if (last == expected) return
+            Thread.sleep(200)
+        }
+        assertEquals(expected, last, "Upstream connection count on the target database did not settle")
+    }
+
+    private fun awaitConnectionCount(target: ProxyServer, expected: Int, timeoutMillis: Long = 20_000) {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+        while (System.currentTimeMillis() < deadline && target.currentConnections != expected) {
+            Thread.sleep(100)
+        }
+        assertEquals(expected, target.currentConnections, "Expected the proxy to be handling $expected connection(s)")
+    }
+
+    private fun awaitPendingHandshakeCount(target: ProxyServer, expected: Int, timeoutMillis: Long = 20_000) {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+        while (System.currentTimeMillis() < deadline && target.pendingHandshakes != expected) {
+            Thread.sleep(100)
+        }
+        assertEquals(expected, target.pendingHandshakes, "Expected $expected pending handshake(s)")
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `cleanly disconnected sessions close their upstream connections and are pruned`(type: DatasourceType) {
+        val proxy = startProxy(type)
+        val direct = directConnection(type)
+        val baselineUpstream = upstreamConnectionCount(direct)
+        val sessionCount = 2
+
+        val connections = (1..sessionCount).map { proxy.connect() }
+        connections.forEach { it.createStatement().executeQuery("SELECT 1").close() }
+        awaitUpstreamCount(direct, baselineUpstream + sessionCount)
+        awaitConnectionCount(proxy.proxy, sessionCount)
+
+        connections.forEach { it.close() }
+
+        awaitUpstreamCount(direct, baselineUpstream)
+        awaitConnectionCount(proxy.proxy, 0)
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `an abrupt client disconnect closes the upstream connection`(type: DatasourceType) {
+        val proxy = startProxy(type)
+        val direct = directConnection(type)
+        val baselineUpstream = upstreamConnectionCount(direct)
+
+        // TargetMySqlSocketFactory is a full wire-protocol client, so pointing it at the proxy gives an
+        // authenticated raw socket that can be closed without any Quit message, like a crashed client.
+        val client = TargetMySqlSocketFactory(
+            type,
+            AuthenticationDetails.UserPassword(proxy.username, proxy.password),
+            "testdb",
+            "localhost",
+            proxy.port,
+        ).createTargetMySqlConnection()
+        awaitUpstreamCount(direct, baselineUpstream + 1)
+
+        client.socket.close()
+
+        awaitUpstreamCount(direct, baselineUpstream)
+        awaitConnectionCount(proxy.proxy, 0)
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `a bare TCP connection that closes immediately opens no upstream connection and frees the slot`(
+        type: DatasourceType,
+    ) {
+        val proxy = startProxy(type)
+        val direct = directConnection(type)
+        val baselineUpstream = upstreamConnectionCount(direct)
+
+        Socket("localhost", proxy.port).close()
+
+        awaitConnectionCount(proxy.proxy, 0)
+        awaitPendingHandshakeCount(proxy.proxy, 0)
+        awaitUpstreamCount(direct, baselineUpstream)
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `an idle client that never completes the handshake is dropped after the deadline`(type: DatasourceType) {
+        val proxy = startProxy(type, handshakeTimeoutMs = 2500)
+        val direct = directConnection(type)
+        val baselineUpstream = upstreamConnectionCount(direct)
+        val socket = Socket("localhost", proxy.port)
+        try {
+            // The idle client never answers the proxy's initial handshake, so it occupies a
+            // pending-handshake slot (not a relay slot) until the deadline.
+            awaitPendingHandshakeCount(proxy.proxy, 1, timeoutMillis = 2000)
+            awaitPendingHandshakeCount(proxy.proxy, 0)
+            awaitUpstreamCount(direct, baselineUpstream)
+        } finally {
+            socket.close()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `queries through the proxy are audited`(type: DatasourceType) {
+        val proxy = startProxy(type)
+        proxy.connect().use { conn ->
+            conn.createStatement().executeQuery("SELECT 42").use { rs ->
+                assertTrue(rs.next())
+                assertEquals(42, rs.getInt(1))
+            }
+        }
+        proxy.eventService.assertAuditedQueryContains("SELECT 42")
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `server-side prepared statements are audited on execute`(type: DatasourceType) {
+        val proxy = startProxy(type)
+        val url = mysqlClientJdbcUrl(type, proxy.port, extraParams = "&useServerPrepStmts=true")
+        DriverManager.getConnection(
+            url,
+            Properties().apply {
+                setProperty("user", proxy.username)
+                setProperty("password", proxy.password)
+            },
+        ).use { conn ->
+            conn.prepareStatement("SELECT ? + 40").use { stmt ->
+                stmt.setInt(1, 2)
+                stmt.executeQuery().use { rs ->
+                    assertTrue(rs.next())
+                    assertEquals(42, rs.getInt(1))
+                }
+            }
+        }
+        proxy.eventService.assertAuditedQueryContains("? + 40")
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyExpiryTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyExpiryTest.kt
@@ -1,0 +1,187 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.db.EventAdapter
+import dev.kviklet.kviklet.db.ExecutionRequestAdapter
+import dev.kviklet.kviklet.helper.ExecutionRequestFactory
+import dev.kviklet.kviklet.proxy.core.ProxyServer
+import dev.kviklet.kviklet.proxy.core.ProxySession
+import dev.kviklet.kviklet.proxy.helpers.mysqlClientJdbcUrl
+import dev.kviklet.kviklet.proxy.helpers.waitForProxyStart
+import dev.kviklet.kviklet.proxy.mocks.EventServiceMock
+import dev.kviklet.kviklet.proxy.mysql.MySqlProtocol
+import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.DatasourceType
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.containers.JdbcDatabaseContainer
+import org.testcontainers.containers.MariaDBContainer
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.lifecycle.Startables
+import org.testcontainers.utility.DockerImageName
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Duration
+import java.time.Instant
+import java.util.Properties
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MySqlProxyExpiryTest {
+    @Autowired
+    lateinit var executionRequestAdapter: ExecutionRequestAdapter
+
+    @Autowired
+    lateinit var eventAdapter: EventAdapter
+    private lateinit var server: ProxyServer
+    private var port = 0
+
+    companion object {
+        private val mysqlContainer: MySQLContainer<*> = MySQLContainer(DockerImageName.parse("mysql:8.2")).apply {
+            withDatabaseName("testdb")
+            withUsername("test")
+            withPassword("test")
+        }
+        private val mariadbContainer: MariaDBContainer<*> = MariaDBContainer(DockerImageName.parse("mariadb:11.4"))
+            .apply {
+                withDatabaseName("testdb")
+                withUsername("test")
+                withPassword("test")
+            }
+
+        @JvmStatic
+        @BeforeAll
+        fun startContainers() {
+            Startables.deepStart(listOf(mysqlContainer, mariadbContainer)).join()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopContainers() {
+            mysqlContainer.stop()
+            mariadbContainer.stop()
+        }
+    }
+
+    @BeforeEach
+    fun setup() {
+        port = (31001..32000).random()
+        server = ProxyServer(port, MySqlProtocol(eventServiceMock(), null))
+        server.start()
+        waitForProxyStart(server)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdownServer()
+    }
+
+    private fun eventServiceMock() = EventServiceMock(
+        executionRequestAdapter,
+        eventAdapter,
+        ExecutionRequestFactory().createDatasourceExecutionRequest(),
+    )
+
+    private fun register(
+        username: String,
+        password: String,
+        container: JdbcDatabaseContainer<*>,
+        datasourceType: DatasourceType,
+        expiresAt: Instant = Instant.now().plus(Duration.ofMinutes(10)),
+    ) {
+        server.registerSession(
+            ProxySession(
+                username = username,
+                password = password,
+                executionRequest = ExecutionRequestFactory().createDatasourceExecutionRequest(),
+                userId = "mock",
+                targetHost = container.host,
+                targetPort = container.getMappedPort(3306),
+                databaseName = "testdb",
+                datasourceType = datasourceType,
+                authenticationDetails = AuthenticationDetails.UserPassword("test", "test"),
+            ),
+            expiresAt = expiresAt,
+        )
+    }
+
+    private fun connect(datasourceType: DatasourceType, username: String, password: String): Connection =
+        DriverManager.getConnection(
+            mysqlClientJdbcUrl(datasourceType, port),
+            Properties().apply {
+                setProperty("user", username)
+                setProperty("password", password)
+            },
+        )
+
+    @Test
+    fun `an expiring session tears down its live connection while the shared listener keeps serving`() {
+        // A finite session whose window elapses must close its own in-flight connection and free the slot,
+        // while the one shared listener stays up and keeps serving other sessions.
+
+        // Expire ~5s from now. The headroom lets the connect + query below finish while the session is
+        // still live, even on slow CI.
+        register(
+            "expiring",
+            "pw",
+            mysqlContainer,
+            DatasourceType.MYSQL,
+            expiresAt = Instant.now().plusSeconds(5),
+        )
+        val conn = connect(DatasourceType.MYSQL, "expiring", "pw")
+        conn.createStatement().executeQuery("SELECT 1").close()
+        assertTrue(server.currentConnections >= 1, "The session's connection should be live before it expires")
+
+        val deadline = System.currentTimeMillis() + 15_000
+        while (server.currentConnections != 0 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(100)
+        }
+        assertEquals(0, server.currentConnections, "The expired session's live connection was not torn down")
+        assertTrue(server.isRunning, "Session expiry must not shut the server down")
+        runCatching { conn.close() }
+
+        // The listener still serves a fresh session on the same port after the other one expired.
+        register("fresh", "pw2", mysqlContainer, DatasourceType.MYSQL)
+        connect(DatasourceType.MYSQL, "fresh", "pw2").use { fresh ->
+            fresh.createStatement().executeQuery("SELECT 1").close()
+        }
+    }
+
+    @Test
+    fun `one listener routes two sessions to different upstreams by username`() {
+        // The datasourceType carried on the session is what picks the upstream flavor: one 3306-style
+        // listener serves a MySQL session and a MariaDB session side by side, told apart only by the temp
+        // username in the client handshake.
+        register("mysqluser", "mysqlpw", mysqlContainer, DatasourceType.MYSQL)
+        register("mariauser", "mariapw", mariadbContainer, DatasourceType.MARIADB)
+
+        connect(DatasourceType.MYSQL, "mysqluser", "mysqlpw").use { conn ->
+            conn.createStatement().executeQuery("SELECT VERSION()").use { rs ->
+                assertTrue(rs.next())
+                assertFalse(
+                    rs.getString(1).contains("MariaDB", ignoreCase = true),
+                    "The MySQL session must land on the MySQL upstream, got: ${rs.getString(1)}",
+                )
+            }
+        }
+
+        connect(DatasourceType.MARIADB, "mariauser", "mariapw").use { conn ->
+            conn.createStatement().executeQuery("SELECT VERSION()").use { rs ->
+                assertTrue(rs.next())
+                assertTrue(
+                    rs.getString(1).contains("MariaDB", ignoreCase = true),
+                    "The MariaDB session must land on the MariaDB upstream, got: ${rs.getString(1)}",
+                )
+            }
+        }
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
@@ -1,0 +1,211 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.proxy.mysql.MySqlClientPacketParser
+import dev.kviklet.kviklet.proxy.mysql.MySqlServerPacketParser
+import dev.kviklet.kviklet.proxy.mysql.buildErrPacket
+import dev.kviklet.kviklet.proxy.mysql.buildInitialHandshake
+import dev.kviklet.kviklet.proxy.mysql.buildOkPacket
+import dev.kviklet.kviklet.proxy.mysql.verifyPassword
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+
+class MySqlProxyUnitTest {
+
+    @Test
+    fun `test verifyPassword with correct and incorrect credentials`() {
+        val scramble = byteArrayOf(
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+            11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        )
+        val password = "secretPassword123"
+
+        // Let's compute the expected client hash manually using the formula:
+        // SHA1(password) XOR SHA1(scramble + SHA1(SHA1(password)))
+        val sha1 = java.security.MessageDigest.getInstance("SHA-1")
+        val sha1Password = sha1.digest(password.toByteArray(Charsets.UTF_8))
+        val sha1Sha1Password = sha1.digest(sha1Password)
+
+        val concat = ByteArray(scramble.size + sha1Sha1Password.size)
+        System.arraycopy(scramble, 0, concat, 0, scramble.size)
+        System.arraycopy(sha1Sha1Password, 0, concat, scramble.size, sha1Sha1Password.size)
+
+        val sha1Concat = sha1.digest(concat)
+        val clientHash = ByteArray(sha1Password.size)
+        for (i in sha1Password.indices) {
+            clientHash[i] = (sha1Password[i].toInt() xor sha1Concat[i].toInt()).toByte()
+        }
+
+        // Must verify successfully
+        assertTrue(verifyPassword(scramble, password, clientHash))
+
+        // Must fail with incorrect password
+        assertFalse(verifyPassword(scramble, "wrongPassword", clientHash))
+
+        // Must fail with modified client hash
+        clientHash[0] = (clientHash[0] + 1).toByte()
+        assertFalse(verifyPassword(scramble, password, clientHash))
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser parses COM_QUERY successfully`() {
+        var parsedQuery = ""
+        val parser = MySqlClientPacketParser(
+            onQuery = { parsedQuery = it },
+            onPrepare = {},
+            onExecute = {},
+            onQuit = {},
+        )
+
+        val sql = "SELECT * FROM users WHERE id = 1"
+        val sqlBytes = sql.toByteArray(Charsets.UTF_8)
+
+        val bos = ByteArrayOutputStream()
+        // MySQL Packet Header: 3 bytes length, 1 byte sequence id
+        val length = sqlBytes.size + 1 // +1 for the command byte
+        bos.write(length and 0xFF)
+        bos.write((length ushr 8) and 0xFF)
+        bos.write((length ushr 16) and 0xFF)
+        bos.write(0) // Sequence ID
+
+        bos.write(0x03) // COM_QUERY command byte
+        bos.write(sqlBytes)
+
+        parser.addBytes(bos.toByteArray())
+
+        assertEquals(sql, parsedQuery)
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser parses COM_STMT_PREPARE successfully`() {
+        var parsedQuery = ""
+        val parser = MySqlClientPacketParser(
+            onQuery = {},
+            onPrepare = { parsedQuery = it },
+            onExecute = {},
+            onQuit = {},
+        )
+
+        val sql = "INSERT INTO logs (message) VALUES (?)"
+        val sqlBytes = sql.toByteArray(Charsets.UTF_8)
+
+        val bos = ByteArrayOutputStream()
+        val length = sqlBytes.size + 1
+        bos.write(length and 0xFF)
+        bos.write((length ushr 8) and 0xFF)
+        bos.write((length ushr 16) and 0xFF)
+        bos.write(0) // Sequence ID
+
+        bos.write(0x16) // COM_STMT_PREPARE command byte
+        bos.write(sqlBytes)
+
+        parser.addBytes(bos.toByteArray())
+
+        assertEquals(sql, parsedQuery)
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser parses COM_STMT_EXECUTE successfully`() {
+        var executedStmtId = 0
+        val parser = MySqlClientPacketParser(
+            onQuery = {},
+            onPrepare = {},
+            onExecute = { executedStmtId = it },
+            onQuit = {},
+        )
+
+        val bos = ByteArrayOutputStream()
+        val length = 5 // 1 cmd + 4 stmtId
+        bos.write(length and 0xFF)
+        bos.write((length ushr 8) and 0xFF)
+        bos.write((length ushr 16) and 0xFF)
+        bos.write(0) // Sequence ID
+
+        bos.write(0x17) // COM_STMT_EXECUTE command byte
+        bos.write(42 and 0xFF) // stmtId byte 1
+        bos.write(0)
+        bos.write(0)
+        bos.write(0)
+
+        parser.addBytes(bos.toByteArray())
+
+        assertEquals(42, executedStmtId)
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser parses COM_QUIT successfully`() {
+        var quitCalled = false
+        val parser = MySqlClientPacketParser(
+            onQuery = {},
+            onPrepare = {},
+            onExecute = {},
+            onQuit = { quitCalled = true },
+        )
+
+        val bos = ByteArrayOutputStream()
+        val length = 1
+        bos.write(length and 0xFF)
+        bos.write((length ushr 8) and 0xFF)
+        bos.write((length ushr 16) and 0xFF)
+        bos.write(0) // Sequence ID
+
+        bos.write(0x01) // COM_QUIT command byte
+
+        parser.addBytes(bos.toByteArray())
+
+        assertTrue(quitCalled)
+    }
+
+    @Test
+    fun `test MySqlServerPacketParser parses STMT_PREPARE_OK successfully`() {
+        var returnedStmtId = 0
+        val parser = MySqlServerPacketParser({ returnedStmtId = it })
+
+        val bos = ByteArrayOutputStream()
+        val length = 12 // 1 status + 4 stmt_id + 2 columns + 2 params + 1 filler + 2 warnings
+        bos.write(length and 0xFF)
+        bos.write((length ushr 8) and 0xFF)
+        bos.write((length ushr 16) and 0xFF)
+        bos.write(1) // Sequence ID
+
+        bos.write(0x00) // status
+        bos.write(99 and 0xFF) // stmtId byte 1
+        bos.write(0)
+        bos.write(0)
+        bos.write(0)
+
+        // Filler columns, params, warning
+        for (i in 0 until 7) bos.write(0)
+
+        parser.addBytes(bos.toByteArray())
+
+        assertEquals(99, returnedStmtId)
+    }
+
+    @Test
+    fun `test buildInitialHandshake structure`() {
+        val salt = ByteArray(20) { it.toByte() }
+        val handshake = buildInitialHandshake(1234, salt, false)
+
+        // Protocol version must be 10
+        assertEquals(10.toByte(), handshake[0])
+
+        // Server version should start after protocol byte
+        val versionStr = String(handshake, 1, 14, Charsets.US_ASCII)
+        assertEquals("8.0.35-kviklet", versionStr)
+    }
+
+    @Test
+    fun `test buildOkPacket and buildErrPacket structure`() {
+        val ok = buildOkPacket()
+        assertEquals(0x00.toByte(), ok[0]) // OK header
+
+        val err = buildErrPacket(1045, "28000", "Access denied")
+        assertEquals(0xFF.toByte(), err[0]) // ERR header
+        assertEquals(1045 and 0xFF, err[1].toInt() and 0xFF)
+        assertEquals('#'.code.toByte(), err[3])
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyAuthTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyAuthTest.kt
@@ -13,6 +13,7 @@ import dev.kviklet.kviklet.proxy.helpers.waitForProxyStart
 import dev.kviklet.kviklet.proxy.mocks.EventServiceMock
 import dev.kviklet.kviklet.proxy.postgres.PostgresProtocol
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.DatasourceType
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -99,6 +100,7 @@ class PostgresProxyAuthTest {
                 targetHost = postgresContainer.host,
                 targetPort = postgresContainer.getMappedPort(5432),
                 databaseName = "testdb",
+                datasourceType = DatasourceType.POSTGRESQL,
                 authenticationDetails = connAuth,
             ),
             expiresAt = Instant.now().plus(Duration.ofMinutes(10)),
@@ -136,6 +138,7 @@ class PostgresProxyAuthTest {
                 targetHost = postgresContainer.host,
                 targetPort = postgresContainer.getMappedPort(5432),
                 databaseName = "testdb",
+                datasourceType = DatasourceType.POSTGRESQL,
                 authenticationDetails = connAuth,
             ),
             expiresAt = Instant.now().plus(Duration.ofMinutes(10)),
@@ -207,6 +210,7 @@ class PostgresProxyAuthTest {
                     targetHost = postgresContainer.host,
                     targetPort = postgresContainer.getMappedPort(5432),
                     databaseName = "testdb",
+                    datasourceType = DatasourceType.POSTGRESQL,
                     authenticationDetails = connAuth,
                 ),
                 expiresAt = Instant.now().plus(Duration.ofMinutes(10)),
@@ -262,6 +266,7 @@ class PostgresProxyAuthTest {
                 targetHost = postgresContainer.host,
                 targetPort = postgresContainer.getMappedPort(5432),
                 databaseName = "testdb",
+                datasourceType = DatasourceType.POSTGRESQL,
                 authenticationDetails = AuthenticationDetails.UserPassword("test", "test"),
             ),
             expiresAt = Instant.now().plus(Duration.ofMinutes(10)),

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyExpiryTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyExpiryTest.kt
@@ -11,6 +11,7 @@ import dev.kviklet.kviklet.proxy.helpers.waitForProxyStart
 import dev.kviklet.kviklet.proxy.mocks.EventServiceMock
 import dev.kviklet.kviklet.proxy.postgres.PostgresProtocol
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.DatasourceType
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -76,6 +77,7 @@ class PostgresProxyExpiryTest {
                 targetHost = postgresContainer.host,
                 targetPort = postgresContainer.getMappedPort(5432),
                 databaseName = "testdb",
+                datasourceType = DatasourceType.POSTGRESQL,
                 authenticationDetails = AuthenticationDetails.UserPassword("test", "test"),
             ),
             expiresAt = getShutdownDate(startTime, maxTimeMinutes).toInstant(),

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/ProxyServerSessionReuseTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/ProxyServerSessionReuseTest.kt
@@ -8,6 +8,7 @@ import dev.kviklet.kviklet.proxy.core.ProxyProtocol
 import dev.kviklet.kviklet.proxy.core.ProxyServer
 import dev.kviklet.kviklet.proxy.core.ProxySession
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.DatasourceType
 import dev.kviklet.kviklet.service.dto.ExecutionRequest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -46,6 +47,7 @@ class ProxyServerSessionReuseTest {
         targetHost = "localhost",
         targetPort = 5432,
         databaseName = "testdb",
+        datasourceType = DatasourceType.POSTGRESQL,
         authenticationDetails = AuthenticationDetails.UserPassword("test", "test"),
     )
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/MySqlFactories.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/MySqlFactories.kt
@@ -1,0 +1,90 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy.helpers
+
+import dev.kviklet.kviklet.db.EventAdapter
+import dev.kviklet.kviklet.db.ExecutionRequestAdapter
+import dev.kviklet.kviklet.helper.ExecutionRequestFactory
+import dev.kviklet.kviklet.proxy.core.ProxyServer
+import dev.kviklet.kviklet.proxy.core.ProxySession
+import dev.kviklet.kviklet.proxy.core.TLSCertificate
+import dev.kviklet.kviklet.proxy.mocks.EventServiceMock
+import dev.kviklet.kviklet.proxy.mysql.MySqlProtocol
+import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.DatasourceType
+import org.testcontainers.containers.JdbcDatabaseContainer
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Duration
+import java.time.Instant
+import java.util.Properties
+
+class MySqlProxyInstance(
+    val port: Int,
+    val connectionString: String,
+    val proxy: ProxyServer,
+    val eventService: EventServiceMock,
+    val username: String,
+    val password: String,
+) {
+    fun connect(user: String = username, pass: String = password): Connection = DriverManager.getConnection(
+        connectionString,
+        Properties().apply {
+            setProperty("user", user)
+            setProperty("password", pass)
+        },
+    )
+}
+
+// The client-side JDBC URL for connecting THROUGH the proxy: the matching driver per flavor, with TLS off
+// (the plain-test proxy does not advertise CLIENT_SSL).
+fun mysqlClientJdbcUrl(datasourceType: DatasourceType, port: Int, extraParams: String = ""): String = when (
+    datasourceType
+) {
+    DatasourceType.MYSQL -> "jdbc:mysql://localhost:$port/testdb?sslMode=DISABLED$extraParams"
+    DatasourceType.MARIADB -> "jdbc:mariadb://localhost:$port/testdb?sslMode=disable$extraParams"
+    else -> throw IllegalArgumentException("$datasourceType is not served by the MySQL proxy")
+}
+
+fun mysqlDirectConnectionFactory(container: JdbcDatabaseContainer<*>): Connection = DriverManager.getConnection(
+    container.jdbcUrl,
+    Properties().apply {
+        setProperty("user", "test")
+        setProperty("password", "test")
+    },
+)
+
+fun mysqlProxyServerFactory(
+    container: JdbcDatabaseContainer<*>,
+    datasourceType: DatasourceType,
+    executionRequestAdapter: ExecutionRequestAdapter,
+    eventAdapter: EventAdapter,
+    tlsCertificate: TLSCertificate? = null,
+    eventServiceOverride: EventServiceMock? = null,
+    handshakeTimeoutMs: Int = 10_000,
+    username: String = "proxyUser",
+    password: String = "proxyPassword",
+): MySqlProxyInstance {
+    val connAuth = AuthenticationDetails.UserPassword("test", "test")
+    val executionRequestFactory = ExecutionRequestFactory()
+    val request = executionRequestFactory.createDatasourceExecutionRequest()
+    val eventService = eventServiceOverride ?: EventServiceMock(executionRequestAdapter, eventAdapter, request)
+    val port = (12000..20000).random()
+    val proxy = ProxyServer(port, MySqlProtocol(eventService, tlsCertificate), handshakeTimeoutMs)
+    proxy.start()
+    waitForProxyStart(proxy)
+    proxy.registerSession(
+        ProxySession(
+            username = username,
+            password = password,
+            executionRequest = request,
+            userId = "mock",
+            targetHost = container.host,
+            targetPort = container.getMappedPort(3306),
+            databaseName = "testdb",
+            datasourceType = datasourceType,
+            authenticationDetails = connAuth,
+        ),
+        expiresAt = Instant.now().plus(Duration.ofMinutes(10)),
+    )
+    return MySqlProxyInstance(port, mysqlClientJdbcUrl(datasourceType, port), proxy, eventService, username, password)
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/PgFactories.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/PgFactories.kt
@@ -10,6 +10,7 @@ import dev.kviklet.kviklet.proxy.core.TLSCertificate
 import dev.kviklet.kviklet.proxy.mocks.EventServiceMock
 import dev.kviklet.kviklet.proxy.postgres.PostgresProtocol
 import dev.kviklet.kviklet.service.dto.AuthenticationDetails
+import dev.kviklet.kviklet.service.dto.DatasourceType
 import org.testcontainers.containers.PostgreSQLContainer
 import java.sql.Connection
 import java.sql.DriverManager
@@ -59,6 +60,7 @@ fun proxyServerFactory(
             targetHost = postgresContainer.host,
             targetPort = postgresContainer.getMappedPort(5432),
             databaseName = "testdb",
+            datasourceType = DatasourceType.POSTGRESQL,
             authenticationDetails = connAuth,
         ),
         expiresAt = Instant.now().plus(Duration.ofMinutes(10)),


### PR DESCRIPTION
Adds MySQL and MariaDB to the proxy feature, plugged into the protocol-agnostic proxy core: a new `MySqlProtocol` implements the `ProxyProtocol` seam (server-speaks-first handshake, temp-username routing, anti-enumeration access-denied, TLS upgrade via the shared `enableSSL`, and the total handshake-deadline budget), and `MySqlConnection` implements `ProxyConnection` with the raw-socket teardown so TLS clients don't leak fds on close.

Since MySQL and MariaDB share one wire protocol, a single stable listener (default port 3306, `kviklet.proxy.mysql.port`) serves both. To pick the right upstream flavor per session, `ProxySession`/`registerSession` now carry a neutral `datasourceType`; the Postgres callers pass `POSTGRESQL` and are otherwise unchanged.

The upstream connection is opened by the MariaDB JDBC driver and its socket extracted for the relay — the same approach the Postgres proxy takes with pgjdbc — so auth-plugin negotiation (native password, caching_sha2 incl. RSA full auth, AuthSwitch) is maintained by the driver instead of hand-rolled crypto. The MariaDB driver is used for both MySQL and MariaDB targets deliberately: the relay is a transparent byte pump, so the upstream-negotiated capabilities must produce the wire format the proxy's own client-facing handshake advertises. Connector/J enables `CLIENT_DEPRECATE_EOF` unconditionally (which would desync downstream clients), while the MariaDB driver lets every format-changing capability be pinned off (`deprecateEof`, `extendedTypeInfo`, `enableBulkUnitResult`, `enableSkipMeta`). The extracted socket's JDBC connection is retained by the relay and closed on teardown, so no orphaned driver connection can be reaped mid-session.

`ExecutionRequestService.proxy()` now accepts MYSQL and MARIADB connections and routes them to the new listener. The client-facing packet parsing and handshake builders are carried over from #485; the old per-request-port `MySqlProxy` server is superseded by the shared `ProxyServer` core.

Tested with new integration suites (`MySqlProxyAuthTest`, `MySqlProxyConnectionLifecycleTest`, `MySqlProxyExpiryTest`) parameterized across MySQL 8.2 and MariaDB 11.4 Testcontainers, plus the ported parser/crypto unit tests.