### PR TITLE
Make the MySQL proxy fail closed on traffic the audit log cannot record

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/ClientMySqlConnectionSetup.kt
@@ -23,6 +23,10 @@ import java.security.SecureRandom
 const val NATIVE_PASSWORD_PLUGIN = "mysql_native_password"
 
 private const val CLIENT_SSL = 0x0800
+private const val CLIENT_PROTOCOL_41 = 0x0200
+private const val CLIENT_COMPRESS = 0x0020
+private const val CLIENT_LOCAL_FILES = 0x0080
+private const val CLIENT_ZSTD_COMPRESSION = 0x04000000
 private const val COM_QUIT = 0x01
 
 // Generous cap on any client packet during the handshake. A HandshakeResponse is far smaller; a declared
@@ -91,6 +95,34 @@ fun authenticateClientMySql(
     // authenticates and has nothing to relay: drop it rather than failing it as malformed.
     if (payload.size == 1 && (payload[0].toInt() and 0xFF) == COM_QUIT) {
         return null
+    }
+
+    // The relay parses every packet on this connection for the audit log, which becomes impossible if the
+    // client switches the stream to a form the parser does not understand (compressed packets) or opens a
+    // side channel the audit never sees (LOAD DATA LOCAL file transfers). None of these capabilities are
+    // advertised in the initial handshake, so a well-behaved client never requests them; one that does
+    // anyway is refused up front (fail closed) instead of trusted to not use them.
+    if (payload.size < 4) {
+        throw IOException("Malformed HandshakeResponse packet (truncated)")
+    }
+    val clientCapabilities = readClientCapabilities(payload)
+    if ((clientCapabilities and CLIENT_PROTOCOL_41) == 0) {
+        writePacket(output, seq + 1, buildErrPacket(1105, "HY000", "Kviklet proxy requires a protocol 4.1 client"))
+        throw IOException("Client does not speak protocol 4.1")
+    }
+    val unsupportedCapabilities = listOfNotNull(
+        "COMPRESS".takeIf { (clientCapabilities and CLIENT_COMPRESS) != 0 },
+        "ZSTD_COMPRESSION".takeIf { (clientCapabilities and CLIENT_ZSTD_COMPRESSION) != 0 },
+        "LOCAL_FILES".takeIf { (clientCapabilities and CLIENT_LOCAL_FILES) != 0 },
+    )
+    if (unsupportedCapabilities.isNotEmpty()) {
+        val names = unsupportedCapabilities.joinToString(", ")
+        writePacket(
+            output,
+            seq + 1,
+            buildErrPacket(1105, "HY000", "Kviklet proxy does not support the client capabilities: $names"),
+        )
+        throw IOException("Client requested unsupported capabilities: $names")
     }
 
     val response = HandshakeResponse.parse(payload)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -12,6 +12,8 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
 
 private val logger = LoggerFactory.getLogger("MySqlConnection")
 
@@ -21,6 +23,11 @@ private val logger = LoggerFactory.getLogger("MySqlConnection")
 // max_allowed_packet at 1GB.
 private const val MAX_SPLIT_PACKET_LENGTH = 0xFFFFFF
 private const val MAX_ASSEMBLED_PAYLOAD_LENGTH = 0x40000000
+
+// How long abortSession waits for the client write lock before giving up on the courtesy ERR packet and
+// closing the sockets anyway. Kept short: the lock is only ever held for a single relayed write, and the
+// close() that follows a timeout is what actually unblocks a write that has parked.
+private const val ABORT_ERR_TIMEOUT_MS = 2000L
 
 // A fail-closed violation on the relay: traffic the proxy must not forward because the audit log could not
 // record it (a failed audit write, an execute of a statement the proxy cannot attribute, a command that
@@ -62,8 +69,11 @@ class MySqlConnection(
     // injected ERR packet, callable from either relay thread). The lock serializes them so one write cannot
     // be split by the other, and -- because the pump's forward and the abort both consult sessionAborted
     // while holding it -- guarantees no server chunk is forwarded after the abort ERR. sessionAborted is
-    // only ever accessed under the lock, which supplies the happens-before edge.
-    private val clientWriteLock = Any()
+    // only ever accessed under the lock, which supplies the happens-before edge. A ReentrantLock rather than
+    // a monitor so abortSession can take it with a timeout: the pump may be parked in a blocking, unbounded
+    // write to a client that stopped reading while holding this lock, and a plain synchronized abort would
+    // block forever behind it (pinning both threads and the upstream connection).
+    private val clientWriteLock = ReentrantLock()
     private var sessionAborted: Boolean = false
 
     // MySQL assigns prepared-statement ids server-side, so a COM_STMT_PREPARE's query text can only be
@@ -159,18 +169,35 @@ class MySqlConnection(
     // Tells the client why the session is being killed (an ERR packet), then closes both sockets. The ERR
     // is written under clientWriteLock so a concurrent server->client chunk cannot split it and nothing is
     // forwarded to the client after it; close() then ends both relay loops.
+    //
+    // The ERR is best effort: the lock is taken with a timeout, because the pump may be holding it in a
+    // blocking write to a client that has stopped reading. Waiting for it unconditionally would deadlock the
+    // abort -- and therefore teardown -- behind that write. On a timeout the ERR is skipped and close() runs
+    // anyway; closing the sockets unblocks that parked write, so both relay threads still exit.
     private fun abortSession(reason: String) {
-        synchronized(clientWriteLock) {
+        val locked = try {
+            clientWriteLock.tryLock(ABORT_ERR_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            false
+        }
+        if (locked) {
             try {
                 // Sequence id 1: the abort is triggered by a client command packet (sequence id 0), and 1
                 // is where the client expects that command's response. An abort raised from the server side
                 // mid-response may mismatch the client's expected sequence, which is acceptable for a
                 // session that is being torn down.
                 writePacket(clientOutput, 1, buildErrPacket(1105, "HY000", reason))
+                sessionAborted = true
             } catch (e: Exception) {
                 logger.warn("Failed to send the ERR packet to the client while aborting the session", e)
+            } finally {
+                clientWriteLock.unlock()
             }
-            sessionAborted = true
+        } else {
+            logger.warn(
+                "Could not acquire the client write lock to send an abort ERR (relay write in progress); closing",
+            )
         }
         close()
     }
@@ -234,11 +261,14 @@ class MySqlConnection(
                     abortSession(e.message!!)
                     break
                 }
-                synchronized(clientWriteLock) {
+                clientWriteLock.lock()
+                try {
                     // If an abort sent its ERR packet while this chunk was being read, stop rather than
                     // forwarding server bytes after the error the client already saw.
                     if (sessionAborted) break
                     clientOutput.writeAndFlush(chunk)
+                } finally {
+                    clientWriteLock.unlock()
                 }
             }
         } catch (e: Exception) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -76,14 +76,17 @@ class MySqlConnection(
     private val clientWriteLock = ReentrantLock()
     private var sessionAborted: Boolean = false
 
-    // MySQL assigns prepared-statement ids server-side, so a COM_STMT_PREPARE's query text can only be
-    // paired with its id when the prepare-ok response arrives. Responses come back in request order, so the
-    // texts wait in a FIFO: pushed by the client->server thread on each prepare, popped by the
-    // server->client pump on each prepare response (ok or err). A single "awaiting" flag instead of a queue
-    // would let two pipelined prepares misattribute (first response paired with second text) and leave the
-    // second id untracked -- and an untracked id's execute is exactly what onExecute must fail closed on.
+    // MySQL assigns prepared-statement ids server-side, so a COM_STMT_PREPARE's query text can only be paired
+    // with its id when the prepare-ok response arrives. The proxy can only recognise that response
+    // heuristically (a 12-byte 0x00 packet, or a 0xFF ERR), which is reliable only when exactly one prepare
+    // is outstanding and no other command's response can interleave. So at most one prepare is tracked at a
+    // time: the client thread stores the in-flight prepare's text, the server pump pairs it with the id in
+    // the next prepare-ok (or drops it on an ERR). A client that pipelines a second prepare before the first
+    // response arrives is failed closed rather than mis-audited -- pairing the wrong text to an id (or worse,
+    // overwriting a live id's text) would falsify the audit log. All three fields are guarded by prepareLock.
     private val prepareLock = Any()
-    private val pendingPrepares = ArrayDeque<String>()
+    private var prepareInFlight = false
+    private var inFlightPrepareQuery: String? = null
     private val preparedQueries = ConcurrentHashMap<Int, String>()
 
     private val clientParser = MySqlClientPacketParser(
@@ -92,13 +95,23 @@ class MySqlConnection(
         },
         onPrepare = { query ->
             synchronized(prepareLock) {
-                pendingPrepares.addLast(query)
+                // Fail closed on a pipelined prepare: with one already awaiting its response, the proxy
+                // cannot tell which response belongs to which prepare, so it cannot audit them reliably.
+                if (prepareInFlight) {
+                    throw FailClosedException(
+                        "Kviklet proxy received a COM_STMT_PREPARE while a previous prepare was still " +
+                            "awaiting its response; pipelined prepares cannot be reliably audited. The " +
+                            "command was blocked and the session closed.",
+                    )
+                }
+                prepareInFlight = true
+                inFlightPrepareQuery = query
             }
         },
         onExecute = { stmtId ->
             // Fail closed: an execute the proxy cannot attribute to query text must not reach the server.
-            // Ids go untracked when the prepare-response pairing was disturbed (see pendingPrepares) or when
-            // the client fabricates an id it never prepared on this connection.
+            // Ids go untracked when the prepare-response pairing was disturbed (a non-prepare response
+            // interleaved with the prepare) or when the client fabricates an id it never prepared here.
             val query = preparedQueries[stmtId]
                 ?: throw FailClosedException(
                     "Kviklet proxy does not know the prepared statement id $stmtId and cannot audit this " +
@@ -118,14 +131,36 @@ class MySqlConnection(
     private val serverParser = MySqlServerPacketParser(
         onPrepareOk = { stmtId ->
             synchronized(prepareLock) {
-                pendingPrepares.removeFirstOrNull()?.let { preparedQueries[stmtId] = it }
+                // Only pair while a prepare is actually outstanding; otherwise this is an ordinary OK packet
+                // that merely happens to be 12 bytes, not a prepare-ok.
+                if (prepareInFlight) {
+                    val query = inFlightPrepareQuery
+                    prepareInFlight = false
+                    inFlightPrepareQuery = null
+                    // A fresh prepare-ok must never collide with a live id (the client closes an id before it
+                    // can be reassigned). A collision means a non-prepare response was misread as a
+                    // prepare-ok: the statement stream is out of sync, so fail closed rather than overwrite a
+                    // tracked statement's text and falsify its future audit entries.
+                    if (query != null && preparedQueries.putIfAbsent(stmtId, query) != null) {
+                        throw FailClosedException(
+                            "Kviklet proxy saw prepared statement id $stmtId assigned while it was still in " +
+                                "use; the statement stream is out of sync and cannot be audited. The " +
+                                "session was closed.",
+                        )
+                    }
+                }
             }
         },
         onPrepareErr = {
-            // The server rejected the oldest outstanding COM_STMT_PREPARE; drop its text so a later
-            // prepare-ok is not paired with the wrong query.
+            // An ERR while a prepare is outstanding is taken as that prepare failing: drop its text so a
+            // later prepare-ok is not paired with it. (If the ERR actually answered an interleaved command,
+            // the real prepare-ok then finds no prepare in flight and its id goes untracked -- its execute
+            // fails closed, which is safe.)
             synchronized(prepareLock) {
-                pendingPrepares.removeFirstOrNull()
+                if (prepareInFlight) {
+                    prepareInFlight = false
+                    inFlightPrepareQuery = null
+                }
             }
         },
     )

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -126,6 +126,15 @@ class MySqlConnection(
         onQuit = {
             terminationMessageReceived = true
         },
+        onResetConnection = {
+            // The server forgets every prepared statement and reassigns ids from scratch, so drop the
+            // proxy's tracking too or a reused id would resolve to a stale (wrong) query text.
+            synchronized(prepareLock) {
+                prepareInFlight = false
+                inFlightPrepareQuery = null
+                preparedQueries.clear()
+            }
+        },
     )
 
     private val serverParser = MySqlServerPacketParser(
@@ -388,20 +397,31 @@ class MySqlClientPacketParser(
     private val onExecute: (Int) -> Unit,
     private val onClose: (Int) -> Unit = {},
     private val onQuit: () -> Unit,
+    private val onResetConnection: () -> Unit = {},
 ) {
     private val framer = MySqlPacketFramer { payload -> handlePacket(payload) }
 
     fun addBytes(bytes: ByteArray) = framer.addBytes(bytes)
 
-    // Dispatches one client command packet to its callback. Deliberately without a catch-all: a violation
-    // (or an unexpected parsing error) must propagate so the relay blocks the packet and aborts the
-    // session -- swallowing it here would forward traffic the audit log never saw.
+    // Dispatches one client command packet. This is a default-deny allowlist: a command is handled here only
+    // if the proxy can either audit its SQL or be sure it carries none, and everything else fails closed.
+    // Forwarding an unrecognised command would relay traffic the audit log never saw (COM_BINLOG_DUMP streams
+    // every row change, COM_CHANGE_USER re-authenticates, legacy COM_CREATE_DB/COM_DROP_DB run schema DDL).
+    // There is deliberately no catch-all around the dispatch: a violation (or an unexpected parsing error)
+    // must propagate so the relay blocks the packet and aborts the session.
     private fun handlePacket(payload: ByteArray) {
         if (payload.isEmpty()) return
         val cmd = payload[0].toInt() and 0xFF
         when (cmd) {
-            0x01 -> { // COM_QUIT
-                onQuit()
+            0x01 -> onQuit()
+
+            // COM_QUIT
+
+            0x02 -> { // COM_INIT_DB
+                // Switching the default schema changes what the unqualified names in later audited queries
+                // resolve to, so record it as an explicit USE instead of letting it pass unaudited.
+                val db = String(payload, 1, payload.size - 1, Charsets.UTF_8)
+                onQuery("USE `" + db.replace("`", "``") + "`")
             }
 
             0x03 -> { // COM_QUERY
@@ -411,28 +431,34 @@ class MySqlClientPacketParser(
                 }
             }
 
-            // Legacy schema DDL and mid-session re-authentication carry no auditable SQL text, so they
-            // must not pass through an audited session. No modern client sends them.
-            0x05 -> throw FailClosedException(blockedCommandMessage("COM_CREATE_DB"))
-
-            0x06 -> throw FailClosedException(blockedCommandMessage("COM_DROP_DB"))
-
-            0x11 -> throw FailClosedException(blockedCommandMessage("COM_CHANGE_USER"))
-
             0x16 -> { // COM_STMT_PREPARE
                 // Every prepare is tracked, even a blank one: the server answers each with exactly one
-                // response, and the response pairing (see pendingPrepares) relies on nothing being skipped.
+                // response, and the in-flight pairing relies on nothing being skipped.
                 val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
                 onPrepare(query)
             }
 
-            0x17 -> { // COM_STMT_EXECUTE
-                onExecute(readStatementId(payload, "COM_STMT_EXECUTE"))
-            }
+            0x17 -> onExecute(readStatementId(payload, "COM_STMT_EXECUTE"))
 
-            0x19 -> { // COM_STMT_CLOSE
-                onClose(readStatementId(payload, "COM_STMT_CLOSE"))
-            }
+            // COM_STMT_EXECUTE
+
+            0x19 -> onClose(readStatementId(payload, "COM_STMT_CLOSE"))
+
+            // COM_STMT_CLOSE
+
+            // COM_RESET_CONNECTION forgets every server-side prepared statement (and reassigns ids from
+            // scratch), so the proxy must drop its own tracking to stay in sync.
+            0x1F -> onResetConnection()
+
+            // Commands that carry no auditable SQL and cannot defeat the audit, relayed unchanged:
+            //   COM_STATISTICS, COM_PING            -- server-info / liveness, no SQL
+            //   COM_STMT_SEND_LONG_DATA             -- parameter bytes for a prepared execute that is audited
+            //   COM_STMT_RESET, COM_STMT_FETCH      -- reset / cursor-read of an already-audited statement
+            //   COM_SET_OPTION                      -- multi-statements stay auditable (COM_QUERY text is
+            //                                          captured verbatim, all statements included)
+            0x09, 0x0E, 0x18, 0x1A, 0x1B, 0x1C -> {}
+
+            else -> throw FailClosedException(blockedCommandMessage(cmd))
         }
     }
 
@@ -451,9 +477,28 @@ class MySqlClientPacketParser(
             ((payload[4].toInt() and 0xFF) shl 24)
     }
 
-    private fun blockedCommandMessage(commandName: String): String =
-        "Kviklet proxy does not support $commandName because it bypasses the audited session. The " +
-            "command was blocked and the session closed."
+    private fun blockedCommandMessage(cmd: Int): String {
+        val name = KNOWN_COMMAND_NAMES[cmd] ?: "0x%02x".format(cmd)
+        return "Kviklet proxy does not permit MySQL command $name because it cannot be audited or bypasses " +
+            "the audited session. The command was blocked and the session closed."
+    }
+
+    companion object {
+        // Names for the more notable blocked commands, only to make the abort message and logs readable;
+        // any command not on the allowlist is blocked whether or not it appears here.
+        private val KNOWN_COMMAND_NAMES = mapOf(
+            0x04 to "COM_FIELD_LIST",
+            0x05 to "COM_CREATE_DB",
+            0x06 to "COM_DROP_DB",
+            0x07 to "COM_REFRESH",
+            0x08 to "COM_SHUTDOWN",
+            0x0C to "COM_PROCESS_KILL",
+            0x11 to "COM_CHANGE_USER",
+            0x12 to "COM_BINLOG_DUMP",
+            0x13 to "COM_TABLE_DUMP",
+            0x1E to "COM_BINLOG_DUMP_GTID",
+        )
+    }
 }
 
 class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit, private val onPrepareErr: () -> Unit = {}) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -15,6 +15,19 @@ import java.util.concurrent.ConcurrentHashMap
 
 private val logger = LoggerFactory.getLogger("MySqlConnection")
 
+// A payload of exactly 0xFFFFFF signals that the logical payload continues in the next packet, so the
+// reassembled payload needs its own bound: like the Postgres proxy's 1GB message cap, anything beyond it
+// can only be garbage or an attack, and buffering it would be unbounded. MySQL itself caps
+// max_allowed_packet at 1GB.
+private const val MAX_SPLIT_PACKET_LENGTH = 0xFFFFFF
+private const val MAX_ASSEMBLED_PAYLOAD_LENGTH = 0x40000000
+
+// A fail-closed violation on the relay: traffic the proxy must not forward because the audit log could not
+// record it (a failed audit write, an execute of a statement the proxy cannot attribute, a command that
+// sidesteps the audited session). The message is client-facing: it is sent to the client in the ERR packet
+// that aborts the session.
+class FailClosedException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
 class MySqlConnection(
     private val clientSocket: Socket,
     private val targetSocket: Socket,
@@ -45,9 +58,22 @@ class MySqlConnection(
     @Volatile
     private var serverTerminating: Boolean = false
 
-    @Volatile
-    private var awaitingPrepareResponse = false
-    private var lastPreparedQuery: String? = null
+    // clientOutput has two writers: the server->client pump (normal server bytes) and abortSession (an
+    // injected ERR packet, callable from either relay thread). The lock serializes them so one write cannot
+    // be split by the other, and -- because the pump's forward and the abort both consult sessionAborted
+    // while holding it -- guarantees no server chunk is forwarded after the abort ERR. sessionAborted is
+    // only ever accessed under the lock, which supplies the happens-before edge.
+    private val clientWriteLock = Any()
+    private var sessionAborted: Boolean = false
+
+    // MySQL assigns prepared-statement ids server-side, so a COM_STMT_PREPARE's query text can only be
+    // paired with its id when the prepare-ok response arrives. Responses come back in request order, so the
+    // texts wait in a FIFO: pushed by the client->server thread on each prepare, popped by the
+    // server->client pump on each prepare response (ok or err). A single "awaiting" flag instead of a queue
+    // would let two pipelined prepares misattribute (first response paired with second text) and leave the
+    // second id untracked -- and an untracked id's execute is exactly what onExecute must fail closed on.
+    private val prepareLock = Any()
+    private val pendingPrepares = ArrayDeque<String>()
     private val preparedQueries = ConcurrentHashMap<Int, String>()
 
     private val clientParser = MySqlClientPacketParser(
@@ -55,16 +81,20 @@ class MySqlConnection(
             auditQuery(query)
         },
         onPrepare = { query ->
-            synchronized(this) {
-                lastPreparedQuery = query
-                awaitingPrepareResponse = true
+            synchronized(prepareLock) {
+                pendingPrepares.addLast(query)
             }
         },
         onExecute = { stmtId ->
+            // Fail closed: an execute the proxy cannot attribute to query text must not reach the server.
+            // Ids go untracked when the prepare-response pairing was disturbed (see pendingPrepares) or when
+            // the client fabricates an id it never prepared on this connection.
             val query = preparedQueries[stmtId]
-            if (query != null) {
-                auditQuery(query)
-            }
+                ?: throw FailClosedException(
+                    "Kviklet proxy does not know the prepared statement id $stmtId and cannot audit this " +
+                        "execution. The query was blocked and the session closed.",
+                )
+            auditQuery(query)
         },
         onClose = { stmtId ->
             // Release the stored query when the client closes the prepared statement
@@ -77,20 +107,15 @@ class MySqlConnection(
 
     private val serverParser = MySqlServerPacketParser(
         onPrepareOk = { stmtId ->
-            synchronized(this) {
-                if (awaitingPrepareResponse) {
-                    lastPreparedQuery?.let { preparedQueries[stmtId] = it }
-                    awaitingPrepareResponse = false
-                    lastPreparedQuery = null
-                }
+            synchronized(prepareLock) {
+                pendingPrepares.removeFirstOrNull()?.let { preparedQueries[stmtId] = it }
             }
         },
         onPrepareErr = {
-            // The server rejected the COM_STMT_PREPARE; drop the pending state so the
-            // next unrelated OK packet is not mistaken for this prepare's response.
-            synchronized(this) {
-                awaitingPrepareResponse = false
-                lastPreparedQuery = null
+            // The server rejected the oldest outstanding COM_STMT_PREPARE; drop its text so a later
+            // prepare-ok is not paired with the wrong query.
+            synchronized(prepareLock) {
+                pendingPrepares.removeFirstOrNull()
             }
         },
     )
@@ -100,7 +125,12 @@ class MySqlConnection(
             val executePayload = ExecutePayload(query = query)
             eventService.saveEvent(executionRequest.id!!, userId, executePayload)
         } catch (e: Exception) {
-            logger.error("Failed to audit query", e)
+            // Fail closed: a query the audit log did not record must not reach the server.
+            throw FailClosedException(
+                "Kviklet could not record the query in the audit log. The query was blocked and the " +
+                    "session closed.",
+                e,
+            )
         }
     }
 
@@ -126,13 +156,32 @@ class MySqlConnection(
         upstreamJdbcConnection?.let { runCatching { it.close() } }
     }
 
+    // Tells the client why the session is being killed (an ERR packet), then closes both sockets. The ERR
+    // is written under clientWriteLock so a concurrent server->client chunk cannot split it and nothing is
+    // forwarded to the client after it; close() then ends both relay loops.
+    private fun abortSession(reason: String) {
+        synchronized(clientWriteLock) {
+            try {
+                // Sequence id 1: the abort is triggered by a client command packet (sequence id 0), and 1
+                // is where the client expects that command's response. An abort raised from the server side
+                // mid-response may mismatch the client's expected sequence, which is acceptable for a
+                // session that is being torn down.
+                writePacket(clientOutput, 1, buildErrPacket(1105, "HY000", reason))
+            } catch (e: Exception) {
+                logger.warn("Failed to send the ERR packet to the client while aborting the session", e)
+            }
+            sessionAborted = true
+        }
+        close()
+    }
+
     override fun startHandling() {
         // Two blocking threads per session. This (pool) thread drives client->server: it feeds the packet
         // parser (which audits queries and tracks prepared statements) and forwards the raw bytes. A single
         // spawned thread pumps server->client, feeding its parser only to match prepared-statement ids.
-        // The finally is the single teardown path for every exit: clean COM_QUIT, client/server EOF or an
-        // exception. It closes both sockets (freeing the upstream connection) which also unblocks the pump
-        // thread, then joins it.
+        // The finally is the single teardown path for every exit: clean COM_QUIT, client/server EOF, an
+        // aborted session or an exception. It closes both sockets (freeing the upstream connection) which
+        // also unblocks the pump thread, then joins it.
         val serverToClient = Thread({ pumpServerToClient() }, "mysql-proxy-server-to-client")
         serverToClient.start()
         try {
@@ -145,9 +194,25 @@ class MySqlConnection(
                     if (serverTerminating) break
                     throw e
                 } ?: break // client reached EOF
-                // Audit before forwarding: the parser callbacks run synchronously inside addBytes, so every
-                // query is recorded before its bytes reach the server.
-                clientParser.addBytes(chunk)
+                // Fail closed: nothing is forwarded to the server unless the whole chunk was parsed and
+                // audited. The parser callbacks run synchronously inside addBytes, so every query is
+                // recorded before its bytes reach the server; a violation drops the entire chunk (an
+                // already-audited packet in it is dropped too, which is safe -- audited-but-never-executed
+                // is fine, forwarded-but-never-audited is not) and aborts the session with an ERR packet.
+                try {
+                    clientParser.addBytes(chunk)
+                } catch (e: FailClosedException) {
+                    logger.warn("Blocking client traffic and closing the session: ${e.message}", e.cause ?: e)
+                    abortSession(e.message!!)
+                    break
+                } catch (e: Exception) {
+                    logger.error("Failed to parse client traffic, blocking it and closing the session", e)
+                    abortSession(
+                        "Kviklet proxy could not parse the client message. The message was blocked and " +
+                            "the session closed.",
+                    )
+                    break
+                }
                 serverOutput.writeAndFlush(chunk)
             }
         } finally {
@@ -160,8 +225,21 @@ class MySqlConnection(
         try {
             while (!serverTerminating) {
                 val chunk = readChunk(serverInput) ?: break // server reached EOF
-                serverParser.addBytes(chunk)
-                clientOutput.writeAndFlush(chunk)
+                try {
+                    serverParser.addBytes(chunk)
+                } catch (e: FailClosedException) {
+                    // The server side only fails closed on unbounded split packets; without parsing them the
+                    // prepared-statement tracking (and so the audit) can no longer be trusted.
+                    logger.warn("Blocking server traffic and closing the session: ${e.message}", e.cause ?: e)
+                    abortSession(e.message!!)
+                    break
+                }
+                synchronized(clientWriteLock) {
+                    // If an abort sent its ERR packet while this chunk was being read, stop rather than
+                    // forwarding server bytes after the error the client already saw.
+                    if (sessionAborted) break
+                    clientOutput.writeAndFlush(chunk)
+                }
             }
         } catch (e: Exception) {
             // The client->server thread closing the sockets during teardown unblocks this read with an
@@ -182,12 +260,16 @@ class MySqlConnection(
     }
 }
 
-// Buffers a raw MySQL byte stream and slices it into complete packets, invoking [onPacket] once per full
-// packet payload (the 4-byte length + sequence header is consumed here). A partial packet stays buffered
-// until the rest of it arrives, so only the incomplete tail is ever re-copied between calls. Shared by the
-// client and server parsers, which differ only in what they do with a payload.
+// Buffers a raw MySQL byte stream and slices it into complete logical packets, invoking [onPacket] once per
+// full payload (the 4-byte length + sequence header is consumed here). A partial packet stays buffered until
+// the rest of it arrives, so only the incomplete tail is ever re-copied between calls. A payload of exactly
+// 0xFFFFFF means the logical payload continues in the following packet(s); those are reassembled into one
+// payload before [onPacket] runs, so a >16MB statement is audited whole instead of being misread as a
+// truncated query plus garbage commands. Shared by the client and server parsers, which differ only in what
+// they do with a payload.
 private class MySqlPacketFramer(private val onPacket: (ByteArray) -> Unit) {
     private val buffer = ByteArrayOutputStream()
+    private val pendingSplitPayload = ByteArrayOutputStream()
 
     @Synchronized
     fun addBytes(bytes: ByteArray) {
@@ -203,9 +285,27 @@ private class MySqlPacketFramer(private val onPacket: (ByteArray) -> Unit) {
                 break // Need more data for a full packet
             }
 
-            val payload = ByteArray(length)
-            System.arraycopy(data, offset + 4, payload, 0, length)
-            onPacket(payload)
+            if (pendingSplitPayload.size() + length > MAX_ASSEMBLED_PAYLOAD_LENGTH) {
+                throw FailClosedException(
+                    "Kviklet proxy does not support MySQL payloads larger than 1GB. The packet was " +
+                        "blocked and the session closed.",
+                )
+            }
+
+            if (length == MAX_SPLIT_PACKET_LENGTH) {
+                // The logical payload continues in the next packet; buffer this piece and keep going.
+                pendingSplitPayload.write(data, offset + 4, length)
+            } else if (pendingSplitPayload.size() > 0) {
+                // The final piece of a split payload: reassemble and emit as one logical packet.
+                pendingSplitPayload.write(data, offset + 4, length)
+                val payload = pendingSplitPayload.toByteArray()
+                pendingSplitPayload.reset()
+                onPacket(payload)
+            } else {
+                val payload = ByteArray(length)
+                System.arraycopy(data, offset + 4, payload, 0, length)
+                onPacket(payload)
+            }
 
             offset += 4 + length
         }
@@ -228,53 +328,67 @@ class MySqlClientPacketParser(
 
     fun addBytes(bytes: ByteArray) = framer.addBytes(bytes)
 
+    // Dispatches one client command packet to its callback. Deliberately without a catch-all: a violation
+    // (or an unexpected parsing error) must propagate so the relay blocks the packet and aborts the
+    // session -- swallowing it here would forward traffic the audit log never saw.
     private fun handlePacket(payload: ByteArray) {
         if (payload.isEmpty()) return
         val cmd = payload[0].toInt() and 0xFF
-        try {
-            when (cmd) {
-                0x01 -> { // COM_QUIT
-                    onQuit()
-                }
+        when (cmd) {
+            0x01 -> { // COM_QUIT
+                onQuit()
+            }
 
-                0x03 -> { // COM_QUERY
-                    val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
-                    if (query.trim().isNotEmpty()) {
-                        onQuery(query)
-                    }
-                }
-
-                0x16 -> { // COM_STMT_PREPARE
-                    val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
-                    if (query.trim().isNotEmpty()) {
-                        onPrepare(query)
-                    }
-                }
-
-                0x17 -> { // COM_STMT_EXECUTE
-                    if (payload.size >= 5) {
-                        val stmtId = (payload[1].toInt() and 0xFF) or
-                            ((payload[2].toInt() and 0xFF) shl 8) or
-                            ((payload[3].toInt() and 0xFF) shl 16) or
-                            ((payload[4].toInt() and 0xFF) shl 24)
-                        onExecute(stmtId)
-                    }
-                }
-
-                0x19 -> { // COM_STMT_CLOSE
-                    if (payload.size >= 5) {
-                        val stmtId = (payload[1].toInt() and 0xFF) or
-                            ((payload[2].toInt() and 0xFF) shl 8) or
-                            ((payload[3].toInt() and 0xFF) shl 16) or
-                            ((payload[4].toInt() and 0xFF) shl 24)
-                        onClose(stmtId)
-                    }
+            0x03 -> { // COM_QUERY
+                val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
+                if (query.trim().isNotEmpty()) {
+                    onQuery(query)
                 }
             }
-        } catch (e: Exception) {
-            logger.error("Error parsing client packet", e)
+
+            // Legacy schema DDL and mid-session re-authentication carry no auditable SQL text, so they
+            // must not pass through an audited session. No modern client sends them.
+            0x05 -> throw FailClosedException(blockedCommandMessage("COM_CREATE_DB"))
+
+            0x06 -> throw FailClosedException(blockedCommandMessage("COM_DROP_DB"))
+
+            0x11 -> throw FailClosedException(blockedCommandMessage("COM_CHANGE_USER"))
+
+            0x16 -> { // COM_STMT_PREPARE
+                // Every prepare is tracked, even a blank one: the server answers each with exactly one
+                // response, and the response pairing (see pendingPrepares) relies on nothing being skipped.
+                val query = String(payload, 1, payload.size - 1, Charsets.UTF_8)
+                onPrepare(query)
+            }
+
+            0x17 -> { // COM_STMT_EXECUTE
+                onExecute(readStatementId(payload, "COM_STMT_EXECUTE"))
+            }
+
+            0x19 -> { // COM_STMT_CLOSE
+                onClose(readStatementId(payload, "COM_STMT_CLOSE"))
+            }
         }
     }
+
+    // The 4-byte little-endian statement id following the command byte. A packet too short to carry it is
+    // garbage the server cannot meaningfully execute either; fail closed rather than forwarding it.
+    private fun readStatementId(payload: ByteArray, commandName: String): Int {
+        if (payload.size < 5) {
+            throw FailClosedException(
+                "Kviklet proxy could not parse a truncated $commandName packet. The packet was blocked " +
+                    "and the session closed.",
+            )
+        }
+        return (payload[1].toInt() and 0xFF) or
+            ((payload[2].toInt() and 0xFF) shl 8) or
+            ((payload[3].toInt() and 0xFF) shl 16) or
+            ((payload[4].toInt() and 0xFF) shl 24)
+    }
+
+    private fun blockedCommandMessage(commandName: String): String =
+        "Kviklet proxy does not support $commandName because it bypasses the audited session. The " +
+            "command was blocked and the session closed."
 }
 
 class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit, private val onPrepareErr: () -> Unit = {}) {
@@ -285,22 +399,20 @@ class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit, private va
     private fun handlePacket(payload: ByteArray) {
         if (payload.isEmpty()) return
         val status = payload[0].toInt() and 0xFF
-        // COM_STMT_PREPARE_OK has a fixed 12-byte payload (0x00 status + 4 stmt_id
-        // + 2 columns + 2 params + 1 reserved + 2 warnings). Requiring the exact
-        // length avoids mistaking a generic OK packet (also 0x00) for a prepare-ok.
-        // ERR packets (0xFF) clear any pending prepare so a later OK is not misread.
+        // COM_STMT_PREPARE_OK has a fixed 12-byte payload (0x00 status + 4 stmt_id + 2 columns + 2 params
+        // + 1 reserved + 2 warnings). Requiring the exact length avoids mistaking a generic OK packet
+        // (also 0x00) for a prepare-ok. ERR packets (0xFF) pop the pending prepare so a later OK is not
+        // misread. Both callbacks no-op when no prepare is outstanding, which keeps ordinary resultset
+        // and error traffic from being misread; a client interleaving other commands with an outstanding
+        // prepare can still disturb the pairing, and the executes of a mispaired id then fail closed.
         if (status == 0xFF) {
             onPrepareErr()
         } else if (status == 0x00 && payload.size == 12) {
-            try {
-                val stmtId = (payload[1].toInt() and 0xFF) or
-                    ((payload[2].toInt() and 0xFF) shl 8) or
-                    ((payload[3].toInt() and 0xFF) shl 16) or
-                    ((payload[4].toInt() and 0xFF) shl 24)
-                onPrepareOk(stmtId)
-            } catch (e: Exception) {
-                logger.error("Error parsing server prepare-ok packet", e)
-            }
+            val stmtId = (payload[1].toInt() and 0xFF) or
+                ((payload[2].toInt() and 0xFF) shl 8) or
+                ((payload[3].toInt() and 0xFF) shl 16) or
+                ((payload[4].toInt() and 0xFF) shl 24)
+            onPrepareOk(stmtId)
         }
     }
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -299,8 +299,9 @@ class MySqlConnection(
                 try {
                     serverParser.addBytes(chunk)
                 } catch (e: FailClosedException) {
-                    // The server side only fails closed on unbounded split packets; without parsing them the
-                    // prepared-statement tracking (and so the audit) can no longer be trusted.
+                    // The server side fails closed only when a prepare-ok is assigned an id that is still in
+                    // use (a sign the statement stream is out of sync); large result payloads are streamed
+                    // past, not parsed, so they never reach here.
                     logger.warn("Blocking server traffic and closing the session: ${e.message}", e.cause ?: e)
                     abortSession(e.message!!)
                     break
@@ -334,59 +335,85 @@ class MySqlConnection(
     }
 }
 
-// Buffers a raw MySQL byte stream and slices it into complete logical packets, invoking [onPacket] once per
-// full payload (the 4-byte length + sequence header is consumed here). A partial packet stays buffered until
-// the rest of it arrives, so only the incomplete tail is ever re-copied between calls. A payload of exactly
-// 0xFFFFFF means the logical payload continues in the following packet(s); those are reassembled into one
-// payload before [onPacket] runs, so a >16MB statement is audited whole instead of being misread as a
-// truncated query plus garbage commands. Shared by the client and server parsers, which differ only in what
-// they do with a payload.
-private class MySqlPacketFramer(private val onPacket: (ByteArray) -> Unit) {
-    private val buffer = ByteArrayOutputStream()
-    private val pendingSplitPayload = ByteArrayOutputStream()
+// Any control packet the parsers actually inspect (a 12-byte prepare-ok, a small ERR) is far under this, so
+// in the streaming (server) direction a packet larger than this needs neither buffering nor inspection: it
+// is streamed past. Generous enough to never clip a real ERR message.
+private const val MAX_STREAMED_CONTROL_PACKET = 4096
+
+// Slices a raw MySQL byte stream into logical packets, invoking [onPacket] once per full payload (the 4-byte
+// length + sequence header is consumed here). It consumes the input incrementally -- a byte is copied at most
+// once and a partial packet is never re-copied between calls -- so there is no O(n^2) buffer churn under
+// chunked reads. A payload of exactly 0xFFFFFF means the logical payload continues in the following
+// packet(s).
+//
+// [reassemble] chooses what happens to those split payloads, which is the only difference between the two
+// directions:
+//   - client->server (reassemble = true): split payloads are joined and emitted whole (bounded by
+//     MAX_ASSEMBLED_PAYLOAD_LENGTH), so a >16MB statement is audited verbatim instead of being misread as a
+//     truncated query plus garbage commands.
+//   - server->client (reassemble = false): the parser only inspects short control packets, so any payload
+//     over MAX_STREAMED_CONTROL_PACKET (including every 16MB+ split result row) is streamed past without
+//     buffering and never emitted. This keeps server-direction memory at O(1): a large BLOB result can no
+//     longer pin up to 1GB of heap and trip an OutOfMemoryError that would bypass the fail-closed handlers.
+private class MySqlPacketFramer(private val reassemble: Boolean, private val onPacket: (ByteArray) -> Unit) {
+    private val header = ByteArray(4)
+    private var headerFilled = 0
+    private var payloadRemaining = 0
+    private var currentIsContinuation = false
+
+    // True while we are in the middle of a split logical payload (the previous packet was a 0xFFFFFF piece).
+    private var continuingSplit = false
+
+    // True while streaming past a payload we will not emit (server direction only). Decided once, at the
+    // first packet of a logical payload, and held for the whole split chain.
+    private var skipping = false
+
+    // Accumulates the payload to emit: one small packet, or a reassembled split payload in reassemble mode.
+    private val payload = ByteArrayOutputStream()
 
     @Synchronized
     fun addBytes(bytes: ByteArray) {
-        buffer.write(bytes)
-        val data = buffer.toByteArray()
-        var offset = 0
-        while (data.size - offset >= 4) {
-            val length = (data[offset].toInt() and 0xFF) or
-                ((data[offset + 1].toInt() and 0xFF) shl 8) or
-                ((data[offset + 2].toInt() and 0xFF) shl 16)
-
-            if (data.size - offset < 4 + length) {
-                break // Need more data for a full packet
+        var i = 0
+        while (i < bytes.size) {
+            if (headerFilled < 4) {
+                val take = minOf(4 - headerFilled, bytes.size - i)
+                System.arraycopy(bytes, i, header, headerFilled, take)
+                headerFilled += take
+                i += take
+                if (headerFilled < 4) break // wait for the rest of the header
+                val length = (header[0].toInt() and 0xFF) or
+                    ((header[1].toInt() and 0xFF) shl 8) or
+                    ((header[2].toInt() and 0xFF) shl 16)
+                currentIsContinuation = length == MAX_SPLIT_PACKET_LENGTH
+                payloadRemaining = length
+                if (!continuingSplit) {
+                    // First packet of a new logical payload: decide once whether to buffer or stream past it.
+                    skipping = !reassemble && (currentIsContinuation || length > MAX_STREAMED_CONTROL_PACKET)
+                }
+                if (reassemble && payload.size() + length > MAX_ASSEMBLED_PAYLOAD_LENGTH) {
+                    throw FailClosedException(
+                        "Kviklet proxy does not support MySQL payloads larger than 1GB. The packet was " +
+                            "blocked and the session closed.",
+                    )
+                }
             }
-
-            if (pendingSplitPayload.size() + length > MAX_ASSEMBLED_PAYLOAD_LENGTH) {
-                throw FailClosedException(
-                    "Kviklet proxy does not support MySQL payloads larger than 1GB. The packet was " +
-                        "blocked and the session closed.",
-                )
+            if (payloadRemaining > 0) {
+                val take = minOf(payloadRemaining, bytes.size - i)
+                if (!skipping) payload.write(bytes, i, take)
+                payloadRemaining -= take
+                i += take
             }
-
-            if (length == MAX_SPLIT_PACKET_LENGTH) {
-                // The logical payload continues in the next packet; buffer this piece and keep going.
-                pendingSplitPayload.write(data, offset + 4, length)
-            } else if (pendingSplitPayload.size() > 0) {
-                // The final piece of a split payload: reassemble and emit as one logical packet.
-                pendingSplitPayload.write(data, offset + 4, length)
-                val payload = pendingSplitPayload.toByteArray()
-                pendingSplitPayload.reset()
-                onPacket(payload)
-            } else {
-                val payload = ByteArray(length)
-                System.arraycopy(data, offset + 4, payload, 0, length)
-                onPacket(payload)
+            if (headerFilled == 4 && payloadRemaining == 0) {
+                headerFilled = 0
+                if (currentIsContinuation) {
+                    continuingSplit = true // more packets belong to this logical payload
+                } else {
+                    continuingSplit = false
+                    if (!skipping) onPacket(payload.toByteArray())
+                    payload.reset()
+                    skipping = false
+                }
             }
-
-            offset += 4 + length
-        }
-
-        buffer.reset()
-        if (data.size > offset) {
-            buffer.write(data, offset, data.size - offset)
         }
     }
 }
@@ -399,7 +426,8 @@ class MySqlClientPacketParser(
     private val onQuit: () -> Unit,
     private val onResetConnection: () -> Unit = {},
 ) {
-    private val framer = MySqlPacketFramer { payload -> handlePacket(payload) }
+    // reassemble = true: a >16MB client statement is joined so its full text can be audited verbatim.
+    private val framer = MySqlPacketFramer(reassemble = true) { payload -> handlePacket(payload) }
 
     fun addBytes(bytes: ByteArray) = framer.addBytes(bytes)
 
@@ -502,7 +530,9 @@ class MySqlClientPacketParser(
 }
 
 class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit, private val onPrepareErr: () -> Unit = {}) {
-    private val framer = MySqlPacketFramer { payload -> handlePacket(payload) }
+    // reassemble = false: the parser only inspects short control packets, so large result payloads (a split
+    // multi-megabyte BLOB row) are streamed past without buffering rather than accumulated up to 1GB.
+    private val framer = MySqlPacketFramer(reassemble = false) { payload -> handlePacket(payload) }
 
     fun addBytes(bytes: ByteArray) = framer.addBytes(bytes)
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyFailClosedTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyFailClosedTest.kt
@@ -149,21 +149,21 @@ class MySqlProxyFailClosedTest {
     }
 
     @Test
-    fun `two pipelined prepares are attributed to their own statement ids`() {
+    fun `sequential prepares are each attributed to their own statement id`() {
         RelayHarness(executionRequestAdapter, eventAdapter).use { harness ->
             val firstSql = "SELECT * FROM users WHERE id = ?"
             val secondSql = "DELETE FROM users WHERE id = ?"
-            // Both prepares are sent before either response arrives; a single "awaiting prepare" flag
-            // would pair the first response with the second query and lose the second id entirely
-            harness.sendToProxy(
-                mysqlPacket(0, byteArrayOf(0x16) + firstSql.toByteArray(Charsets.UTF_8)) +
-                    mysqlPacket(0, byteArrayOf(0x16) + secondSql.toByteArray(Charsets.UTF_8)),
-            )
-            harness.readPacketForwardedUpstream()
-            harness.readPacketForwardedUpstream()
 
-            harness.sendFromUpstream(prepareOk(sequenceId = 1, stmtId = 1) + prepareOk(sequenceId = 1, stmtId = 2))
+            // Each prepare completes (its prepare-ok is relayed back to the client) before the next is sent,
+            // the way a synchronous client drives the connection
+            harness.sendToProxy(mysqlPacket(0, byteArrayOf(0x16) + firstSql.toByteArray(Charsets.UTF_8)))
+            harness.readPacketForwardedUpstream()
+            harness.sendFromUpstream(prepareOk(sequenceId = 1, stmtId = 1))
             harness.readPacketOnClient()
+
+            harness.sendToProxy(mysqlPacket(0, byteArrayOf(0x16) + secondSql.toByteArray(Charsets.UTF_8)))
+            harness.readPacketForwardedUpstream()
+            harness.sendFromUpstream(prepareOk(sequenceId = 1, stmtId = 2))
             harness.readPacketOnClient()
 
             harness.sendToProxy(comStmtExecute(1))
@@ -172,6 +172,28 @@ class MySqlProxyFailClosedTest {
             harness.readPacketForwardedUpstream()
 
             assertEquals(listOf(firstSql, secondSql), harness.eventService.rawQueries)
+        }
+    }
+
+    @Test
+    fun `a second prepare pipelined before the first response is blocked`() {
+        RelayHarness(executionRequestAdapter, eventAdapter).use { harness ->
+            // Two prepares in one chunk, before either prepare-ok arrives: the proxy cannot pair the
+            // responses reliably, so it must fail closed instead of guessing (which could misattribute a
+            // statement id to the wrong query text)
+            harness.sendToProxy(
+                mysqlPacket(0, byteArrayOf(0x16) + "SELECT * FROM users WHERE id = ?".toByteArray(Charsets.UTF_8)) +
+                    mysqlPacket(0, byteArrayOf(0x16) + "DELETE FROM users WHERE id = ?".toByteArray(Charsets.UTF_8)),
+            )
+
+            val (_, errPayload) = harness.readPacketOnClient()
+            assertEquals(0xFF, errPayload[0].toInt() and 0xFF)
+
+            harness.handler.join(5000)
+            assertFalse(harness.handler.isAlive)
+
+            // The whole chunk is dropped: neither prepare reaches the server
+            assertEquals(-1, harness.readByteForwardedUpstream())
         }
     }
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyFailClosedTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyFailClosedTest.kt
@@ -1,0 +1,212 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.db.EventAdapter
+import dev.kviklet.kviklet.db.ExecutionRequestAdapter
+import dev.kviklet.kviklet.helper.ExecutionRequestFactory
+import dev.kviklet.kviklet.proxy.mocks.FailingEventServiceMock
+import dev.kviklet.kviklet.proxy.mysql.MySqlConnection
+import dev.kviklet.kviklet.proxy.mysql.readPacket
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketTimeoutException
+import kotlin.concurrent.thread
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MySqlProxyFailClosedTest {
+    @Autowired
+    lateinit var executionRequestAdapter: ExecutionRequestAdapter
+
+    @Autowired
+    lateinit var eventAdapter: EventAdapter
+
+    // A relay session over raw sockets, bypassing connection setup, so tests can speak the wire protocol
+    // directly with the same socket configuration the proxy applies after authentication
+    private class RelayHarness(executionRequestAdapter: ExecutionRequestAdapter, eventAdapter: EventAdapter) :
+        AutoCloseable {
+        val request = ExecutionRequestFactory().createDatasourceExecutionRequest()
+        val eventService = FailingEventServiceMock(executionRequestAdapter, eventAdapter, request)
+        private val upstreamListener = ServerSocket(0)
+        private val clientListener = ServerSocket(0)
+        val clientSide = Socket("localhost", clientListener.localPort)
+        private val proxyClientSocket = clientListener.accept()
+        private val proxyTargetSocket = Socket("localhost", upstreamListener.localPort)
+        val upstreamSide: Socket = upstreamListener.accept()
+        val handler: Thread
+
+        init {
+            // Match the socket configuration the proxy applies to the relay after setup: the blocking
+            // thread-per-direction relay uses no read timeout (soTimeout 0), parking in a read until data
+            // arrives or the socket is closed on teardown.
+            proxyClientSocket.soTimeout = 0
+            proxyTargetSocket.soTimeout = 0
+            val connection = MySqlConnection(proxyClientSocket, proxyTargetSocket, eventService, request, "mock")
+            handler = thread { connection.startHandling() }
+        }
+
+        fun sendToProxy(bytes: ByteArray) {
+            clientSide.getOutputStream().write(bytes)
+            clientSide.getOutputStream().flush()
+        }
+
+        // The next complete packet the proxy forwarded to the target database
+        fun readPacketForwardedUpstream(timeoutMillis: Int = 5000): Pair<Int, ByteArray> {
+            upstreamSide.soTimeout = timeoutMillis
+            return readPacket(upstreamSide.getInputStream())
+        }
+
+        // Returns -1 if nothing arrives at the target database within the timeout
+        fun readByteForwardedUpstream(timeoutMillis: Int = 500): Int {
+            upstreamSide.soTimeout = timeoutMillis
+            return try {
+                upstreamSide.getInputStream().read()
+            } catch (e: SocketTimeoutException) {
+                -1
+            }
+        }
+
+        fun sendFromUpstream(bytes: ByteArray) {
+            upstreamSide.getOutputStream().write(bytes)
+            upstreamSide.getOutputStream().flush()
+        }
+
+        // The next complete packet the proxy relayed back to the client
+        fun readPacketOnClient(timeoutMillis: Int = 5000): Pair<Int, ByteArray> {
+            clientSide.soTimeout = timeoutMillis
+            return readPacket(clientSide.getInputStream())
+        }
+
+        override fun close() {
+            clientSide.close()
+            proxyClientSocket.close()
+            proxyTargetSocket.close()
+            upstreamSide.close()
+            upstreamListener.close()
+            clientListener.close()
+        }
+    }
+
+    @Test
+    fun `a query whose audit write fails is blocked with an ERR packet and the session is closed`() {
+        RelayHarness(executionRequestAdapter, eventAdapter).use { harness ->
+            harness.eventService.failing = true
+            harness.sendToProxy(comQuery("DROP TABLE users"))
+
+            // The client must receive an ERR packet (0xFF), not a dead socket
+            val (_, errPayload) = harness.readPacketOnClient()
+            assertEquals(0xFF, errPayload[0].toInt() and 0xFF)
+
+            // The session must terminate
+            harness.handler.join(5000)
+            assertFalse(harness.handler.isAlive)
+
+            // Nothing must have been forwarded to the target database
+            assertEquals(-1, harness.readByteForwardedUpstream())
+        }
+    }
+
+    @Test
+    fun `an execute of a statement id the proxy never saw prepared is blocked`() {
+        RelayHarness(executionRequestAdapter, eventAdapter).use { harness ->
+            harness.sendToProxy(comStmtExecute(42))
+
+            val (_, errPayload) = harness.readPacketOnClient()
+            assertEquals(0xFF, errPayload[0].toInt() and 0xFF)
+
+            harness.handler.join(5000)
+            assertFalse(harness.handler.isAlive)
+
+            assertEquals(-1, harness.readByteForwardedUpstream())
+            assertTrue(harness.eventService.queries.isEmpty())
+        }
+    }
+
+    @Test
+    fun `an executed prepared statement is audited with the text it was prepared with`() {
+        RelayHarness(executionRequestAdapter, eventAdapter).use { harness ->
+            val sql = "INSERT INTO logs (message) VALUES (?)"
+            harness.sendToProxy(mysqlPacket(0, byteArrayOf(0x16) + sql.toByteArray(Charsets.UTF_8)))
+            harness.readPacketForwardedUpstream()
+
+            // The upstream answers with a prepare-ok assigning statement id 7; reading the relayed
+            // response on the client guarantees the proxy has processed it
+            harness.sendFromUpstream(prepareOk(sequenceId = 1, stmtId = 7))
+            harness.readPacketOnClient()
+
+            harness.sendToProxy(comStmtExecute(7))
+            val (_, forwarded) = harness.readPacketForwardedUpstream()
+            assertEquals(0x17, forwarded[0].toInt() and 0xFF)
+            harness.eventService.assertAuditedQueryContains(sql)
+        }
+    }
+
+    @Test
+    fun `two pipelined prepares are attributed to their own statement ids`() {
+        RelayHarness(executionRequestAdapter, eventAdapter).use { harness ->
+            val firstSql = "SELECT * FROM users WHERE id = ?"
+            val secondSql = "DELETE FROM users WHERE id = ?"
+            // Both prepares are sent before either response arrives; a single "awaiting prepare" flag
+            // would pair the first response with the second query and lose the second id entirely
+            harness.sendToProxy(
+                mysqlPacket(0, byteArrayOf(0x16) + firstSql.toByteArray(Charsets.UTF_8)) +
+                    mysqlPacket(0, byteArrayOf(0x16) + secondSql.toByteArray(Charsets.UTF_8)),
+            )
+            harness.readPacketForwardedUpstream()
+            harness.readPacketForwardedUpstream()
+
+            harness.sendFromUpstream(prepareOk(sequenceId = 1, stmtId = 1) + prepareOk(sequenceId = 1, stmtId = 2))
+            harness.readPacketOnClient()
+            harness.readPacketOnClient()
+
+            harness.sendToProxy(comStmtExecute(1))
+            harness.readPacketForwardedUpstream()
+            harness.sendToProxy(comStmtExecute(2))
+            harness.readPacketForwardedUpstream()
+
+            assertEquals(listOf(firstSql, secondSql), harness.eventService.rawQueries)
+        }
+    }
+
+    private fun comQuery(sql: String): ByteArray = mysqlPacket(0, byteArrayOf(0x03) + sql.toByteArray(Charsets.UTF_8))
+
+    private fun comStmtExecute(stmtId: Int): ByteArray = mysqlPacket(
+        0,
+        byteArrayOf(
+            0x17,
+            (stmtId and 0xFF).toByte(),
+            ((stmtId ushr 8) and 0xFF).toByte(),
+            ((stmtId ushr 16) and 0xFF).toByte(),
+            ((stmtId ushr 24) and 0xFF).toByte(),
+            0x00, // flags
+            0x01, 0x00, 0x00, 0x00, // iteration count
+        ),
+    )
+
+    // COM_STMT_PREPARE_OK: 0x00 status + 4-byte stmt id + 2 columns + 2 params + 1 reserved + 2 warnings
+    private fun prepareOk(sequenceId: Int, stmtId: Int): ByteArray {
+        val payload = ByteArray(12)
+        payload[1] = (stmtId and 0xFF).toByte()
+        payload[2] = ((stmtId ushr 8) and 0xFF).toByte()
+        payload[3] = ((stmtId ushr 16) and 0xFF).toByte()
+        payload[4] = ((stmtId ushr 24) and 0xFF).toByte()
+        return mysqlPacket(sequenceId, payload)
+    }
+
+    private fun mysqlPacket(sequenceId: Int, payload: ByteArray): ByteArray {
+        val header = byteArrayOf(
+            (payload.size and 0xFF).toByte(),
+            ((payload.size ushr 8) and 0xFF).toByte(),
+            ((payload.size ushr 16) and 0xFF).toByte(),
+            (sequenceId and 0xFF).toByte(),
+        )
+        return header + payload
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
@@ -290,6 +290,34 @@ class MySqlProxyUnitTest {
     }
 
     @Test
+    fun `test MySqlServerPacketParser streams past an oversized split payload and still parses a prepare-ok`() {
+        var returnedStmtId = 0
+        val parser = MySqlServerPacketParser({ returnedStmtId = it })
+
+        // A split logical payload (a 0xFFFFFF continuation packet plus a small final packet) is larger than
+        // any control packet the server parser inspects, so it must be streamed past without buffering
+        val continuation = mysqlPacket(0, ByteArray(0xFFFFFF))
+        val finalPiece = mysqlPacket(1, ByteArray(8))
+        val prepareOk = ByteArray(12).also { it[1] = 55 } // 0x00 status, stmt id 55
+        parser.addBytes(continuation + finalPiece + mysqlPacket(2, prepareOk))
+
+        assertEquals(55, returnedStmtId)
+    }
+
+    @Test
+    fun `test MySqlServerPacketParser streams past a large single packet and still parses a prepare-ok`() {
+        var returnedStmtId = 0
+        val parser = MySqlServerPacketParser({ returnedStmtId = it })
+
+        // A single result packet larger than the control-packet cap, but not split, is also streamed past
+        val bigRow = mysqlPacket(0, ByteArray(5000))
+        val prepareOk = ByteArray(12).also { it[1] = 7 }
+        parser.addBytes(bigRow + mysqlPacket(1, prepareOk))
+
+        assertEquals(7, returnedStmtId)
+    }
+
+    @Test
     fun `test buildInitialHandshake structure`() {
         val salt = ByteArray(20) { it.toByte() }
         val handshake = buildInitialHandshake(1234, salt, false)

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
@@ -1,6 +1,7 @@
 // This file is not MIT licensed
 package dev.kviklet.kviklet.proxy
 
+import dev.kviklet.kviklet.proxy.mysql.FailClosedException
 import dev.kviklet.kviklet.proxy.mysql.MySqlClientPacketParser
 import dev.kviklet.kviklet.proxy.mysql.MySqlServerPacketParser
 import dev.kviklet.kviklet.proxy.mysql.buildErrPacket
@@ -9,6 +10,7 @@ import dev.kviklet.kviklet.proxy.mysql.buildOkPacket
 import dev.kviklet.kviklet.proxy.mysql.verifyPassword
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
@@ -186,6 +188,78 @@ class MySqlProxyUnitTest {
     }
 
     @Test
+    fun `test MySqlClientPacketParser parses a packet delivered across two reads`() {
+        var parsedQuery = ""
+        val parser = MySqlClientPacketParser(
+            onQuery = { parsedQuery = it },
+            onPrepare = {},
+            onExecute = {},
+            onQuit = {},
+        )
+
+        val sql = "SELECT * FROM users"
+        val packet = mysqlPacket(0, byteArrayOf(0x03) + sql.toByteArray(Charsets.UTF_8))
+
+        // TCP can split a packet anywhere; nothing may be parsed until it is complete
+        parser.addBytes(packet.copyOfRange(0, 7))
+        assertEquals("", parsedQuery)
+        parser.addBytes(packet.copyOfRange(7, packet.size))
+        assertEquals(sql, parsedQuery)
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser reassembles a split 16MB+ COM_QUERY`() {
+        var parsedQuery = ""
+        val parser = MySqlClientPacketParser(
+            onQuery = { parsedQuery = it },
+            onPrepare = {},
+            onExecute = {},
+            onQuit = {},
+        )
+
+        // A payload of exactly 0xFFFFFF continues in the next packet. Build a query spanning two packets:
+        // the first carries the command byte plus 0xFFFFFF-1 filler chars, the second the final "END".
+        val firstPayload = ByteArray(0xFFFFFF)
+        firstPayload[0] = 0x03 // COM_QUERY
+        for (i in 1 until firstPayload.size) firstPayload[i] = 'a'.code.toByte()
+        val bytes = mysqlPacket(0, firstPayload) + mysqlPacket(1, "END".toByteArray(Charsets.UTF_8))
+
+        parser.addBytes(bytes)
+
+        assertEquals(0xFFFFFF - 1 + 3, parsedQuery.length)
+        assertTrue(parsedQuery.endsWith("aaaEND"))
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser fails closed on COM_CHANGE_USER`() {
+        val parser = MySqlClientPacketParser(
+            onQuery = {},
+            onPrepare = {},
+            onExecute = {},
+            onQuit = {},
+        )
+
+        val packet = mysqlPacket(0, byteArrayOf(0x11) + "someuser".toByteArray(Charsets.UTF_8))
+        val exception = assertThrows(FailClosedException::class.java) { parser.addBytes(packet) }
+        assertTrue(exception.message!!.contains("COM_CHANGE_USER"))
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser fails closed on a truncated COM_STMT_EXECUTE`() {
+        val parser = MySqlClientPacketParser(
+            onQuery = {},
+            onPrepare = {},
+            onExecute = {},
+            onQuit = {},
+        )
+
+        // COM_STMT_EXECUTE needs at least the command byte plus a 4-byte statement id
+        val packet = mysqlPacket(0, byteArrayOf(0x17, 0x01, 0x00))
+        val exception = assertThrows(FailClosedException::class.java) { parser.addBytes(packet) }
+        assertTrue(exception.message!!.contains("COM_STMT_EXECUTE"))
+    }
+
+    @Test
     fun `test buildInitialHandshake structure`() {
         val salt = ByteArray(20) { it.toByte() }
         val handshake = buildInitialHandshake(1234, salt, false)
@@ -207,5 +281,16 @@ class MySqlProxyUnitTest {
         assertEquals(0xFF.toByte(), err[0]) // ERR header
         assertEquals(1045 and 0xFF, err[1].toInt() and 0xFF)
         assertEquals('#'.code.toByte(), err[3])
+    }
+
+    // One wire packet: 3-byte little-endian payload length, 1-byte sequence id, payload
+    private fun mysqlPacket(sequenceId: Int, payload: ByteArray): ByteArray {
+        val header = byteArrayOf(
+            (payload.size and 0xFF).toByte(),
+            ((payload.size ushr 8) and 0xFF).toByte(),
+            ((payload.size ushr 16) and 0xFF).toByte(),
+            (sequenceId and 0xFF).toByte(),
+        )
+        return header + payload
     }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
@@ -245,6 +245,36 @@ class MySqlProxyUnitTest {
     }
 
     @Test
+    fun `test MySqlClientPacketParser fails closed on an unlisted command`() {
+        val parser = MySqlClientPacketParser(
+            onQuery = {},
+            onPrepare = {},
+            onExecute = {},
+            onQuit = {},
+        )
+
+        // COM_BINLOG_DUMP (0x12) streams row changes with no auditable SQL and is not on the allowlist
+        val packet = mysqlPacket(0, byteArrayOf(0x12, 0x00, 0x00, 0x00, 0x00))
+        val exception = assertThrows(FailClosedException::class.java) { parser.addBytes(packet) }
+        assertTrue(exception.message!!.contains("COM_BINLOG_DUMP"))
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser audits COM_INIT_DB as a USE statement`() {
+        var parsedQuery = ""
+        val parser = MySqlClientPacketParser(
+            onQuery = { parsedQuery = it },
+            onPrepare = {},
+            onExecute = {},
+            onQuit = {},
+        )
+
+        val packet = mysqlPacket(0, byteArrayOf(0x02) + "reporting".toByteArray(Charsets.UTF_8))
+        parser.addBytes(packet)
+        assertEquals("USE `reporting`", parsedQuery)
+    }
+
+    @Test
     fun `test MySqlClientPacketParser fails closed on a truncated COM_STMT_EXECUTE`() {
         val parser = MySqlClientPacketParser(
             onQuery = {},


### PR DESCRIPTION
The MySQL relay previously forwarded traffic even when the audit path could not record it: audit write failures were logged and swallowed, an execute of an unknown statement id was silently relayed, parse errors were caught and ignored, and statements larger than 16MB were audited truncated while executing in full. This PR makes the MySQL proxy match the Postgres proxy's fail-closed posture: anything the audit log cannot record is blocked and the session is aborted with an ERR packet instead of being forwarded.

- Audit write failures, unattributable `COM_STMT_EXECUTE`s, unparseable packets, and commands that sidestep the audited session (`COM_CHANGE_USER`, legacy `COM_CREATE_DB`/`COM_DROP_DB`) now block the packet and close the session with a client-visible ERR, mirroring the Postgres `abortSession` mechanism (including the client-write lock so the ERR cannot interleave with relayed server bytes).
- Prepared-statement tracking uses a FIFO of pending prepare texts instead of a single awaiting flag, so pipelined prepares can no longer attribute the wrong query text to a statement id or leave an id untracked (which would previously relay its executes unaudited).
- The packet framer reassembles payloads split at the 16MB wire boundary (capped at 1GB, matching the Postgres framer), so large statements are audited whole instead of being misread as a truncated query followed by garbage commands.
- The handshake now requires a protocol 4.1 client and rejects capability bits that would make the audited stream unparseable (`COMPRESS`, `ZSTD_COMPRESSION`, `LOCAL_FILES`).