### PR TITLE
Interpolate bound parameter values into the MySQL proxy audit log

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -35,6 +35,18 @@ private const val ABORT_ERR_TIMEOUT_MS = 2000L
 // that aborts the session.
 class FailClosedException(message: String, cause: Throwable? = null) : Exception(message, cause)
 
+// Everything the proxy tracks about one live server-side prepared statement. query and paramCount are
+// fixed at prepare time: the server pump writes them and the ConcurrentHashMap publishes them to the
+// client thread. The two mutable fields are only ever touched on the client thread (executes, long data
+// and resets are all client commands), so they need no further synchronization: paramTypes caches the
+// last resent parameter types (a re-execute with new-params-bound-flag = 0 omits them), and
+// longDataParams marks the parameters whose value arrived via COM_STMT_SEND_LONG_DATA (absent from the
+// execute packet, rendered as an explicit marker).
+private class PreparedStatementRecord(val query: String, val paramCount: Int) {
+    var paramTypes: IntArray? = null
+    val longDataParams = mutableSetOf<Int>()
+}
+
 class MySqlConnection(
     private val clientSocket: Socket,
     private val targetSocket: Socket,
@@ -87,7 +99,7 @@ class MySqlConnection(
     private val prepareLock = Any()
     private var prepareInFlight = false
     private var inFlightPrepareQuery: String? = null
-    private val preparedQueries = ConcurrentHashMap<Int, String>()
+    private val preparedQueries = ConcurrentHashMap<Int, PreparedStatementRecord>()
 
     private val clientParser = MySqlClientPacketParser(
         onQuery = { query ->
@@ -108,16 +120,48 @@ class MySqlConnection(
                 inFlightPrepareQuery = query
             }
         },
-        onExecute = { stmtId ->
+        onExecute = { stmtId, payload ->
             // Fail closed: an execute the proxy cannot attribute to query text must not reach the server.
             // Ids go untracked when the prepare-response pairing was disturbed (a non-prepare response
             // interleaved with the prepare) or when the client fabricates an id it never prepared here.
-            val query = preparedQueries[stmtId]
+            val statement = preparedQueries[stmtId]
                 ?: throw FailClosedException(
                     "Kviklet proxy does not know the prepared statement id $stmtId and cannot audit this " +
                         "execution. The query was blocked and the session closed.",
                 )
-            auditQuery(query)
+            // Best effort: render the execute's binary parameter values into the placeholder text so the
+            // audit log shows what actually ran. A payload the decoder cannot fully and unambiguously
+            // decode falls back to the placeholder text -- a wrong value in the log would be worse than no
+            // value, and blocking would break legitimate clients over an audit nicety.
+            val interpolated = interpolateExecutePayload(
+                statement.query,
+                statement.paramCount,
+                statement.paramTypes,
+                statement.longDataParams,
+                payload,
+            )
+            if (interpolated == null) {
+                logger.warn(
+                    "Could not decode the parameters of prepared statement $stmtId; " +
+                        "auditing its placeholder text",
+                )
+                auditQuery(statement.query)
+            } else {
+                // Cache the decoded types: a re-execute with new-params-bound-flag = 0 does not resend them.
+                interpolated.paramTypes?.let { statement.paramTypes = it }
+                auditQuery(interpolated.query)
+            }
+        },
+        onLongData = { stmtId, paramIndex ->
+            // The parameter's bytes travel ahead of the execute and are not repeated in the execute
+            // packet, so the execute decoder must skip that parameter; it renders as an explicit marker.
+            // The server keeps accumulated long data until COM_STMT_RESET, so the mark does too. An
+            // unknown id needs no action: its execute fails closed anyway.
+            preparedQueries[stmtId]?.longDataParams?.add(paramIndex)
+        },
+        onStmtReset = { stmtId ->
+            // COM_STMT_RESET discards the statement's accumulated long data server-side.
+            preparedQueries[stmtId]?.longDataParams?.clear()
         },
         onClose = { stmtId ->
             // Release the stored query when the client closes the prepared statement
@@ -138,7 +182,7 @@ class MySqlConnection(
     )
 
     private val serverParser = MySqlServerPacketParser(
-        onPrepareOk = { stmtId ->
+        onPrepareOk = { stmtId, paramCount ->
             synchronized(prepareLock) {
                 // Only pair while a prepare is actually outstanding; otherwise this is an ordinary OK packet
                 // that merely happens to be 12 bytes, not a prepare-ok.
@@ -150,7 +194,9 @@ class MySqlConnection(
                     // can be reassigned). A collision means a non-prepare response was misread as a
                     // prepare-ok: the statement stream is out of sync, so fail closed rather than overwrite a
                     // tracked statement's text and falsify its future audit entries.
-                    if (query != null && preparedQueries.putIfAbsent(stmtId, query) != null) {
+                    if (query != null &&
+                        preparedQueries.putIfAbsent(stmtId, PreparedStatementRecord(query, paramCount)) != null
+                    ) {
                         throw FailClosedException(
                             "Kviklet proxy saw prepared statement id $stmtId assigned while it was still in " +
                                 "use; the statement stream is out of sync and cannot be audited. The " +
@@ -421,10 +467,15 @@ private class MySqlPacketFramer(private val reassemble: Boolean, private val onP
 class MySqlClientPacketParser(
     private val onQuery: (String) -> Unit,
     private val onPrepare: (String) -> Unit,
-    private val onExecute: (Int) -> Unit,
+    // Receives the statement id and the full COM_STMT_EXECUTE payload, so the listener can decode the
+    // bound parameter values for the audit log.
+    private val onExecute: (Int, ByteArray) -> Unit,
     private val onClose: (Int) -> Unit = {},
     private val onQuit: () -> Unit,
     private val onResetConnection: () -> Unit = {},
+    // Statement id and parameter index of a COM_STMT_SEND_LONG_DATA (the data bytes are not passed on).
+    private val onLongData: (Int, Int) -> Unit = { _, _ -> },
+    private val onStmtReset: (Int) -> Unit = {},
 ) {
     // reassemble = true: a >16MB client statement is joined so its full text can be audited verbatim.
     private val framer = MySqlPacketFramer(reassemble = true) { payload -> handlePacket(payload) }
@@ -466,13 +517,31 @@ class MySqlClientPacketParser(
                 onPrepare(query)
             }
 
-            0x17 -> onExecute(readStatementId(payload, "COM_STMT_EXECUTE"))
+            0x17 -> onExecute(readStatementId(payload, "COM_STMT_EXECUTE"), payload)
 
             // COM_STMT_EXECUTE
+
+            // COM_STMT_SEND_LONG_DATA: statement id (4 bytes) then parameter index (2 bytes, little-endian)
+            // after the command byte. The data bytes are relayed but not passed on -- the execute they belong
+            // to is audited with an explicit long-data marker for this parameter.
+            0x18 -> {
+                if (payload.size < 7) {
+                    throw FailClosedException(
+                        "Kviklet proxy could not parse a truncated COM_STMT_SEND_LONG_DATA packet. The " +
+                            "packet was blocked and the session closed.",
+                    )
+                }
+                val paramIndex = (payload[5].toInt() and 0xFF) or ((payload[6].toInt() and 0xFF) shl 8)
+                onLongData(readStatementId(payload, "COM_STMT_SEND_LONG_DATA"), paramIndex)
+            }
 
             0x19 -> onClose(readStatementId(payload, "COM_STMT_CLOSE"))
 
             // COM_STMT_CLOSE
+
+            // COM_STMT_RESET discards a statement's accumulated long data server-side, so the audit-side
+            // long-data tracking must be dropped with it.
+            0x1A -> onStmtReset(readStatementId(payload, "COM_STMT_RESET"))
 
             // COM_RESET_CONNECTION forgets every server-side prepared statement (and reassigns ids from
             // scratch), so the proxy must drop its own tracking to stay in sync.
@@ -480,11 +549,10 @@ class MySqlClientPacketParser(
 
             // Commands that carry no auditable SQL and cannot defeat the audit, relayed unchanged:
             //   COM_STATISTICS, COM_PING            -- server-info / liveness, no SQL
-            //   COM_STMT_SEND_LONG_DATA             -- parameter bytes for a prepared execute that is audited
-            //   COM_STMT_RESET, COM_STMT_FETCH      -- reset / cursor-read of an already-audited statement
+            //   COM_STMT_FETCH                      -- cursor-read of an already-audited statement
             //   COM_SET_OPTION                      -- multi-statements stay auditable (COM_QUERY text is
             //                                          captured verbatim, all statements included)
-            0x09, 0x0E, 0x18, 0x1A, 0x1B, 0x1C -> {}
+            0x09, 0x0E, 0x1B, 0x1C -> {}
 
             else -> throw FailClosedException(blockedCommandMessage(cmd))
         }
@@ -529,7 +597,9 @@ class MySqlClientPacketParser(
     }
 }
 
-class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit, private val onPrepareErr: () -> Unit = {}) {
+// onPrepareOk receives the assigned statement id and the statement's parameter count, both read from the
+// prepare-ok payload; the count is what lets the execute decoder parse the binary parameter section.
+class MySqlServerPacketParser(private val onPrepareOk: (Int, Int) -> Unit, private val onPrepareErr: () -> Unit = {}) {
     // reassemble = false: the parser only inspects short control packets, so large result payloads (a split
     // multi-megabyte BLOB row) are streamed past without buffering rather than accumulated up to 1GB.
     private val framer = MySqlPacketFramer(reassemble = false) { payload -> handlePacket(payload) }
@@ -552,7 +622,8 @@ class MySqlServerPacketParser(private val onPrepareOk: (Int) -> Unit, private va
                 ((payload[2].toInt() and 0xFF) shl 8) or
                 ((payload[3].toInt() and 0xFF) shl 16) or
                 ((payload[4].toInt() and 0xFF) shl 24)
-            onPrepareOk(stmtId)
+            val paramCount = (payload[7].toInt() and 0xFF) or ((payload[8].toInt() and 0xFF) shl 8)
+            onPrepareOk(stmtId, paramCount)
         }
     }
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlConnection.kt
@@ -140,27 +140,33 @@ class MySqlConnection(
                 statement.longDataParams,
                 payload,
             )
-            if (interpolated == null) {
+            // Long data is consumed by this execute: the protocol scopes COM_STMT_SEND_LONG_DATA to the
+            // next execute (a client that streams again re-marks the parameters), so a mark must never
+            // leak into a later execute where the parameter's value is back in the packet.
+            statement.longDataParams.clear()
+            // Track the types the server now holds for this statement even when nothing was interpolated:
+            // a later execute with new-params-bound-flag = 0 does not resend them, and decoding it against
+            // an out-of-date cache would render plausible but wrong values.
+            statement.paramTypes = interpolated.paramTypes
+            if (interpolated.query == null) {
                 logger.warn(
                     "Could not decode the parameters of prepared statement $stmtId; " +
                         "auditing its placeholder text",
                 )
                 auditQuery(statement.query)
             } else {
-                // Cache the decoded types: a re-execute with new-params-bound-flag = 0 does not resend them.
-                interpolated.paramTypes?.let { statement.paramTypes = it }
                 auditQuery(interpolated.query)
             }
         },
         onLongData = { stmtId, paramIndex ->
             // The parameter's bytes travel ahead of the execute and are not repeated in the execute
             // packet, so the execute decoder must skip that parameter; it renders as an explicit marker.
-            // The server keeps accumulated long data until COM_STMT_RESET, so the mark does too. An
-            // unknown id needs no action: its execute fails closed anyway.
+            // An unknown id needs no action: its execute fails closed anyway.
             preparedQueries[stmtId]?.longDataParams?.add(paramIndex)
         },
         onStmtReset = { stmtId ->
-            // COM_STMT_RESET discards the statement's accumulated long data server-side.
+            // COM_STMT_RESET discards any accumulated long data server-side before an execute ever
+            // consumes it.
             preparedQueries[stmtId]?.longDataParams?.clear()
         },
         onClose = { stmtId ->

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlStatementInterpolator.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlStatementInterpolator.kt
@@ -6,15 +6,18 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.charset.CharacterCodingException
 import java.nio.charset.CodingErrorAction
+import java.util.HexFormat
+import java.util.Locale
 
 // Decodes a COM_STMT_EXECUTE payload's binary parameter values and renders them into the prepared
 // statement's placeholder text, so the audit log records the statement as it actually ran instead of
 // "VALUES (?)". Interpolation is audit-only and strictly best effort: it must never block a legitimate
 // client and must never put a wrong value in the log. So the decode is all-or-nothing -- anything the
 // decoder cannot fully and unambiguously account for (an unknown type code, a layout mismatch, leftover
-// bytes) abandons interpolation entirely (returns null) and the caller audits the placeholder text, which
-// is exactly what was audited before values existed. The rendered SQL aims for readability, not for
-// byte-perfect re-executability (same standard as the Postgres proxy's interpolateQuery).
+// bytes) abandons interpolation entirely (a null query in the result) and the caller audits the
+// placeholder text, which is exactly what was audited before values existed. The rendered SQL aims for
+// readability, not for byte-perfect re-executability (same standard as the Postgres proxy's
+// interpolateQuery).
 
 // Binary-protocol type codes (the low byte of the 2-byte type field in the execute packet).
 private const val TYPE_DECIMAL = 0x00
@@ -57,9 +60,16 @@ private const val EXECUTE_HEADER_LENGTH = 10
 // so the audit log gets an explicit marker instead of a value.
 const val LONG_DATA_PLACEHOLDER = "<long data>"
 
-// paramTypes are the types the values were decoded with (resent types, or the caller's cached ones);
-// the caller caches them because a re-execute with new-params-bound-flag = 0 does not resend them.
-class InterpolatedExecute(val query: String, val paramTypes: IntArray?)
+private val HEX = HexFormat.of()
+
+// query is the interpolated statement, or null when the payload could not be decoded and the caller must
+// audit the placeholder text instead. paramTypes is the type array now in effect for the statement on the
+// server -- the resent one when the execute carried types (reported even when the value decode then
+// fails, so the caller's cache can never go stale against the server's), the cached one otherwise, or
+// null when it is unknown. The caller must store it either way: a later execute with
+// new-params-bound-flag = 0 does not resend types, and decoding it with an out-of-date cache would render
+// plausible but wrong values.
+class InterpolatedExecute(val query: String?, val paramTypes: IntArray?)
 
 fun interpolateExecutePayload(
     query: String,
@@ -67,36 +77,55 @@ fun interpolateExecutePayload(
     cachedParamTypes: IntArray?,
     longDataParams: Set<Int>,
     payload: ByteArray,
-): InterpolatedExecute? {
+): InterpolatedExecute {
     if (paramCount == 0) return InterpolatedExecute(query, null)
-    // The server derived paramCount by really parsing the statement; if this scan disagrees, its idea of
-    // where the placeholders sit cannot be trusted, so do not splice values into the wrong places.
-    val placeholders = findPlaceholders(query)
-    if (placeholders.size != paramCount) return null
-    return try {
-        val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
-        buffer.position(EXECUTE_HEADER_LENGTH)
-        val nullBitmap = ByteArray((paramCount + 7) / 8)
+    val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+    if (payload.size < EXECUTE_HEADER_LENGTH) return InterpolatedExecute(null, null)
+    buffer.position(EXECUTE_HEADER_LENGTH)
+
+    // The wire is read up to and including the type array before anything can bail out on the statement
+    // text: the types are what the server will hold for this statement from now on, and the cache must
+    // track them even when nothing gets interpolated.
+    val nullBitmap = ByteArray((paramCount + 7) / 8)
+    val paramTypes = try {
         buffer.get(nullBitmap)
-        val newParamsBound = (buffer.get().toInt() and 0xFF) == 1
-        val paramTypes = if (newParamsBound) {
+        // The server treats any non-zero new-params-bound byte as "types follow" -- matching only 1 would
+        // let a nonstandard client desync this parse from the server's.
+        val newParamsBound = (buffer.get().toInt() and 0xFF) != 0
+        if (newParamsBound) {
             IntArray(paramCount) { buffer.short.toInt() and 0xFFFF }
         } else {
-            cachedParamTypes ?: return null
+            cachedParamTypes ?: return InterpolatedExecute(null, null)
         }
-        if (paramTypes.size != paramCount) return null
+    } catch (e: BufferUnderflowException) {
+        return InterpolatedExecute(null, null)
+    }
+    if (paramTypes.size != paramCount) return InterpolatedExecute(null, null)
+
+    // The server derived paramCount by really parsing the statement; if this scan disagrees, its idea of
+    // where the placeholders sit cannot be trusted, so do not splice values into the wrong places. The
+    // text is also scanned under both backslash conventions: sql_mode=NO_BACKSLASH_ESCAPES changes how
+    // string literals tokenize, the proxy cannot see which mode the session is in, and interpolating is
+    // only safe when both readings agree on the placeholder positions.
+    val placeholders = findPlaceholders(query, stringBackslashEscapes = true)
+    if (placeholders.size != paramCount || placeholders != findPlaceholders(query, stringBackslashEscapes = false)) {
+        return InterpolatedExecute(null, paramTypes)
+    }
+
+    return try {
+        // The buffer sits at the first value byte: the null bitmap, flag and type array were consumed above.
         val values = ArrayList<String>(paramCount)
         for (i in 0 until paramCount) {
             val isNull = (nullBitmap[i / 8].toInt() shr (i % 8)) and 1 == 1
             values += when {
                 isNull -> "NULL"
                 i in longDataParams -> LONG_DATA_PLACEHOLDER
-                else -> renderValue(paramTypes[i], buffer) ?: return null
+                else -> renderValue(paramTypes[i], buffer) ?: return InterpolatedExecute(null, paramTypes)
             }
         }
         // Leftover bytes mean the layout was not what the decoder assumed, so some value above was
         // probably misread from the wrong offset; none of it can be trusted.
-        if (buffer.hasRemaining()) return null
+        if (buffer.hasRemaining()) return InterpolatedExecute(null, paramTypes)
         val interpolated = StringBuilder(query.length + 16 * paramCount)
         var copiedUpTo = 0
         placeholders.forEachIndexed { i, position ->
@@ -106,10 +135,7 @@ fun interpolateExecutePayload(
         interpolated.append(query, copiedUpTo, query.length)
         InterpolatedExecute(interpolated.toString(), paramTypes)
     } catch (e: BufferUnderflowException) {
-        null
-    } catch (e: IllegalArgumentException) {
-        // A payload shorter than the execute header: buffer.position() rejects the offset.
-        null
+        InterpolatedExecute(null, paramTypes)
     }
 }
 
@@ -197,14 +223,11 @@ private fun renderString(buffer: ByteBuffer): String? {
     }
 }
 
-private fun toHexLiteral(bytes: ByteArray): String = if (bytes.isEmpty()) {
-    "''"
-} else {
-    "0x" + bytes.joinToString("") { "%02x".format(it) }
-}
+private fun toHexLiteral(bytes: ByteArray): String = if (bytes.isEmpty()) "''" else "0x" + HEX.formatHex(bytes)
 
 // Binary DATE/DATETIME/TIMESTAMP: a length byte (0, 4, 7 or 11) then the packed fields; trailing
 // all-zero fields are omitted on the wire, so length 0 is the zero date and length 4 a date-only value.
+// Locale.ROOT keeps %d rendering ASCII digits regardless of the JVM's default locale.
 private fun renderTemporal(buffer: ByteBuffer): String? {
     val length = buffer.get().toInt() and 0xFF
     if (length > buffer.remaining()) return null
@@ -213,13 +236,15 @@ private fun renderTemporal(buffer: ByteBuffer): String? {
     val year = buffer.short.toInt() and 0xFFFF
     val month = buffer.get().toInt() and 0xFF
     val day = buffer.get().toInt() and 0xFF
-    if (length == 4) return "'%04d-%02d-%02d'".format(year, month, day)
+    if (length == 4) return "'%04d-%02d-%02d'".format(Locale.ROOT, year, month, day)
     val hour = buffer.get().toInt() and 0xFF
     val minute = buffer.get().toInt() and 0xFF
     val second = buffer.get().toInt() and 0xFF
-    if (length == 7) return "'%04d-%02d-%02d %02d:%02d:%02d'".format(year, month, day, hour, minute, second)
+    if (length == 7) {
+        return "'%04d-%02d-%02d %02d:%02d:%02d'".format(Locale.ROOT, year, month, day, hour, minute, second)
+    }
     val micros = buffer.int
-    return "'%04d-%02d-%02d %02d:%02d:%02d.%06d'".format(year, month, day, hour, minute, second, micros)
+    return "'%04d-%02d-%02d %02d:%02d:%02d.%06d'".format(Locale.ROOT, year, month, day, hour, minute, second, micros)
 }
 
 // Binary TIME: a length byte (0, 8 or 12), then sign, days and the clock fields. A MySQL TIME is an
@@ -236,16 +261,18 @@ private fun renderTime(buffer: ByteBuffer): String? {
     val seconds = buffer.get().toInt() and 0xFF
     val sign = if (negative) "-" else ""
     val totalHours = days.toLong() * 24 + hours
-    if (length == 8) return "'$sign%02d:%02d:%02d'".format(totalHours, minutes, seconds)
+    if (length == 8) return "'$sign%02d:%02d:%02d'".format(Locale.ROOT, totalHours, minutes, seconds)
     val micros = buffer.int
-    return "'$sign%02d:%02d:%02d.%06d'".format(totalHours, minutes, seconds, micros)
+    return "'$sign%02d:%02d:%02d.%06d'".format(Locale.ROOT, totalHours, minutes, seconds, micros)
 }
 
 // Offsets of the bare `?` placeholders in the statement text. A `?` inside a string literal, a quoted
 // identifier or a comment is not a parameter marker, so those regions are skipped the way the MySQL
-// parser reads them (backslash and doubled-quote escapes in strings, doubled backticks in identifiers,
-// `-- ` and `#` line comments, `/* */` block comments).
-private fun findPlaceholders(query: String): List<Int> {
+// parser reads them (doubled-quote escapes in strings, doubled backticks in identifiers, `-- ` and `#`
+// line comments, `/* */` block comments). stringBackslashEscapes selects whether a backslash escapes the
+// next character inside '...' and "..." (the default) or is an ordinary character
+// (sql_mode=NO_BACKSLASH_ESCAPES); backticks never honor backslash escapes.
+private fun findPlaceholders(query: String, stringBackslashEscapes: Boolean): List<Int> {
     val positions = mutableListOf<Int>()
     var i = 0
     while (i < query.length) {
@@ -255,7 +282,7 @@ private fun findPlaceholders(query: String): List<Int> {
                 i++
             }
 
-            '\'', '"' -> i = skipQuoted(query, i, backslashEscapes = true)
+            '\'', '"' -> i = skipQuoted(query, i, backslashEscapes = stringBackslashEscapes)
 
             '`' -> i = skipQuoted(query, i, backslashEscapes = false)
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlStatementInterpolator.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlStatementInterpolator.kt
@@ -1,0 +1,306 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy.mysql
+
+import java.nio.BufferUnderflowException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
+
+// Decodes a COM_STMT_EXECUTE payload's binary parameter values and renders them into the prepared
+// statement's placeholder text, so the audit log records the statement as it actually ran instead of
+// "VALUES (?)". Interpolation is audit-only and strictly best effort: it must never block a legitimate
+// client and must never put a wrong value in the log. So the decode is all-or-nothing -- anything the
+// decoder cannot fully and unambiguously account for (an unknown type code, a layout mismatch, leftover
+// bytes) abandons interpolation entirely (returns null) and the caller audits the placeholder text, which
+// is exactly what was audited before values existed. The rendered SQL aims for readability, not for
+// byte-perfect re-executability (same standard as the Postgres proxy's interpolateQuery).
+
+// Binary-protocol type codes (the low byte of the 2-byte type field in the execute packet).
+private const val TYPE_DECIMAL = 0x00
+private const val TYPE_TINY = 0x01
+private const val TYPE_SHORT = 0x02
+private const val TYPE_LONG = 0x03
+private const val TYPE_FLOAT = 0x04
+private const val TYPE_DOUBLE = 0x05
+private const val TYPE_NULL = 0x06
+private const val TYPE_TIMESTAMP = 0x07
+private const val TYPE_LONGLONG = 0x08
+private const val TYPE_INT24 = 0x09
+private const val TYPE_DATE = 0x0A
+private const val TYPE_TIME = 0x0B
+private const val TYPE_DATETIME = 0x0C
+private const val TYPE_YEAR = 0x0D
+private const val TYPE_VARCHAR = 0x0F
+private const val TYPE_BIT = 0x10
+private const val TYPE_JSON = 0xF5
+private const val TYPE_NEWDECIMAL = 0xF6
+private const val TYPE_ENUM = 0xF7
+private const val TYPE_SET = 0xF8
+private const val TYPE_TINY_BLOB = 0xF9
+private const val TYPE_MEDIUM_BLOB = 0xFA
+private const val TYPE_LONG_BLOB = 0xFB
+private const val TYPE_BLOB = 0xFC
+private const val TYPE_VAR_STRING = 0xFD
+private const val TYPE_STRING = 0xFE
+private const val TYPE_GEOMETRY = 0xFF
+
+// The unsigned flag lives in the high byte of the 2-byte type field.
+private const val UNSIGNED_FLAG = 0x8000
+
+// COM_STMT_EXECUTE payload prefix: command byte + 4-byte statement id + 1-byte flags + 4-byte iteration
+// count. The parameter section (when the statement has parameters) starts right after it.
+private const val EXECUTE_HEADER_LENGTH = 10
+
+// What a parameter streamed ahead of the execute via COM_STMT_SEND_LONG_DATA renders as. Its bytes are
+// not in the execute packet (and are deliberately not accumulated -- they can be arbitrarily large blobs),
+// so the audit log gets an explicit marker instead of a value.
+const val LONG_DATA_PLACEHOLDER = "<long data>"
+
+// paramTypes are the types the values were decoded with (resent types, or the caller's cached ones);
+// the caller caches them because a re-execute with new-params-bound-flag = 0 does not resend them.
+class InterpolatedExecute(val query: String, val paramTypes: IntArray?)
+
+fun interpolateExecutePayload(
+    query: String,
+    paramCount: Int,
+    cachedParamTypes: IntArray?,
+    longDataParams: Set<Int>,
+    payload: ByteArray,
+): InterpolatedExecute? {
+    if (paramCount == 0) return InterpolatedExecute(query, null)
+    // The server derived paramCount by really parsing the statement; if this scan disagrees, its idea of
+    // where the placeholders sit cannot be trusted, so do not splice values into the wrong places.
+    val placeholders = findPlaceholders(query)
+    if (placeholders.size != paramCount) return null
+    return try {
+        val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+        buffer.position(EXECUTE_HEADER_LENGTH)
+        val nullBitmap = ByteArray((paramCount + 7) / 8)
+        buffer.get(nullBitmap)
+        val newParamsBound = (buffer.get().toInt() and 0xFF) == 1
+        val paramTypes = if (newParamsBound) {
+            IntArray(paramCount) { buffer.short.toInt() and 0xFFFF }
+        } else {
+            cachedParamTypes ?: return null
+        }
+        if (paramTypes.size != paramCount) return null
+        val values = ArrayList<String>(paramCount)
+        for (i in 0 until paramCount) {
+            val isNull = (nullBitmap[i / 8].toInt() shr (i % 8)) and 1 == 1
+            values += when {
+                isNull -> "NULL"
+                i in longDataParams -> LONG_DATA_PLACEHOLDER
+                else -> renderValue(paramTypes[i], buffer) ?: return null
+            }
+        }
+        // Leftover bytes mean the layout was not what the decoder assumed, so some value above was
+        // probably misread from the wrong offset; none of it can be trusted.
+        if (buffer.hasRemaining()) return null
+        val interpolated = StringBuilder(query.length + 16 * paramCount)
+        var copiedUpTo = 0
+        placeholders.forEachIndexed { i, position ->
+            interpolated.append(query, copiedUpTo, position).append(values[i])
+            copiedUpTo = position + 1
+        }
+        interpolated.append(query, copiedUpTo, query.length)
+        InterpolatedExecute(interpolated.toString(), paramTypes)
+    } catch (e: BufferUnderflowException) {
+        null
+    } catch (e: IllegalArgumentException) {
+        // A payload shorter than the execute header: buffer.position() rejects the offset.
+        null
+    }
+}
+
+// Renders one non-NULL parameter value, consuming exactly its wire bytes. Returns null for a type whose
+// wire length the decoder does not know -- consuming a guessed number of bytes would misalign every value
+// after it.
+private fun renderValue(typeField: Int, buffer: ByteBuffer): String? {
+    val unsigned = (typeField and UNSIGNED_FLAG) != 0
+    return when (typeField and 0xFF) {
+        TYPE_NULL -> "NULL"
+
+        TYPE_TINY -> {
+            val value = buffer.get()
+            if (unsigned) (value.toInt() and 0xFF).toString() else value.toString()
+        }
+
+        TYPE_SHORT, TYPE_YEAR -> {
+            val value = buffer.short
+            if (unsigned) (value.toInt() and 0xFFFF).toString() else value.toString()
+        }
+
+        TYPE_LONG, TYPE_INT24 -> {
+            val value = buffer.int
+            if (unsigned) (value.toLong() and 0xFFFFFFFFL).toString() else value.toString()
+        }
+
+        TYPE_LONGLONG -> {
+            val value = buffer.long
+            if (unsigned) value.toULong().toString() else value.toString()
+        }
+
+        TYPE_FLOAT -> buffer.float.toString()
+
+        TYPE_DOUBLE -> buffer.double.toString()
+
+        TYPE_DATE, TYPE_DATETIME, TYPE_TIMESTAMP -> renderTemporal(buffer)
+
+        TYPE_TIME -> renderTime(buffer)
+
+        TYPE_DECIMAL, TYPE_NEWDECIMAL, TYPE_VARCHAR, TYPE_ENUM, TYPE_SET, TYPE_JSON,
+        TYPE_TINY_BLOB, TYPE_MEDIUM_BLOB, TYPE_LONG_BLOB, TYPE_BLOB, TYPE_VAR_STRING, TYPE_STRING,
+        -> renderString(buffer)
+
+        TYPE_BIT, TYPE_GEOMETRY -> readLengthEncodedBytes(buffer)?.let { toHexLiteral(it) }
+
+        else -> null
+    }
+}
+
+// A length-encoded byte string: a length-encoded integer followed by that many bytes. Returns null on the
+// NULL/ERR markers (0xFB/0xFF, which are not valid value lengths) or a length beyond the buffer.
+private fun readLengthEncodedBytes(buffer: ByteBuffer): ByteArray? {
+    val first = buffer.get().toInt() and 0xFF
+    val length = when {
+        first < 0xFB -> first.toLong()
+
+        first == 0xFC -> buffer.short.toLong() and 0xFFFF
+
+        first == 0xFD -> (buffer.get().toLong() and 0xFF) or
+            ((buffer.get().toLong() and 0xFF) shl 8) or
+            ((buffer.get().toLong() and 0xFF) shl 16)
+
+        first == 0xFE -> buffer.long
+
+        else -> return null
+    }
+    if (length < 0 || length > buffer.remaining()) return null
+    val bytes = ByteArray(length.toInt())
+    buffer.get(bytes)
+    return bytes
+}
+
+// Text values become a quoted SQL literal; bytes that are not valid UTF-8 (binary blobs) become a hex
+// literal instead of mojibake.
+private fun renderString(buffer: ByteBuffer): String? {
+    val bytes = readLengthEncodedBytes(buffer) ?: return null
+    val decoder = Charsets.UTF_8.newDecoder()
+        .onMalformedInput(CodingErrorAction.REPORT)
+        .onUnmappableCharacter(CodingErrorAction.REPORT)
+    return try {
+        val text = decoder.decode(ByteBuffer.wrap(bytes)).toString()
+        "'" + text.replace("\\", "\\\\").replace("'", "''") + "'"
+    } catch (e: CharacterCodingException) {
+        toHexLiteral(bytes)
+    }
+}
+
+private fun toHexLiteral(bytes: ByteArray): String = if (bytes.isEmpty()) {
+    "''"
+} else {
+    "0x" + bytes.joinToString("") { "%02x".format(it) }
+}
+
+// Binary DATE/DATETIME/TIMESTAMP: a length byte (0, 4, 7 or 11) then the packed fields; trailing
+// all-zero fields are omitted on the wire, so length 0 is the zero date and length 4 a date-only value.
+private fun renderTemporal(buffer: ByteBuffer): String? {
+    val length = buffer.get().toInt() and 0xFF
+    if (length > buffer.remaining()) return null
+    if (length == 0) return "'0000-00-00'"
+    if (length != 4 && length != 7 && length != 11) return null
+    val year = buffer.short.toInt() and 0xFFFF
+    val month = buffer.get().toInt() and 0xFF
+    val day = buffer.get().toInt() and 0xFF
+    if (length == 4) return "'%04d-%02d-%02d'".format(year, month, day)
+    val hour = buffer.get().toInt() and 0xFF
+    val minute = buffer.get().toInt() and 0xFF
+    val second = buffer.get().toInt() and 0xFF
+    if (length == 7) return "'%04d-%02d-%02d %02d:%02d:%02d'".format(year, month, day, hour, minute, second)
+    val micros = buffer.int
+    return "'%04d-%02d-%02d %02d:%02d:%02d.%06d'".format(year, month, day, hour, minute, second, micros)
+}
+
+// Binary TIME: a length byte (0, 8 or 12), then sign, days and the clock fields. A MySQL TIME is an
+// interval, so it can be negative and exceed 24 hours; days are folded into the hour figure.
+private fun renderTime(buffer: ByteBuffer): String? {
+    val length = buffer.get().toInt() and 0xFF
+    if (length > buffer.remaining()) return null
+    if (length == 0) return "'00:00:00'"
+    if (length != 8 && length != 12) return null
+    val negative = (buffer.get().toInt() and 0xFF) == 1
+    val days = buffer.int
+    val hours = buffer.get().toInt() and 0xFF
+    val minutes = buffer.get().toInt() and 0xFF
+    val seconds = buffer.get().toInt() and 0xFF
+    val sign = if (negative) "-" else ""
+    val totalHours = days.toLong() * 24 + hours
+    if (length == 8) return "'$sign%02d:%02d:%02d'".format(totalHours, minutes, seconds)
+    val micros = buffer.int
+    return "'$sign%02d:%02d:%02d.%06d'".format(totalHours, minutes, seconds, micros)
+}
+
+// Offsets of the bare `?` placeholders in the statement text. A `?` inside a string literal, a quoted
+// identifier or a comment is not a parameter marker, so those regions are skipped the way the MySQL
+// parser reads them (backslash and doubled-quote escapes in strings, doubled backticks in identifiers,
+// `-- ` and `#` line comments, `/* */` block comments).
+private fun findPlaceholders(query: String): List<Int> {
+    val positions = mutableListOf<Int>()
+    var i = 0
+    while (i < query.length) {
+        when (query[i]) {
+            '?' -> {
+                positions.add(i)
+                i++
+            }
+
+            '\'', '"' -> i = skipQuoted(query, i, backslashEscapes = true)
+
+            '`' -> i = skipQuoted(query, i, backslashEscapes = false)
+
+            '#' -> i = skipToLineEnd(query, i)
+
+            '-' -> i = if (i + 2 < query.length && query[i + 1] == '-' && query[i + 2].isWhitespace()) {
+                skipToLineEnd(query, i)
+            } else if (i + 2 == query.length && query[i + 1] == '-') {
+                query.length
+            } else {
+                i + 1
+            }
+
+            '/' -> i = if (i + 1 < query.length && query[i + 1] == '*') {
+                val end = query.indexOf("*/", i + 2)
+                if (end == -1) query.length else end + 2
+            } else {
+                i + 1
+            }
+
+            else -> i++
+        }
+    }
+    return positions
+}
+
+// Skips a quoted region starting at the opening quote; returns the index just past the closing quote.
+// A doubled quote character is an escaped quote inside the region, not its end. An unterminated region
+// runs to the end of the string.
+private fun skipQuoted(query: String, start: Int, backslashEscapes: Boolean): Int {
+    val quote = query[start]
+    var i = start + 1
+    while (i < query.length) {
+        val c = query[i]
+        when {
+            backslashEscapes && c == '\\' -> i += 2
+            c == quote && i + 1 < query.length && query[i + 1] == quote -> i += 2
+            c == quote -> return i + 1
+            else -> i++
+        }
+    }
+    return query.length
+}
+
+private fun skipToLineEnd(query: String, start: Int): Int {
+    val newline = query.indexOf('\n', start)
+    return if (newline == -1) query.length else newline + 1
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyConnectionLifecycleTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyConnectionLifecycleTest.kt
@@ -251,6 +251,7 @@ class MySqlProxyConnectionLifecycleTest {
                 }
             }
         }
-        proxy.eventService.assertAuditedQueryContains("? + 40")
+        // The bound value is decoded from the execute packet and rendered into the prepared text.
+        proxy.eventService.assertAuditedQueryContains("SELECT 2 + 40")
     }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyFailClosedTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyFailClosedTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.io.ByteArrayOutputStream
 import java.net.ServerSocket
 import java.net.Socket
 import java.net.SocketTimeoutException
@@ -197,6 +198,53 @@ class MySqlProxyFailClosedTest {
         }
     }
 
+    @Test
+    fun `an execute whose parameters cannot be decoded is forwarded and audited with the placeholder text`() {
+        RelayHarness(executionRequestAdapter, eventAdapter).use { harness ->
+            val sql = "INSERT INTO logs (message) VALUES (?)"
+            harness.sendToProxy(mysqlPacket(0, byteArrayOf(0x16) + sql.toByteArray(Charsets.UTF_8)))
+            harness.readPacketForwardedUpstream()
+            harness.sendFromUpstream(prepareOk(sequenceId = 1, stmtId = 7, paramCount = 1))
+            harness.readPacketOnClient()
+
+            // The execute carries an unknown parameter type (0x77): the decoder must abandon
+            // interpolation, audit the placeholder text and still forward the packet -- never block a
+            // legitimate client or splice unverifiable values into the audit log.
+            harness.sendToProxy(comStmtExecuteWithParam(7, typeField = 0x77, value = byteArrayOf(1, 0, 0, 0)))
+            val (_, forwarded) = harness.readPacketForwardedUpstream()
+            assertEquals(0x17, forwarded[0].toInt() and 0xFF)
+            harness.eventService.assertAuditedQueryContains(sql)
+        }
+    }
+
+    @Test
+    fun `a long data mark does not outlive its execute`() {
+        RelayHarness(executionRequestAdapter, eventAdapter).use { harness ->
+            val sql = "INSERT INTO logs (message) VALUES (?)"
+            harness.sendToProxy(mysqlPacket(0, byteArrayOf(0x16) + sql.toByteArray(Charsets.UTF_8)))
+            harness.readPacketForwardedUpstream()
+            harness.sendFromUpstream(prepareOk(sequenceId = 1, stmtId = 7, paramCount = 1))
+            harness.readPacketOnClient()
+
+            // First execute: the parameter's bytes were streamed ahead via COM_STMT_SEND_LONG_DATA, so
+            // the execute packet has no value for it and the audit shows the explicit marker.
+            harness.sendToProxy(mysqlPacket(0, byteArrayOf(0x18, 7, 0, 0, 0, 0, 0) + "streamed".toByteArray()))
+            harness.readPacketForwardedUpstream()
+            harness.sendToProxy(comStmtExecuteWithParam(7, typeField = 0xFD, value = null))
+            harness.readPacketForwardedUpstream()
+            harness.eventService.assertAuditedQueryContains("VALUES (<long data>)")
+
+            // Long data is consumed by that execute. A re-execute with the value inline in the packet
+            // must be decoded normally -- a leaked mark would make the decoder skip the value and degrade
+            // (or worse, misread) the audit entry.
+            harness.sendToProxy(
+                comStmtExecuteWithParam(7, typeField = 0xFD, value = byteArrayOf(3) + "abc".toByteArray()),
+            )
+            harness.readPacketForwardedUpstream()
+            harness.eventService.assertAuditedQueryContains("VALUES ('abc')")
+        }
+    }
+
     private fun comQuery(sql: String): ByteArray = mysqlPacket(0, byteArrayOf(0x03) + sql.toByteArray(Charsets.UTF_8))
 
     private fun comStmtExecute(stmtId: Int): ByteArray = mysqlPacket(
@@ -213,13 +261,34 @@ class MySqlProxyFailClosedTest {
     )
 
     // COM_STMT_PREPARE_OK: 0x00 status + 4-byte stmt id + 2 columns + 2 params + 1 reserved + 2 warnings
-    private fun prepareOk(sequenceId: Int, stmtId: Int): ByteArray {
+    private fun prepareOk(sequenceId: Int, stmtId: Int, paramCount: Int = 0): ByteArray {
         val payload = ByteArray(12)
         payload[1] = (stmtId and 0xFF).toByte()
         payload[2] = ((stmtId ushr 8) and 0xFF).toByte()
         payload[3] = ((stmtId ushr 16) and 0xFF).toByte()
         payload[4] = ((stmtId ushr 24) and 0xFF).toByte()
+        payload[7] = (paramCount and 0xFF).toByte()
+        payload[8] = ((paramCount ushr 8) and 0xFF).toByte()
         return mysqlPacket(sequenceId, payload)
+    }
+
+    // A COM_STMT_EXECUTE for one non-NULL parameter with its type resent; a null value means the value
+    // bytes are absent from the packet (the way a long-data parameter is sent).
+    private fun comStmtExecuteWithParam(stmtId: Int, typeField: Int, value: ByteArray?): ByteArray {
+        val payload = ByteArrayOutputStream()
+        payload.write(0x17)
+        payload.write(stmtId and 0xFF)
+        payload.write((stmtId ushr 8) and 0xFF)
+        payload.write((stmtId ushr 16) and 0xFF)
+        payload.write((stmtId ushr 24) and 0xFF)
+        payload.write(0x00) // flags
+        payload.write(byteArrayOf(0x01, 0x00, 0x00, 0x00)) // iteration count
+        payload.write(0x00) // null bitmap: the one parameter is not NULL
+        payload.write(0x01) // new-params-bound flag
+        payload.write(typeField and 0xFF)
+        payload.write((typeField ushr 8) and 0xFF)
+        value?.let { payload.write(it) }
+        return mysqlPacket(0, payload.toByteArray())
     }
 
     private fun mysqlPacket(sequenceId: Int, payload: ByteArray): ByteArray {

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyQueriesAuditTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyQueriesAuditTest.kt
@@ -330,13 +330,21 @@ class MySqlProxyQueriesAuditTest {
                 }
             }
         }
-        // The statement is prepared once and executed three times; each execute is audited with its own
-        // bound value rendered into the prepared text. This also exercises re-executes that do not resend
-        // parameter types (new-params-bound-flag = 0), where the proxy must use the cached types.
+        // The statement is prepared once and executed three times; each execute is audited exactly once
+        // with its own bound value rendered into the prepared text. This also exercises re-executes that
+        // do not resend parameter types (new-params-bound-flag = 0), where the proxy must use the cached
+        // types.
+        val executes = proxy.eventService.rawQueries.count { it.contains("INSERT INTO audit_reuse") }
+        assertEquals(
+            3,
+            executes,
+            "Each execute of the reused statement must be audited: ${proxy.eventService.rawQueries}",
+        )
         for (value in 1..3) {
-            assertTrue(
-                proxy.eventService.rawQueries.any { it.contains("audit_reuse") && it.contains("VALUES ($value)") },
-                "Execute with value $value must be audited: ${proxy.eventService.rawQueries}",
+            assertEquals(
+                1,
+                proxy.eventService.rawQueries.count { it.contains("audit_reuse") && it.contains("VALUES ($value)") },
+                "Execute with value $value must be audited exactly once: ${proxy.eventService.rawQueries}",
             )
         }
     }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyQueriesAuditTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyQueriesAuditTest.kt
@@ -17,7 +17,6 @@ import dev.kviklet.kviklet.service.dto.DatasourceType
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
@@ -241,8 +240,7 @@ class MySqlProxyQueriesAuditTest {
 
     @ParameterizedTest
     @MethodSource("datasourceTypes")
-    fun `a server side prepare audits the placeholder text and not the bound value`(type: DatasourceType) {
-        // TODO(KVI-220): once parameter interpolation lands, this should audit the bound value (2) as well.
+    fun `a server side prepare audits the interpolated bound value`(type: DatasourceType) {
         val proxy = startProxy(type)
         proxyConnection(type, proxy, extraParams = "&useServerPrepStmts=true").use { conn ->
             conn.prepareStatement("SELECT ? + 40").use { stmt ->
@@ -253,12 +251,28 @@ class MySqlProxyQueriesAuditTest {
                 }
             }
         }
-        proxy.eventService.assertAuditedQueryContains("? + 40")
-        assertFalse(
-            proxy.eventService.rawQueries.any { it.contains("SELECT 2 + 40") },
-            "Server-side prepares must not interpolate the bound value until KVI-220; got: " +
-                "${proxy.eventService.rawQueries}",
-        )
+        // The execute's binary parameter is decoded and rendered into the prepared text.
+        proxy.eventService.assertAuditedQueryContains("SELECT 2 + 40")
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `a server side prepare audits bound values of mixed types`(type: DatasourceType) {
+        val proxy = startProxy(type)
+        proxyConnection(type, proxy, extraParams = "&useServerPrepStmts=true").use { conn ->
+            conn.createStatement().use { it.execute("DROP TABLE IF EXISTS audit_params") }
+            conn.createStatement().use {
+                it.execute("CREATE TABLE audit_params (id INTEGER, name VARCHAR(64), note TEXT)")
+            }
+            conn.prepareStatement("INSERT INTO audit_params (id, name, note) VALUES (?, ?, ?)").use { stmt ->
+                stmt.setInt(1, 5)
+                stmt.setString(2, "o'brien")
+                stmt.setNull(3, java.sql.Types.VARCHAR)
+                stmt.executeUpdate()
+            }
+        }
+        // An integer, a string needing quote escaping, and a NULL, all rendered into the audited text.
+        proxy.eventService.assertAuditedQueryContains("VALUES (5, 'o''brien', NULL)")
     }
 
     @ParameterizedTest
@@ -298,8 +312,8 @@ class MySqlProxyQueriesAuditTest {
                 stmt.executeUpdate()
             }
         }
-        proxy.eventService.assertAuditedQueryContains("INSERT INTO audit_seq (id) VALUES (?)")
-        proxy.eventService.assertAuditedQueryContains("DELETE FROM audit_seq WHERE id = ?")
+        proxy.eventService.assertAuditedQueryContains("INSERT INTO audit_seq (id) VALUES (1)")
+        proxy.eventService.assertAuditedQueryContains("DELETE FROM audit_seq WHERE id = 1")
     }
 
     @ParameterizedTest
@@ -316,15 +330,40 @@ class MySqlProxyQueriesAuditTest {
                 }
             }
         }
-        // The statement is prepared once and executed three times; each execute is audited with the prepared
-        // placeholder text. The "VALUES (?)" signature separates the executes from the DROP/CREATE DDL, which
-        // also mention the table name.
-        val executes = proxy.eventService.rawQueries.count { it.contains("audit_reuse") && it.contains("VALUES (?)") }
-        assertEquals(
-            3,
-            executes,
-            "Each execute of the reused statement must be audited: ${proxy.eventService.rawQueries}",
-        )
+        // The statement is prepared once and executed three times; each execute is audited with its own
+        // bound value rendered into the prepared text. This also exercises re-executes that do not resend
+        // parameter types (new-params-bound-flag = 0), where the proxy must use the cached types.
+        for (value in 1..3) {
+            assertTrue(
+                proxy.eventService.rawQueries.any { it.contains("audit_reuse") && it.contains("VALUES ($value)") },
+                "Execute with value $value must be audited: ${proxy.eventService.rawQueries}",
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `a parameter streamed via send long data is audited as an explicit marker`(type: DatasourceType) {
+        val proxy = startProxy(type)
+        proxyConnection(type, proxy, extraParams = "&useServerPrepStmts=true").use { conn ->
+            conn.createStatement().use { it.execute("DROP TABLE IF EXISTS audit_longdata") }
+            conn.createStatement().use { it.execute("CREATE TABLE audit_longdata (id INTEGER, payload TEXT)") }
+            conn.prepareStatement("INSERT INTO audit_longdata (id, payload) VALUES (?, ?)").use { stmt ->
+                stmt.setInt(1, 1)
+                // A stream parameter makes the driver send its bytes ahead of the execute via
+                // COM_STMT_SEND_LONG_DATA; the proxy does not accumulate them (they can be arbitrarily
+                // large), so the audit shows an explicit marker in that position instead of the value.
+                stmt.setCharacterStream(2, java.io.StringReader("streamed payload"))
+                stmt.executeUpdate()
+            }
+        }
+        directConnection(type).createStatement().use { stmt ->
+            stmt.executeQuery("SELECT payload FROM audit_longdata WHERE id = 1").use { rs ->
+                assertTrue(rs.next())
+                assertEquals("streamed payload", rs.getString(1))
+            }
+        }
+        proxy.eventService.assertAuditedQueryContains("VALUES (1, <long data>)")
     }
 
     @ParameterizedTest

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
@@ -138,6 +138,60 @@ class MySqlProxyUnitTest {
     }
 
     @Test
+    fun `test MySqlClientPacketParser parses COM_STMT_SEND_LONG_DATA successfully`() {
+        var longDataStmtId = 0
+        var longDataParamIndex = -1
+        val parser = MySqlClientPacketParser(
+            onQuery = {},
+            onPrepare = {},
+            onExecute = { _, _ -> },
+            onQuit = {},
+            onLongData = { stmtId, paramIndex ->
+                longDataStmtId = stmtId
+                longDataParamIndex = paramIndex
+            },
+        )
+
+        // cmd + stmt id 7 + param index 3 + payload bytes
+        val packet = mysqlPacket(0, byteArrayOf(0x18, 7, 0, 0, 0, 3, 0) + "chunk".toByteArray(Charsets.UTF_8))
+        parser.addBytes(packet)
+
+        assertEquals(7, longDataStmtId)
+        assertEquals(3, longDataParamIndex)
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser fails closed on a truncated COM_STMT_SEND_LONG_DATA`() {
+        val parser = MySqlClientPacketParser(
+            onQuery = {},
+            onPrepare = {},
+            onExecute = { _, _ -> },
+            onQuit = {},
+        )
+
+        // Too short to carry the statement id and the parameter index
+        val packet = mysqlPacket(0, byteArrayOf(0x18, 7, 0, 0, 0))
+        val exception = assertThrows(FailClosedException::class.java) { parser.addBytes(packet) }
+        assertTrue(exception.message!!.contains("COM_STMT_SEND_LONG_DATA"))
+    }
+
+    @Test
+    fun `test MySqlClientPacketParser parses COM_STMT_RESET successfully`() {
+        var resetStmtId = 0
+        val parser = MySqlClientPacketParser(
+            onQuery = {},
+            onPrepare = {},
+            onExecute = { _, _ -> },
+            onQuit = {},
+            onStmtReset = { resetStmtId = it },
+        )
+
+        parser.addBytes(mysqlPacket(0, byteArrayOf(0x1A, 5, 0, 0, 0)))
+
+        assertEquals(5, resetStmtId)
+    }
+
+    @Test
     fun `test MySqlClientPacketParser parses COM_QUIT successfully`() {
         var quitCalled = false
         val parser = MySqlClientPacketParser(

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyUnitTest.kt
@@ -58,7 +58,7 @@ class MySqlProxyUnitTest {
         val parser = MySqlClientPacketParser(
             onQuery = { parsedQuery = it },
             onPrepare = {},
-            onExecute = {},
+            onExecute = { _, _ -> },
             onQuit = {},
         )
 
@@ -87,7 +87,7 @@ class MySqlProxyUnitTest {
         val parser = MySqlClientPacketParser(
             onQuery = {},
             onPrepare = { parsedQuery = it },
-            onExecute = {},
+            onExecute = { _, _ -> },
             onQuit = {},
         )
 
@@ -115,7 +115,7 @@ class MySqlProxyUnitTest {
         val parser = MySqlClientPacketParser(
             onQuery = {},
             onPrepare = {},
-            onExecute = { executedStmtId = it },
+            onExecute = { stmtId, _ -> executedStmtId = stmtId },
             onQuit = {},
         )
 
@@ -143,7 +143,7 @@ class MySqlProxyUnitTest {
         val parser = MySqlClientPacketParser(
             onQuery = {},
             onPrepare = {},
-            onExecute = {},
+            onExecute = { _, _ -> },
             onQuit = { quitCalled = true },
         )
 
@@ -164,7 +164,11 @@ class MySqlProxyUnitTest {
     @Test
     fun `test MySqlServerPacketParser parses STMT_PREPARE_OK successfully`() {
         var returnedStmtId = 0
-        val parser = MySqlServerPacketParser({ returnedStmtId = it })
+        var returnedParamCount = -1
+        val parser = MySqlServerPacketParser({ stmtId, paramCount ->
+            returnedStmtId = stmtId
+            returnedParamCount = paramCount
+        })
 
         val bos = ByteArrayOutputStream()
         val length = 12 // 1 status + 4 stmt_id + 2 columns + 2 params + 1 filler + 2 warnings
@@ -179,12 +183,18 @@ class MySqlProxyUnitTest {
         bos.write(0)
         bos.write(0)
 
-        // Filler columns, params, warning
-        for (i in 0 until 7) bos.write(0)
+        bos.write(0) // columns (2 bytes)
+        bos.write(0)
+        bos.write(3) // params (2 bytes)
+        bos.write(0)
+        bos.write(0) // filler
+        bos.write(0) // warnings (2 bytes)
+        bos.write(0)
 
         parser.addBytes(bos.toByteArray())
 
         assertEquals(99, returnedStmtId)
+        assertEquals(3, returnedParamCount)
     }
 
     @Test
@@ -193,7 +203,7 @@ class MySqlProxyUnitTest {
         val parser = MySqlClientPacketParser(
             onQuery = { parsedQuery = it },
             onPrepare = {},
-            onExecute = {},
+            onExecute = { _, _ -> },
             onQuit = {},
         )
 
@@ -213,7 +223,7 @@ class MySqlProxyUnitTest {
         val parser = MySqlClientPacketParser(
             onQuery = { parsedQuery = it },
             onPrepare = {},
-            onExecute = {},
+            onExecute = { _, _ -> },
             onQuit = {},
         )
 
@@ -235,7 +245,7 @@ class MySqlProxyUnitTest {
         val parser = MySqlClientPacketParser(
             onQuery = {},
             onPrepare = {},
-            onExecute = {},
+            onExecute = { _, _ -> },
             onQuit = {},
         )
 
@@ -249,7 +259,7 @@ class MySqlProxyUnitTest {
         val parser = MySqlClientPacketParser(
             onQuery = {},
             onPrepare = {},
-            onExecute = {},
+            onExecute = { _, _ -> },
             onQuit = {},
         )
 
@@ -265,7 +275,7 @@ class MySqlProxyUnitTest {
         val parser = MySqlClientPacketParser(
             onQuery = { parsedQuery = it },
             onPrepare = {},
-            onExecute = {},
+            onExecute = { _, _ -> },
             onQuit = {},
         )
 
@@ -279,7 +289,7 @@ class MySqlProxyUnitTest {
         val parser = MySqlClientPacketParser(
             onQuery = {},
             onPrepare = {},
-            onExecute = {},
+            onExecute = { _, _ -> },
             onQuit = {},
         )
 
@@ -292,7 +302,7 @@ class MySqlProxyUnitTest {
     @Test
     fun `test MySqlServerPacketParser streams past an oversized split payload and still parses a prepare-ok`() {
         var returnedStmtId = 0
-        val parser = MySqlServerPacketParser({ returnedStmtId = it })
+        val parser = MySqlServerPacketParser({ stmtId, _ -> returnedStmtId = stmtId })
 
         // A split logical payload (a 0xFFFFFF continuation packet plus a small final packet) is larger than
         // any control packet the server parser inspects, so it must be streamed past without buffering
@@ -307,7 +317,7 @@ class MySqlProxyUnitTest {
     @Test
     fun `test MySqlServerPacketParser streams past a large single packet and still parses a prepare-ok`() {
         var returnedStmtId = 0
-        val parser = MySqlServerPacketParser({ returnedStmtId = it })
+        val parser = MySqlServerPacketParser({ stmtId, _ -> returnedStmtId = stmtId })
 
         // A single result packet larger than the control-packet cap, but not split, is also streamed past
         val bigRow = mysqlPacket(0, ByteArray(5000))

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlStatementInterpolatorTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlStatementInterpolatorTest.kt
@@ -5,14 +5,14 @@ import dev.kviklet.kviklet.proxy.mysql.LONG_DATA_PLACEHOLDER
 import dev.kviklet.kviklet.proxy.mysql.interpolateExecutePayload
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 
 // Unit tests for the COM_STMT_EXECUTE parameter decoder, driving interpolateExecutePayload with
 // hand-built binary payloads. Type codes are the MySQL binary-protocol values (LONG = 0x03,
-// VAR_STRING = 0xFD, ...); 0x8000 on a type is the unsigned flag.
+// VAR_STRING = 0xFD, ...); 0x8000 on a type is the unsigned flag. A null result query means the decoder
+// abandoned interpolation and the relay audits the placeholder text.
 class MySqlStatementInterpolatorTest {
 
     @Test
@@ -29,8 +29,7 @@ class MySqlStatementInterpolatorTest {
             emptySet(),
             payload,
         )
-        assertNotNull(result)
-        assertEquals("INSERT INTO t (a, b) VALUES (42, 'o''brien')", result!!.query)
+        assertEquals("INSERT INTO t (a, b) VALUES (42, 'o''brien')", result.query)
         assertArrayEquals(intArrayOf(0x03, 0xFD), result.paramTypes)
     }
 
@@ -44,7 +43,7 @@ class MySqlStatementInterpolatorTest {
             nullParams = setOf(0),
         )
         val result = interpolateExecutePayload("INSERT INTO t VALUES (?, ?)", 2, null, emptySet(), payload)
-        assertEquals("INSERT INTO t VALUES (NULL, 7)", result!!.query)
+        assertEquals("INSERT INTO t VALUES (NULL, 7)", result.query)
     }
 
     @Test
@@ -61,19 +60,52 @@ class MySqlStatementInterpolatorTest {
             emptySet(),
             payload,
         )
-        assertEquals("UPDATE t SET a = 9", result!!.query)
+        assertEquals("UPDATE t SET a = 9", result.query)
+        assertArrayEquals(intArrayOf(0x03), result.paramTypes)
     }
 
     @Test
     fun `a re-execute without resent types and no cache falls back`() {
         val payload = executePayload(paramCount = 1, types = null, values = listOf(int4(9)))
-        assertNull(interpolateExecutePayload("UPDATE t SET a = ?", 1, null, emptySet(), payload))
+        val result = interpolateExecutePayload("UPDATE t SET a = ?", 1, null, emptySet(), payload)
+        assertNull(result.query)
+        assertNull(result.paramTypes)
+    }
+
+    @Test
+    fun `any non-zero new-params-bound byte means types follow`() {
+        // The server treats the flag as a boolean, so a nonstandard client sending 2 must be parsed the
+        // same way the server parses it, not routed to the cached-types path.
+        val payload = executePayload(
+            paramCount = 1,
+            types = listOf(0x03),
+            values = listOf(int4(6)),
+            newParamsBoundByte = 2,
+        )
+        val result = interpolateExecutePayload("SELECT ?", 1, intArrayOf(0xFD), emptySet(), payload)
+        assertEquals("SELECT 6", result.query)
+        assertArrayEquals(intArrayOf(0x03), result.paramTypes)
     }
 
     @Test
     fun `an unknown parameter type falls back`() {
         val payload = executePayload(paramCount = 1, types = listOf(0x77), values = listOf(int4(1)))
-        assertNull(interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload))
+        assertNull(interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload).query)
+    }
+
+    @Test
+    fun `resent types are reported even when the value decode fails`() {
+        // The server holds the resent types from this execute on, so the caller's cache must be updated
+        // even though nothing was interpolated -- otherwise a later flag=0 execute would be decoded with
+        // the previous types and could render plausible but wrong values.
+        val payload = executePayload(
+            paramCount = 2,
+            types = listOf(0x03, 0x77), // the second type is unknown, so the decode fails
+            values = listOf(int4(1), int4(2)),
+        )
+        val result = interpolateExecutePayload("SELECT ?, ?", 2, intArrayOf(0xFD, 0xFD), emptySet(), payload)
+        assertNull(result.query)
+        assertArrayEquals(intArrayOf(0x03, 0x77), result.paramTypes)
     }
 
     @Test
@@ -83,7 +115,7 @@ class MySqlStatementInterpolatorTest {
             types = listOf(0x03),
             values = listOf(int4(1), byteArrayOf(0x00)), // one stray byte after the value
         )
-        assertNull(interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload))
+        assertNull(interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload).query)
     }
 
     @Test
@@ -93,7 +125,7 @@ class MySqlStatementInterpolatorTest {
             types = listOf(0x08), // LONGLONG needs 8 bytes
             values = listOf(int4(1)),
         )
-        assertNull(interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload))
+        assertNull(interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload).query)
     }
 
     @Test
@@ -101,7 +133,7 @@ class MySqlStatementInterpolatorTest {
         val query = "INSERT INTO t (a, b) VALUES ('?', ?) -- trailing ?\n/* also ? */ # and ?"
         val payload = executePayload(paramCount = 1, types = listOf(0x03), values = listOf(int4(5)))
         val result = interpolateExecutePayload(query, 1, null, emptySet(), payload)
-        assertEquals("INSERT INTO t (a, b) VALUES ('?', 5) -- trailing ?\n/* also ? */ # and ?", result!!.query)
+        assertEquals("INSERT INTO t (a, b) VALUES ('?', 5) -- trailing ?\n/* also ? */ # and ?", result.query)
     }
 
     @Test
@@ -113,7 +145,19 @@ class MySqlStatementInterpolatorTest {
             types = listOf(0x03, 0x03),
             values = listOf(int4(1), int4(2)),
         )
-        assertNull(interpolateExecutePayload("SELECT ? + 1", 2, null, emptySet(), payload))
+        assertNull(interpolateExecutePayload("SELECT ? + 1", 2, null, emptySet(), payload).query)
+    }
+
+    @Test
+    fun `a statement whose placeholders depend on the backslash mode falls back`() {
+        // Under the default sql_mode the literal is '\', ?, ' (one placeholder inside it); under
+        // NO_BACKSLASH_ESCAPES the literal is '\' and the ? after it is bare. The proxy cannot see the
+        // session's sql_mode, so a text the two readings disagree on must not be interpolated.
+        val query = "SELECT ?, '\\', ?'"
+        val payload = executePayload(paramCount = 1, types = listOf(0x03), values = listOf(int4(1)))
+        val result = interpolateExecutePayload(query, 1, null, emptySet(), payload)
+        assertNull(result.query)
+        assertArrayEquals(intArrayOf(0x03), result.paramTypes)
     }
 
     @Test
@@ -130,18 +174,23 @@ class MySqlStatementInterpolatorTest {
             setOf(0),
             payload,
         )
-        assertEquals("INSERT INTO t (blob_col, id) VALUES ($LONG_DATA_PLACEHOLDER, 3)", result!!.query)
+        assertEquals("INSERT INTO t (blob_col, id) VALUES ($LONG_DATA_PLACEHOLDER, 3)", result.query)
     }
 
     @Test
-    fun `an unsigned longlong renders its unsigned value`() {
+    fun `unsigned integers render their unsigned values`() {
         val payload = executePayload(
-            paramCount = 1,
-            types = listOf(0x8008), // LONGLONG with the unsigned flag
-            values = listOf(int8(-1L)),
+            paramCount = 4,
+            types = listOf(0x8001, 0x8002, 0x8003, 0x8008), // unsigned TINY, SHORT, LONG, LONGLONG
+            values = listOf(
+                byteArrayOf(0xFF.toByte()),
+                byteArrayOf(0xFF.toByte(), 0xFF.toByte()),
+                int4(-1),
+                int8(-1L),
+            ),
         )
-        val result = interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload)
-        assertEquals("SELECT 18446744073709551615", result!!.query)
+        val result = interpolateExecutePayload("SELECT ?, ?, ?, ?", 4, null, emptySet(), payload)
+        assertEquals("SELECT 255, 65535, 4294967295, 18446744073709551615", result.query)
     }
 
     @Test
@@ -154,7 +203,36 @@ class MySqlStatementInterpolatorTest {
             values = listOf(datetime, date),
         )
         val result = interpolateExecutePayload("SELECT ?, ?", 2, null, emptySet(), payload)
-        assertEquals("SELECT '2025-08-30 12:34:56', '2025-01-02'", result!!.query)
+        assertEquals("SELECT '2025-08-30 12:34:56', '2025-01-02'", result.query)
+    }
+
+    @Test
+    fun `time parameters render sign days and microseconds`() {
+        // length 8: negative, 1 day + 2:03:04 -> -26:03:04; length 12 adds microseconds
+        val negativeTime = byteArrayOf(8, 1) + int4(1) + byteArrayOf(2, 3, 4)
+        val microTime = byteArrayOf(12, 0) + int4(0) + byteArrayOf(5, 6, 7) + int4(1500)
+        val payload = executePayload(
+            paramCount = 2,
+            types = listOf(0x0B, 0x0B), // TIME
+            values = listOf(negativeTime, microTime),
+        )
+        val result = interpolateExecutePayload("SELECT ?, ?", 2, null, emptySet(), payload)
+        assertEquals("SELECT '-26:03:04', '05:06:07.001500'", result.query)
+    }
+
+    @Test
+    fun `a string longer than 250 bytes uses the two-byte length encoding`() {
+        val text = "x".repeat(300)
+        val payload = executePayload(
+            paramCount = 1,
+            types = listOf(0xFD),
+            values = listOf(
+                byteArrayOf(0xFC.toByte(), (300 and 0xFF).toByte(), (300 ushr 8).toByte()) +
+                    text.toByteArray(Charsets.UTF_8),
+            ),
+        )
+        val result = interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload)
+        assertEquals("SELECT '$text'", result.query)
     }
 
     @Test
@@ -165,7 +243,7 @@ class MySqlStatementInterpolatorTest {
             values = listOf(lenenc(byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte()))),
         )
         val result = interpolateExecutePayload("INSERT INTO t VALUES (?)", 1, null, emptySet(), payload)
-        assertEquals("INSERT INTO t VALUES (0xdeadbeef)", result!!.query)
+        assertEquals("INSERT INTO t VALUES (0xdeadbeef)", result.query)
     }
 
     @Test
@@ -176,25 +254,26 @@ class MySqlStatementInterpolatorTest {
             values = listOf(lenenc("""C:\temp""")),
         )
         val result = interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload)
-        assertEquals("""SELECT 'C:\\temp'""", result!!.query)
+        assertEquals("""SELECT 'C:\\temp'""", result.query)
     }
 
     @Test
     fun `a statement without parameters is returned unchanged`() {
         val result = interpolateExecutePayload("SELECT 1", 0, null, emptySet(), executePayload(0, null, emptyList()))
-        assertEquals("SELECT 1", result!!.query)
+        assertEquals("SELECT 1", result.query)
     }
 
     // --- payload builders -------------------------------------------------------------------------------
 
     // One COM_STMT_EXECUTE payload: cmd + stmt id + flags + iteration count, then (with parameters) the
-    // null bitmap, the new-params-bound flag (1 when types are given, 0 otherwise), the type array and
-    // the value bytes.
+    // null bitmap, the new-params-bound flag (1 when types are given, 0 otherwise, unless overridden), the
+    // type array and the value bytes.
     private fun executePayload(
         paramCount: Int,
         types: List<Int>?,
         values: List<ByteArray>,
         nullParams: Set<Int> = emptySet(),
+        newParamsBoundByte: Int? = null,
     ): ByteArray {
         val bos = ByteArrayOutputStream()
         bos.write(0x17)
@@ -205,7 +284,7 @@ class MySqlStatementInterpolatorTest {
             val bitmap = ByteArray((paramCount + 7) / 8)
             for (p in nullParams) bitmap[p / 8] = (bitmap[p / 8].toInt() or (1 shl (p % 8))).toByte()
             bos.write(bitmap)
-            bos.write(if (types != null) 1 else 0)
+            bos.write(newParamsBoundByte ?: if (types != null) 1 else 0)
             types?.forEach { type ->
                 bos.write(type and 0xFF)
                 bos.write((type ushr 8) and 0xFF)

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlStatementInterpolatorTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlStatementInterpolatorTest.kt
@@ -1,0 +1,228 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.proxy.mysql.LONG_DATA_PLACEHOLDER
+import dev.kviklet.kviklet.proxy.mysql.interpolateExecutePayload
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+
+// Unit tests for the COM_STMT_EXECUTE parameter decoder, driving interpolateExecutePayload with
+// hand-built binary payloads. Type codes are the MySQL binary-protocol values (LONG = 0x03,
+// VAR_STRING = 0xFD, ...); 0x8000 on a type is the unsigned flag.
+class MySqlStatementInterpolatorTest {
+
+    @Test
+    fun `interpolates integer and string parameters`() {
+        val payload = executePayload(
+            paramCount = 2,
+            types = listOf(0x03, 0xFD), // LONG, VAR_STRING
+            values = listOf(int4(42), lenenc("o'brien")),
+        )
+        val result = interpolateExecutePayload(
+            "INSERT INTO t (a, b) VALUES (?, ?)",
+            2,
+            null,
+            emptySet(),
+            payload,
+        )
+        assertNotNull(result)
+        assertEquals("INSERT INTO t (a, b) VALUES (42, 'o''brien')", result!!.query)
+        assertArrayEquals(intArrayOf(0x03, 0xFD), result.paramTypes)
+    }
+
+    @Test
+    fun `renders a NULL parameter from the null bitmap`() {
+        // The NULL parameter has a type entry but no value bytes.
+        val payload = executePayload(
+            paramCount = 2,
+            types = listOf(0xFD, 0x03),
+            values = listOf(int4(7)),
+            nullParams = setOf(0),
+        )
+        val result = interpolateExecutePayload("INSERT INTO t VALUES (?, ?)", 2, null, emptySet(), payload)
+        assertEquals("INSERT INTO t VALUES (NULL, 7)", result!!.query)
+    }
+
+    @Test
+    fun `a re-execute without resent types uses the cached types`() {
+        val payload = executePayload(
+            paramCount = 1,
+            types = null, // new-params-bound-flag = 0
+            values = listOf(int4(9)),
+        )
+        val result = interpolateExecutePayload(
+            "UPDATE t SET a = ?",
+            1,
+            intArrayOf(0x03),
+            emptySet(),
+            payload,
+        )
+        assertEquals("UPDATE t SET a = 9", result!!.query)
+    }
+
+    @Test
+    fun `a re-execute without resent types and no cache falls back`() {
+        val payload = executePayload(paramCount = 1, types = null, values = listOf(int4(9)))
+        assertNull(interpolateExecutePayload("UPDATE t SET a = ?", 1, null, emptySet(), payload))
+    }
+
+    @Test
+    fun `an unknown parameter type falls back`() {
+        val payload = executePayload(paramCount = 1, types = listOf(0x77), values = listOf(int4(1)))
+        assertNull(interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload))
+    }
+
+    @Test
+    fun `leftover undecoded bytes fall back`() {
+        val payload = executePayload(
+            paramCount = 1,
+            types = listOf(0x03),
+            values = listOf(int4(1), byteArrayOf(0x00)), // one stray byte after the value
+        )
+        assertNull(interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload))
+    }
+
+    @Test
+    fun `a truncated value falls back`() {
+        val payload = executePayload(
+            paramCount = 1,
+            types = listOf(0x08), // LONGLONG needs 8 bytes
+            values = listOf(int4(1)),
+        )
+        assertNull(interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload))
+    }
+
+    @Test
+    fun `placeholders inside literals and comments are not replaced`() {
+        val query = "INSERT INTO t (a, b) VALUES ('?', ?) -- trailing ?\n/* also ? */ # and ?"
+        val payload = executePayload(paramCount = 1, types = listOf(0x03), values = listOf(int4(5)))
+        val result = interpolateExecutePayload(query, 1, null, emptySet(), payload)
+        assertEquals("INSERT INTO t (a, b) VALUES ('?', 5) -- trailing ?\n/* also ? */ # and ?", result!!.query)
+    }
+
+    @Test
+    fun `a placeholder count mismatch falls back`() {
+        // The server says two parameters but the text only has one bare placeholder: the scan cannot be
+        // trusted to splice values into the right places.
+        val payload = executePayload(
+            paramCount = 2,
+            types = listOf(0x03, 0x03),
+            values = listOf(int4(1), int4(2)),
+        )
+        assertNull(interpolateExecutePayload("SELECT ? + 1", 2, null, emptySet(), payload))
+    }
+
+    @Test
+    fun `a long data parameter renders as a marker and its value is not expected in the payload`() {
+        val payload = executePayload(
+            paramCount = 2,
+            types = listOf(0xFB, 0x03), // LONG_BLOB, LONG
+            values = listOf(int4(3)), // only the second parameter has value bytes
+        )
+        val result = interpolateExecutePayload(
+            "INSERT INTO t (blob_col, id) VALUES (?, ?)",
+            2,
+            null,
+            setOf(0),
+            payload,
+        )
+        assertEquals("INSERT INTO t (blob_col, id) VALUES ($LONG_DATA_PLACEHOLDER, 3)", result!!.query)
+    }
+
+    @Test
+    fun `an unsigned longlong renders its unsigned value`() {
+        val payload = executePayload(
+            paramCount = 1,
+            types = listOf(0x8008), // LONGLONG with the unsigned flag
+            values = listOf(int8(-1L)),
+        )
+        val result = interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload)
+        assertEquals("SELECT 18446744073709551615", result!!.query)
+    }
+
+    @Test
+    fun `datetime and date parameters render as quoted literals`() {
+        val datetime = byteArrayOf(7, 0xE9.toByte(), 0x07, 8, 30, 12, 34, 56) // 2025-08-30 12:34:56
+        val date = byteArrayOf(4, 0xE9.toByte(), 0x07, 1, 2) // 2025-01-02
+        val payload = executePayload(
+            paramCount = 2,
+            types = listOf(0x0C, 0x0A), // DATETIME, DATE
+            values = listOf(datetime, date),
+        )
+        val result = interpolateExecutePayload("SELECT ?, ?", 2, null, emptySet(), payload)
+        assertEquals("SELECT '2025-08-30 12:34:56', '2025-01-02'", result!!.query)
+    }
+
+    @Test
+    fun `bytes that are not valid UTF-8 render as a hex literal`() {
+        val payload = executePayload(
+            paramCount = 1,
+            types = listOf(0xFC), // BLOB
+            values = listOf(lenenc(byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte()))),
+        )
+        val result = interpolateExecutePayload("INSERT INTO t VALUES (?)", 1, null, emptySet(), payload)
+        assertEquals("INSERT INTO t VALUES (0xdeadbeef)", result!!.query)
+    }
+
+    @Test
+    fun `backslashes in a string value are escaped`() {
+        val payload = executePayload(
+            paramCount = 1,
+            types = listOf(0xFD),
+            values = listOf(lenenc("""C:\temp""")),
+        )
+        val result = interpolateExecutePayload("SELECT ?", 1, null, emptySet(), payload)
+        assertEquals("""SELECT 'C:\\temp'""", result!!.query)
+    }
+
+    @Test
+    fun `a statement without parameters is returned unchanged`() {
+        val result = interpolateExecutePayload("SELECT 1", 0, null, emptySet(), executePayload(0, null, emptyList()))
+        assertEquals("SELECT 1", result!!.query)
+    }
+
+    // --- payload builders -------------------------------------------------------------------------------
+
+    // One COM_STMT_EXECUTE payload: cmd + stmt id + flags + iteration count, then (with parameters) the
+    // null bitmap, the new-params-bound flag (1 when types are given, 0 otherwise), the type array and
+    // the value bytes.
+    private fun executePayload(
+        paramCount: Int,
+        types: List<Int>?,
+        values: List<ByteArray>,
+        nullParams: Set<Int> = emptySet(),
+    ): ByteArray {
+        val bos = ByteArrayOutputStream()
+        bos.write(0x17)
+        bos.write(byteArrayOf(1, 0, 0, 0)) // statement id
+        bos.write(0) // flags
+        bos.write(byteArrayOf(1, 0, 0, 0)) // iteration count
+        if (paramCount > 0) {
+            val bitmap = ByteArray((paramCount + 7) / 8)
+            for (p in nullParams) bitmap[p / 8] = (bitmap[p / 8].toInt() or (1 shl (p % 8))).toByte()
+            bos.write(bitmap)
+            bos.write(if (types != null) 1 else 0)
+            types?.forEach { type ->
+                bos.write(type and 0xFF)
+                bos.write((type ushr 8) and 0xFF)
+            }
+            values.forEach { bos.write(it) }
+        }
+        return bos.toByteArray()
+    }
+
+    private fun int4(value: Int): ByteArray = ByteArray(4) { ((value ushr (it * 8)) and 0xFF).toByte() }
+
+    private fun int8(value: Long): ByteArray = ByteArray(8) { ((value ushr (it * 8)) and 0xFF).toByte() }
+
+    private fun lenenc(value: String): ByteArray = lenenc(value.toByteArray(Charsets.UTF_8))
+
+    private fun lenenc(bytes: ByteArray): ByteArray {
+        check(bytes.size < 0xFB) { "test helper only builds one-byte length encodings" }
+        return byteArrayOf(bytes.size.toByte()) + bytes
+    }
+}


### PR DESCRIPTION
Prepared-statement executes through the MySQL/MariaDB proxy were audited with their placeholder text (`INSERT ... VALUES (?)`), so the audit log never showed the values a session actually wrote. This decodes the `COM_STMT_EXECUTE` binary parameter section and renders the bound values into the audited statement text, giving the MySQL proxy the same audit fidelity as the Postgres proxy's `interpolateQuery`.

How it works:

- The prepare-ok's parameter count (previously discarded) is now tracked per statement id, and the execute's type array is cached per statement so re-executes that set `new-params-bound-flag = 0` (which do not resend types) still decode.
- The decoder handles the types drivers actually send: fixed-width integers (signed and unsigned), FLOAT/DOUBLE, length-encoded strings/decimals/blobs (with quote and backslash escaping; non-UTF-8 bytes render as a hex literal), packed DATE/DATETIME/TIMESTAMP/TIME, and NULLs via the null bitmap.
- Placeholder replacement scans the statement text the way the MySQL parser reads it, so a `?` inside a string literal, quoted identifier or comment is never mistaken for a parameter.
- Interpolation is audit-only and all-or-nothing: anything the decoder cannot fully account for (an unknown type, a layout mismatch, leftover bytes, a placeholder-count disagreement) falls back to auditing the placeholder text instead of logging a possibly wrong value or blocking the client.
- Parameters streamed ahead of the execute via `COM_STMT_SEND_LONG_DATA` are not accumulated (they can be arbitrarily large blobs) and render as an explicit `<long data>` marker; `COM_STMT_RESET` drops those marks the way the server drops the data.