### PR TITLE
Gate the database proxy behind an enterprise license and a settings toggle

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ Kviklet ships with a variety of features that an engineering team needs to manag
 - **Single Query**: Execute a singular statement. Allows the reviewer to review your query before execution.
 - **Auditlog**: Singular plane that logs all executed statements with Author, reason for execution etc.
 - **RBAC**: Configure which team has access to which database/table to as fine of a granularity as the DB Engine allows.
-- **Postgres Proxy**: Start a proxy server to use the DB Client of your choice, but everything will be stored in the Kviklet Auditlog.
+- **Postgres Proxy**: Start a proxy server to use the DB Client of your choice, but everything will be stored in the Kviklet Auditlog. (Enterprise only)
 - **Kubernetes Exec**: Execute a statement on a pod in your kubernetes cluster. (Currently only supports Execution of a single command no live session yet)
 - **Role-Based Review Gates**: Require approvals from specific roles before execution. (Enterprise only)
 - **Role Sync**: Automatically sync user roles from your identity provider groups. (Enterprise only)
@@ -591,6 +591,7 @@ Kubernetes commands only wait for 5 seconds for output if the command takes long
 ### Proxy, Postgres only
 
 If you create requests for temporary access, you can - instead of using the web interface - run your queries through a kviklet managed proxy and use the DB client of your choice.
+The proxy is an enterprise feature: it requires a valid license, and an admin additionally has to switch it on under Settings -> General -> Database Proxy (no restart needed).
 For this the container listens on a single stable port (5432 by default, configurable via `kviklet.proxy.postgres.port`), so you need to expose that one port.
 The user can then create a temporary access request, and click "Start Proxy" once it has been approved. Each request gets a temporary username and password on that shared port; Kviklet routes each connection to its request by the username. With these they can connect to the database. Kviklet validates the temp user and password and proxies all requests to the underlying user on the database. Any executed statements are logged in the auditlog as if they were run via the web interface.
 Note that the message parsing on the proxy side hasn't been tested with all clients, so if you run into issues with e.g. statements not being logged feel free to open an issue.

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConfigController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ConfigController.kt
@@ -31,12 +31,16 @@ open class PublicConfigResponse(
     open val validUntil: LocalDate?,
     open val createdAt: LocalDateTime?,
     open val allowedUsers: UInt?,
+    // Public (like licenseValid) because the review page needs it for every user, to decide
+    // whether the proxy action is live, grayed out, or shown as an enterprise upsell.
+    open val proxyEnabled: Boolean,
     open val version: String,
     open val buildDate: String,
     open val gitCommit: String,
 )
 
-data class ConfigRequest(val teamsUrl: String?, val slackUrl: String?)
+// Null fields mean "leave unchanged", so a partial update never wipes the other settings.
+data class ConfigRequest(val teamsUrl: String?, val slackUrl: String?, val proxyEnabled: Boolean? = null)
 
 data class ConfigResponse(
     override val oAuthProvider: String?,
@@ -46,6 +50,7 @@ data class ConfigResponse(
     override val validUntil: LocalDate?,
     override val createdAt: LocalDateTime?,
     override val allowedUsers: UInt?,
+    override val proxyEnabled: Boolean,
     override val version: String,
     override val buildDate: String,
     override val gitCommit: String,
@@ -59,6 +64,7 @@ data class ConfigResponse(
     validUntil,
     createdAt,
     allowedUsers,
+    proxyEnabled,
     version,
     buildDate,
     gitCommit,
@@ -83,6 +89,7 @@ data class ConfigResponse(
                 validUntil = licensesSorted.firstOrNull()?.validUntil,
                 createdAt = licensesSorted.firstOrNull()?.createdAt,
                 allowedUsers = licensesSorted.firstOrNull()?.allowedUsers,
+                proxyEnabled = configuration.proxyEnabled ?: false,
                 version = version,
                 buildDate = buildDate,
                 gitCommit = gitCommit,
@@ -134,6 +141,7 @@ class ConfigController(
                 validUntil = licensesSorted.firstOrNull()?.validUntil,
                 createdAt = licensesSorted.firstOrNull()?.createdAt,
                 allowedUsers = licensesSorted.firstOrNull()?.allowedUsers,
+                proxyEnabled = configService.isProxyEnabled(),
                 version = applicationProperties.version,
                 buildDate = applicationProperties.buildDate,
                 gitCommit = applicationProperties.gitCommit,
@@ -148,6 +156,7 @@ class ConfigController(
             Configuration(
                 teamsUrl = request.teamsUrl,
                 slackUrl = request.slackUrl,
+                proxyEnabled = request.proxyEnabled,
             ),
         )
         return ConfigResponse.fromConfiguration(

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/controller/ExecutionRequestController.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import dev.kviklet.kviklet.security.CurrentUser
+import dev.kviklet.kviklet.security.EnterpriseOnly
 import dev.kviklet.kviklet.security.UserDetailsWithId
 import dev.kviklet.kviklet.security.toPermissionStrings
 import dev.kviklet.kviklet.service.ColumnInfo
@@ -805,6 +806,7 @@ class ExecutionRequestController(val executionRequestService: ExecutionRequestSe
         description = "Start the Kviklet proxy for a temp access request. Only works for postgresql.",
     )
     @PostMapping("/{executionRequestId}/proxy")
+    @EnterpriseOnly(feature = "Database Proxy")
     fun proxy(
         @PathVariable executionRequestId: ExecutionRequestId,
         @CurrentUser userDetails: UserDetailsWithId,

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/db/Configuration.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/db/Configuration.kt
@@ -32,17 +32,21 @@ class ConfigurationAdapter(private val configurationRepository: ConfigurationRep
     fun getConfiguration(): Configuration = configurationRepository.findAll().toDto()
 
     fun setConfiguration(configuration: Configuration): Configuration {
-        val configurationEntities = configurationRepository.saveAll(
+        configurationRepository.saveAll(
             listOfNotNull(
                 configuration.teamsUrl?.let { ConfigurationEntity("teamsUrl", it) },
                 configuration.slackUrl?.let { ConfigurationEntity("slackUrl", it) },
+                configuration.proxyEnabled?.let { ConfigurationEntity("proxyEnabled", it.toString()) },
             ),
         )
-        return configurationEntities.toDto()
+        // Null fields mean "leave unchanged", so the saved entities alone are not the full picture:
+        // re-read everything so a partial update still returns the complete stored configuration.
+        return getConfiguration()
     }
 }
 
 fun List<ConfigurationEntity>.toDto(): Configuration = Configuration(
     teamsUrl = this.find { it.key == "teamsUrl" }?.value,
     slackUrl = this.find { it.key == "slackUrl" }?.value,
+    proxyEnabled = this.find { it.key == "proxyEnabled" }?.value?.toBoolean(),
 )

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ConfigService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ConfigService.kt
@@ -1,6 +1,7 @@
 package dev.kviklet.kviklet.service
 
 import dev.kviklet.kviklet.db.ConfigurationAdapter
+import dev.kviklet.kviklet.security.NoPolicy
 import dev.kviklet.kviklet.security.Permission
 import dev.kviklet.kviklet.security.Policy
 import dev.kviklet.kviklet.service.dto.Configuration
@@ -8,7 +9,10 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-class ConfigService(private val configurationAdapter: ConfigurationAdapter) {
+class ConfigService(
+    private val configurationAdapter: ConfigurationAdapter,
+    private val licenseService: LicenseService,
+) {
 
     @Policy(Permission.CONFIGURATION_GET)
     @Transactional(readOnly = true)
@@ -16,6 +20,22 @@ class ConfigService(private val configurationAdapter: ConfigurationAdapter) {
 
     @Policy(Permission.CONFIGURATION_EDIT)
     @Transactional
-    fun setConfiguration(configuration: Configuration): Configuration =
-        configurationAdapter.setConfiguration(configuration)
+    fun setConfiguration(configuration: Configuration): Configuration {
+        // Turning the proxy on is enterprise-only. Only the false->true transition is gated, so a
+        // config save that merely re-sends an already-enabled flag (or turns it off) still works
+        // after a license expires.
+        if (configuration.proxyEnabled == true &&
+            configurationAdapter.getConfiguration("proxyEnabled") != "true" &&
+            licenseService.getActiveLicense() == null
+        ) {
+            throw LicenseRestrictionException("Enabling the database proxy requires a valid enterprise license")
+        }
+        return configurationAdapter.setConfiguration(configuration)
+    }
+
+    // Read by the review page (and the proxy gate) for every user, so no permission is required:
+    // like the license-validity flag it only reveals whether the feature is switched on.
+    @NoPolicy
+    @Transactional(readOnly = true)
+    fun isProxyEnabled(): Boolean = configurationAdapter.getConfiguration("proxyEnabled") == "true"
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/ExecutionRequestService.kt
@@ -15,6 +15,7 @@ import dev.kviklet.kviklet.db.UserAdapter
 import dev.kviklet.kviklet.proxy.core.ProxyServer
 import dev.kviklet.kviklet.proxy.core.ProxySession
 import dev.kviklet.kviklet.proxy.core.getShutdownDate
+import dev.kviklet.kviklet.security.EnterpriseFeatureException
 import dev.kviklet.kviklet.security.Permission
 import dev.kviklet.kviklet.security.PermissionResolver
 import dev.kviklet.kviklet.security.Policy
@@ -83,6 +84,8 @@ class ExecutionRequestService(
     private val dryRunValidator: DryRunValidator,
     private val roleAdapter: dev.kviklet.kviklet.db.RoleAdapter,
     private val permissionResolver: PermissionResolver,
+    private val licenseService: LicenseService,
+    private val configService: ConfigService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -947,6 +950,17 @@ class ExecutionRequestService(
     @Transactional
     @Policy(Permission.EXECUTION_REQUEST_EXECUTE)
     fun proxy(executionRequestId: ExecutionRequestId, userDetails: UserDetailsWithId): ExecutionProxy {
+        // Defense in depth with the controller's @EnterpriseOnly: the proxy is an enterprise feature,
+        // and additionally has to be switched on in the general settings. Both are runtime state
+        // (license upload and the settings toggle), so a fresh license works without a restart.
+        if (licenseService.getActiveLicense() == null) {
+            throw EnterpriseFeatureException("The database proxy requires a valid enterprise license")
+        }
+        if (!configService.isProxyEnabled()) {
+            throw IllegalArgumentException(
+                "The database proxy is disabled. An admin can enable it in the general settings.",
+            )
+        }
         val executionRequest = executionRequestAdapter.getExecutionRequestDetails(executionRequestId)
         val connection = executionRequest.request.connection
         if (connection !is DatasourceConnection) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/Configuration.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/service/dto/Configuration.kt
@@ -3,7 +3,8 @@ package dev.kviklet.kviklet.service.dto
 import dev.kviklet.kviklet.security.Resource
 import dev.kviklet.kviklet.security.SecuredDomainObject
 
-data class Configuration(val teamsUrl: String?, val slackUrl: String?) : SecuredDomainObject {
+data class Configuration(val teamsUrl: String?, val slackUrl: String?, val proxyEnabled: Boolean? = null) :
+    SecuredDomainObject {
     override fun getSecuredObjectId(): String? = "configuration"
 
     override fun getDomainObjectType(): Resource = Resource.CONFIGURATION

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ConfigurationTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ConfigurationTest.kt
@@ -21,6 +21,7 @@ class ConfigurationTest {
             Configuration(
                 teamsUrl = "",
                 slackUrl = "",
+                proxyEnabled = false,
             ),
         )
     }
@@ -31,6 +32,7 @@ class ConfigurationTest {
         val configuration = Configuration(
             teamsUrl = "https://teams.com",
             slackUrl = "https://slack.com",
+            proxyEnabled = true,
         )
 
         val savedConfiguration = configurationAdapter.setConfiguration(configuration)
@@ -55,5 +57,22 @@ class ConfigurationTest {
 
         assert(savedConfiguration.teamsUrl == longUrl)
         assert(loadedConfiguration.teamsUrl == longUrl)
+    }
+
+    @Test
+    fun `partial update leaves other keys unchanged and returns the full configuration`() {
+        configurationAdapter.setConfiguration(
+            Configuration(teamsUrl = "https://teams.com", slackUrl = "https://slack.com"),
+        )
+
+        // Null fields mean "leave unchanged"; the returned configuration must still be complete.
+        val savedConfiguration = configurationAdapter.setConfiguration(
+            Configuration(teamsUrl = null, slackUrl = null, proxyEnabled = true),
+        )
+
+        assert(savedConfiguration.teamsUrl == "https://teams.com")
+        assert(savedConfiguration.slackUrl == "https://slack.com")
+        assert(savedConfiguration.proxyEnabled == true)
+        assert(configurationAdapter.getConfiguration().proxyEnabled == true)
     }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/ProxyGateTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/ProxyGateTest.kt
@@ -1,0 +1,217 @@
+package dev.kviklet.kviklet
+
+import dev.kviklet.kviklet.db.ConfigurationAdapter
+import dev.kviklet.kviklet.db.LicenseAdapter
+import dev.kviklet.kviklet.db.User
+import dev.kviklet.kviklet.helper.ConnectionHelper
+import dev.kviklet.kviklet.helper.ExecutionRequestHelper
+import dev.kviklet.kviklet.helper.RoleHelper
+import dev.kviklet.kviklet.helper.UserHelper
+import dev.kviklet.kviklet.service.dto.Configuration
+import dev.kviklet.kviklet.service.dto.LicenseFile
+import dev.kviklet.kviklet.service.dto.RequestType
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+import java.time.LocalDateTime
+
+/**
+ * The database proxy is enterprise-only and additionally gated behind the proxyEnabled
+ * configuration toggle. These tests cover both gates on the proxy endpoint and the
+ * license rules around flipping the toggle itself.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ProxyGateTest {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+
+    @Autowired private lateinit var userHelper: UserHelper
+
+    @Autowired private lateinit var roleHelper: RoleHelper
+
+    @Autowired private lateinit var connectionHelper: ConnectionHelper
+
+    @Autowired private lateinit var executionRequestHelper: ExecutionRequestHelper
+
+    @Autowired private lateinit var licenseAdapter: LicenseAdapter
+
+    @Autowired private lateinit var configurationAdapter: ConfigurationAdapter
+
+    private lateinit var adminUser: User
+    private lateinit var reviewerUser: User
+
+    companion object {
+        val db: PostgreSQLContainer<*> = PostgreSQLContainer(DockerImageName.parse("postgres:11.1"))
+            .withUsername("root")
+            .withPassword("root")
+            .withReuse(true)
+            .withDatabaseName("test_db")
+
+        init {
+            db.start()
+        }
+    }
+
+    @BeforeEach
+    fun setup() {
+        // The test license allows only 2 users, so create both before any test installs it.
+        adminUser = userHelper.createUser(permissions = listOf("*"))
+        reviewerUser = userHelper.createUser(permissions = listOf("execution_request:get"))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        executionRequestHelper.deleteAll()
+        connectionHelper.deleteAll()
+        userHelper.deleteAll()
+        roleHelper.deleteAll()
+        licenseAdapter.deleteAll()
+        configurationAdapter.setConfiguration(Configuration(teamsUrl = "", slackUrl = "", proxyEnabled = false))
+    }
+
+    private fun installTestLicense() {
+        // Same signed test license as in SAMLTest / ApiKeyIntegrationTest.
+        val licenseJson = """
+            {
+                "license_data":{"max_users":2,"expiry_date":"2100-01-01","test_license":true},
+                "signature":"E3cqrsVzWccsyWwIeCE2J4Mn/eHyP8j4T05Q4o2dtXH1lhum71rEyPqv9MLn//IcVGsLBY6MwWJGxxa+IBqZTvx0fkLix7e44BRJ5xnV83WzZbKyacNCsNqYEbNpeRcDmtC0pbk7/OSff8VDs5xdqWl7zsI+HA5KNdw878BZKVxusHkHhLtxOhHtbm7Gvcyia4XE86USTWUMYf6aCgNkQgRSOnTo5Zrs+vBUvgSI33l3XyBDx+cQcr9Mell2ytOYrTxQ4zUbRkzcsQtGRTHbh8uXQb5wS389F0zQWSLh7RrCRuaEZ0IDTt8tFkN+72fZ64504bsSR9mNgkgKTv/FvQiVCppKO8vpW0T0hg2xziXMnNSJ3MbihcNlpFsz9C2SEnGm18rQ4UagnLCWTqhz5DtWCxeaAExIT261o6J/wBwlsHHMJRiDaLo/cQOLVOUm43psOt4nlTdbijPoKhBejBuSgqSxTid1R7+8YaFlco/SaprzEspWHcOcVIPUN2jk"
+            }
+        """.trimIndent()
+        licenseAdapter.createLicense(
+            LicenseFile(
+                fileContent = licenseJson,
+                fileName = "test-license.json",
+                createdAt = LocalDateTime.now(),
+            ),
+        )
+    }
+
+    private fun createApprovedTempAccessRequest() = executionRequestHelper.createApprovedRequest(
+        dbcontainer = db,
+        author = adminUser,
+        approver = reviewerUser,
+        requestType = RequestType.TemporaryAccess,
+    )
+
+    @Test
+    fun `starting the proxy without a license returns 402`() {
+        configurationAdapter.setConfiguration(Configuration(teamsUrl = null, slackUrl = null, proxyEnabled = true))
+        val request = createApprovedTempAccessRequest()
+        val cookie = userHelper.login(email = adminUser.email, mockMvc = mockMvc)
+
+        mockMvc.perform(post("/execution-requests/${request.getId()}/proxy").cookie(cookie))
+            .andExpect(status().isPaymentRequired)
+    }
+
+    @Test
+    fun `starting the proxy with a license but the toggle off returns 400`() {
+        installTestLicense()
+        val request = createApprovedTempAccessRequest()
+        val cookie = userHelper.login(email = adminUser.email, mockMvc = mockMvc)
+
+        mockMvc.perform(post("/execution-requests/${request.getId()}/proxy").cookie(cookie))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message", containsString("disabled")))
+    }
+
+    @Test
+    fun `starting the proxy with a license and the toggle on passes both gates`() {
+        installTestLicense()
+        configurationAdapter.setConfiguration(Configuration(teamsUrl = null, slackUrl = null, proxyEnabled = true))
+        val request = createApprovedTempAccessRequest()
+        val cookie = userHelper.login(email = adminUser.email, mockMvc = mockMvc)
+
+        // The test profile disables the proxy listener (port -1), so a request that clears
+        // both feature gates fails on the "listener is not available" check with a 500 —
+        // distinct from the 402/400 the gates produce.
+        mockMvc.perform(post("/execution-requests/${request.getId()}/proxy").cookie(cookie))
+            .andExpect(status().isInternalServerError)
+    }
+
+    @Test
+    fun `enabling the proxy without a license is rejected`() {
+        val cookie = userHelper.login(email = adminUser.email, mockMvc = mockMvc)
+
+        mockMvc.perform(
+            put("/config/")
+                .cookie(cookie)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"proxyEnabled": true}"""),
+        )
+            .andExpect(status().isBadRequest)
+
+        mockMvc.perform(get("/config/").cookie(cookie))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.proxyEnabled").value(false))
+    }
+
+    @Test
+    fun `enabling the proxy with a license works and every user can read the flag`() {
+        installTestLicense()
+        val adminCookie = userHelper.login(email = adminUser.email, mockMvc = mockMvc)
+
+        mockMvc.perform(
+            put("/config/")
+                .cookie(adminCookie)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"proxyEnabled": true}"""),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.proxyEnabled").value(true))
+
+        // The review page needs the flag for users without any configuration permission.
+        val reviewerCookie = userHelper.login(email = reviewerUser.email, mockMvc = mockMvc)
+        mockMvc.perform(get("/config/").cookie(reviewerCookie))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.proxyEnabled").value(true))
+    }
+
+    @Test
+    fun `disabling the proxy does not require a license`() {
+        configurationAdapter.setConfiguration(Configuration(teamsUrl = null, slackUrl = null, proxyEnabled = true))
+        val cookie = userHelper.login(email = adminUser.email, mockMvc = mockMvc)
+
+        mockMvc.perform(
+            put("/config/")
+                .cookie(cookie)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"proxyEnabled": false}"""),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.proxyEnabled").value(false))
+    }
+
+    @Test
+    fun `saving other settings leaves the proxy flag unchanged`() {
+        configurationAdapter.setConfiguration(Configuration(teamsUrl = null, slackUrl = null, proxyEnabled = true))
+        val cookie = userHelper.login(email = adminUser.email, mockMvc = mockMvc)
+
+        // No license installed: a plain webhook save must neither flip the flag nor be
+        // rejected by the license gate that guards enabling.
+        mockMvc.perform(
+            put("/config/")
+                .cookie(cookie)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"teamsUrl": "https://teams.example.com", "slackUrl": null}"""),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.proxyEnabled").value(true))
+            .andExpect(jsonPath("$.teamsUrl").value("https://teams.example.com"))
+    }
+}

--- a/frontend/src/api/ConfigApi.ts
+++ b/frontend/src/api/ConfigApi.ts
@@ -17,6 +17,7 @@ const ConfigResponseSchema = z.object({
   allowedUsers: z.number().nullable().optional(),
   teamsUrl: z.string().nullable().optional(),
   slackUrl: z.string().nullable().optional(),
+  proxyEnabled: z.boolean().default(false),
   version: z.string(),
   buildDate: z.string(),
   gitCommit: z.string(),
@@ -33,6 +34,10 @@ export const ConfigPayloadSchema = ConfigResponseSchema.omit({
   version: true,
   buildDate: true,
   gitCommit: true,
+}).extend({
+  // Optional on writes: a PUT that leaves it out keeps the stored value, so the
+  // notification form can never flip the proxy toggle as a side effect.
+  proxyEnabled: z.boolean().optional(),
 });
 
 export type ConfigResponse = z.infer<typeof ConfigResponseSchema>;

--- a/frontend/src/components/EnterpriseFeatureModal.tsx
+++ b/frontend/src/components/EnterpriseFeatureModal.tsx
@@ -1,0 +1,59 @@
+import { ReactNode } from "react";
+import { SparklesIcon } from "@heroicons/react/24/outline";
+import { Link } from "react-router-dom";
+import Modal from "./Modal";
+import Button from "./Button";
+
+/**
+ * Upsell dialog shown when a user clicks an enterprise-only action without a
+ * valid license: pitches the feature instead of just refusing it.
+ */
+const EnterpriseFeatureModal = (props: {
+  /** Feature name shown as the heading, e.g. "Database Proxy". */
+  feature: string;
+  /** The pitch: what the feature does and why it's worth upgrading for. */
+  children: ReactNode;
+  setVisible: (visible: boolean) => void;
+}) => {
+  return (
+    <Modal setVisible={props.setVisible}>
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+        <div className="flex items-center gap-2">
+          <SparklesIcon className="h-6 w-6 text-purple-600 dark:text-purple-400" />
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">
+            {props.feature}
+          </h2>
+          <span
+            className="rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium
+                       text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+          >
+            Enterprise
+          </span>
+        </div>
+        <div className="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300">
+          {props.children}
+        </div>
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Link
+            to="/settings/license"
+            className="text-sm text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            Already have a license? Upload it here.
+          </Link>
+          <div className="flex items-center gap-2">
+            <Button onClick={() => props.setVisible(false)}>Close</Button>
+            <a
+              href="https://kviklet.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button variant="primary">Get a license at kviklet.dev</Button>
+            </a>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default EnterpriseFeatureModal;

--- a/frontend/src/routes/Review/DatasourceRequestActions.tsx
+++ b/frontend/src/routes/Review/DatasourceRequestActions.tsx
@@ -19,6 +19,8 @@ import {
   NO_EXECUTE_PERMISSION_MESSAGE,
 } from "../../api/Permissions";
 import { useHasPermission } from "../../hooks/permissions";
+import useConfig from "../../components/ConfigProvider";
+import EnterpriseFeatureModal from "../../components/EnterpriseFeatureModal";
 
 function DatasourceRequestActions({
   request,
@@ -47,6 +49,10 @@ function DatasourceRequestActions({
   // so this is the global "can create anywhere" check, not one on this connection.
   const canCreateRequests = useHasPermission("execution_request:edit");
   const [showSQLDumpModal, setShowSQLDumpModal] = useState(false);
+  const [showProxyUpsellModal, setShowProxyUpsellModal] = useState(false);
+  const { config } = useConfig();
+  const licenseValid = config?.licenseValid ?? false;
+  const proxyEnabled = config?.proxyEnabled ?? false;
   const navigate = useNavigate();
 
   const navigateCopy = () => {
@@ -172,23 +178,48 @@ function DatasourceRequestActions({
           },
         ]
       : []),
+    // The proxy entry is always visible so the feature is discoverable: without a license it
+    // opens the enterprise upsell; with a license but the proxy switched off it's grayed out.
     ...(request?.type == "TemporaryAccess"
       ? [
-          {
-            onClick: () => {
-              void startServer();
-            },
-            enabled:
-              isAuthor && canExecute && request?.reviewStatus === "APPROVED",
-            tooltip: !isAuthor
-              ? "Proxy access is granted only to the requester"
-              : request?.reviewStatus !== "APPROVED"
-              ? "Request needs to be approved before starting the proxy"
-              : !canExecute
-              ? NO_EXECUTE_PERMISSION_MESSAGE
-              : undefined,
-            content: "Start Proxy",
-          },
+          !licenseValid
+            ? {
+                onClick: () => {
+                  setShowProxyUpsellModal(true);
+                },
+                enabled: true,
+                content: (
+                  <span className="flex items-center justify-between">
+                    Start Proxy
+                    <span
+                      className="rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium
+                                 text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+                    >
+                      Enterprise
+                    </span>
+                  </span>
+                ),
+              }
+            : {
+                onClick: () => {
+                  void startServer();
+                },
+                enabled:
+                  proxyEnabled &&
+                  isAuthor &&
+                  canExecute &&
+                  request?.reviewStatus === "APPROVED",
+                tooltip: !proxyEnabled
+                  ? "The database proxy is disabled. An admin can enable it in the general settings."
+                  : !isAuthor
+                  ? "Proxy access is granted only to the requester"
+                  : request?.reviewStatus !== "APPROVED"
+                  ? "Request needs to be approved before starting the proxy"
+                  : !canExecute
+                  ? NO_EXECUTE_PERMISSION_MESSAGE
+                  : undefined,
+                content: "Start Proxy",
+              },
         ]
       : []),
   ];
@@ -335,6 +366,23 @@ function DatasourceRequestActions({
         )}
       </div>
       <SQLDumpModal />
+      {showProxyUpsellModal && (
+        <EnterpriseFeatureModal
+          feature="Database Proxy"
+          setVisible={setShowProxyUpsellModal}
+        >
+          <p>
+            Connect psql, mysql, DataGrip, or any other native client straight
+            to an approved temporary-access request — no credentials to hand
+            out, no separate tunnel.
+          </p>
+          <p>
+            Every statement passes through Kviklet and lands in the audit log,
+            so temporary access stays fully reviewable even outside the web
+            editor.
+          </p>
+        </EnterpriseFeatureModal>
+      )}
     </>
   );
 }

--- a/frontend/src/routes/settings/GeneralSettings.tsx
+++ b/frontend/src/routes/settings/GeneralSettings.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
+import { Link } from "react-router-dom";
 import {
   ConfigPayload,
   ConfigPayloadSchema,
@@ -8,6 +9,7 @@ import {
 } from "../../api/ConfigApi";
 import InputField from "../../components/InputField";
 import Button from "../../components/Button";
+import Toggle from "../../components/Toggle";
 import useConfig from "../../components/ConfigProvider";
 import Spinner from "../../components/Spinner";
 import {
@@ -76,12 +78,116 @@ export default function GeneralSettings() {
                 </>
               )}
             </Disclosure>
+            <Disclosure defaultOpen={true}>
+              {({ open }) => (
+                <>
+                  <DisclosureButton className="py-2">
+                    <div className="flex flex-row justify-between">
+                      <div className="flex flex-row items-center gap-2">
+                        <h2>Database Proxy</h2>
+                        <span
+                          className="rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium
+                                     text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+                        >
+                          Enterprise
+                        </span>
+                      </div>
+                      <div className="flex flex-row">
+                        {open ? (
+                          <ChevronDownIcon className="h-6 w-6 text-slate-400 dark:text-slate-500"></ChevronDownIcon>
+                        ) : (
+                          <ChevronRightIcon className="h-6 w-6 text-slate-400 dark:text-slate-500"></ChevronRightIcon>
+                        )}
+                      </div>
+                    </div>
+                  </DisclosureButton>
+                  <DisclosurePanel unmount={false}>
+                    {!canEditConfig && (
+                      <ReadOnlyNotice
+                        resource="these settings"
+                        className="mb-2"
+                      />
+                    )}
+                    <ProxySettings
+                      config={config}
+                      canEditConfig={canEditConfig}
+                      onToggle={(enabled) =>
+                        void updateConfig({ proxyEnabled: enabled })
+                      }
+                    />
+                  </DisclosurePanel>
+                </>
+              )}
+            </Disclosure>
           </div>
         )
       )}
     </div>
   );
 }
+
+const ProxySettings = ({
+  config,
+  canEditConfig,
+  onToggle,
+}: {
+  config: ConfigResponse;
+  canEditConfig: boolean;
+  onToggle: (enabled: boolean) => void;
+}) => {
+  const licenseValid = config.licenseValid;
+  const proxyEnabled = config.proxyEnabled ?? false;
+  // With an expired license the toggle stays usable in one direction: an admin can
+  // still switch a running proxy off, just not turn it (back) on.
+  const lockedByLicense = !licenseValid && !proxyEnabled;
+
+  return (
+    <div className="flex flex-col space-y-4">
+      <span className="text-sm dark:text-slate-300">
+        Lets the author of an approved temporary-access request connect native
+        clients like psql or DataGrip through Kviklet, with every statement
+        recorded in the audit log. Requires the proxy ports to be reachable in
+        your deployment.
+      </span>
+      <div className="flex flex-row items-center justify-between">
+        <span className="text-sm">Enable the proxy for approved requests</span>
+        <Toggle
+          active={proxyEnabled}
+          disabled={!canEditConfig || lockedByLicense}
+          tooltip={
+            !canEditConfig
+              ? "You lack the permission to change this setting"
+              : lockedByLicense
+              ? "The database proxy requires an enterprise license"
+              : undefined
+          }
+          onClick={() => onToggle(!proxyEnabled)}
+        />
+      </div>
+      {!licenseValid && (
+        <span className="text-sm text-slate-500 dark:text-slate-400">
+          The database proxy is an enterprise feature.{" "}
+          <a
+            href="https://kviklet.dev"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            Get a license at kviklet.dev
+          </a>{" "}
+          or{" "}
+          <Link
+            to="/settings/license"
+            className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            upload one here
+          </Link>
+          .
+        </span>
+      )}
+    </div>
+  );
+};
 
 const ConfigForm = ({
   config,


### PR DESCRIPTION
Makes the proxy an enterprise feature that can be switched on at runtime, without a restart.

**Backend**
- New `proxyEnabled` key in the existing key/value configuration store; null fields in a config PUT now mean "leave unchanged", and `setConfiguration` re-reads the full config after saving so partial updates return complete state.
- `ExecutionRequestService.proxy()` refuses to register a session without an active license (402) or with the toggle off (400); the controller endpoint additionally carries `@EnterpriseOnly`. The listeners still bind at startup as before — a session-less listener rejects every connection, so the feature gate lives at session registration and reacts immediately to a license upload or toggle flip.
- Enabling the toggle itself requires a license (only the off->on transition is gated, so an expired license can still turn it off or save other settings).
- `proxyEnabled` is exposed on the public config response so the review page can render the right state for every user.

**Frontend**
- General settings gets a "Database Proxy" section with an immediate-save toggle: read-only without `configuration:edit`, locked with a license hint while unlicensed.
- The "Start Proxy" action on temporary-access requests is now always visible: live when licensed and enabled, grayed out with a tooltip when licensed but disabled, and behind a new reusable `EnterpriseFeatureModal` upsell (with a kviklet.dev CTA and license-upload link) when unlicensed.