### PR TITLE
Back off instead of spinning when the proxy accept loop fails

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/core/ProxyServer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/core/ProxyServer.kt
@@ -59,6 +59,9 @@ class ProxyServer(
     private val maxPendingHandshakes = 50
     private val activeHandshakes = AtomicInteger(0)
 
+    // How long the accept loop pauses after a failed accept before trying again.
+    private val acceptFailureBackoffMs = 1000L
+
     // Concurrent in-flight (pre-auth) handshakes, exposed for tests and monitoring. Distinct from
     // currentConnections: an unauthenticated client (idle, aborting, cancelling) occupies one of these, never a
     // relay slot.
@@ -183,9 +186,17 @@ class ProxyServer(
         }
     }
 
+    // A failing accept is almost always persistent (out of file descriptors, listener broken), so retrying
+    // immediately would turn the accept loop into a 100% CPU spin until the condition clears. Back off before
+    // the next attempt instead. During shutdown the closed listener also throws here, but isRunning is already
+    // false by then, so the loop exits without logging or sleeping.
     private fun acceptClientConnection(): Socket? = try {
         serverSocket.accept()
     } catch (e: Exception) {
+        if (isRunning) {
+            logger.warn("Failed to accept a proxy connection, retrying in ${acceptFailureBackoffMs}ms", e)
+            Thread.sleep(acceptFailureBackoffMs)
+        }
         null
     }
 


### PR DESCRIPTION
A failed `accept()` in the proxy listener was swallowed and retried immediately, so a persistent accept failure (e.g. fd exhaustion) turned the accept loop into a 100% CPU spin. The loop now logs the failure and backs off for a second before retrying. During shutdown the closed listener still exits the loop quietly, since `isRunning` is already false.