### PR TITLE
Make Postgres client-message framing linear instead of quadratic

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/MessageFramer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/MessageFramer.kt
@@ -7,34 +7,79 @@ import java.nio.ByteBuffer
 // garbage or an attack and waiting for the remaining bytes would buffer unbounded amounts of data
 private const val MAX_MESSAGE_LENGTH = 0x40000000
 
+// Above this capacity the buffer is released once fully drained instead of kept for reuse.
+private const val SHRINK_THRESHOLD = 0x10000
+
 // Reassembles wire-protocol messages from the raw chunks read off the client socket. A single
 // read can contain several messages and a single message can be split across several reads
 // (anything larger than the socket read buffer always is), so complete messages are extracted
 // and the trailing partial message is buffered until the next chunk arrives.
+//
+// The buffer is an explicit [start, end) window over a growable array, not a re-allocated
+// ByteArray: appending with `buffered += chunk` would copy the whole accumulated partial message
+// on every socket read, which is quadratic in message size -- ruinous for anything large (a big
+// Bind parameter, COPY FROM STDIN) since a message may legally run to 1GB. Unconsumed bytes only
+// move when the array has to grow (doubling) or when the free tail is exhausted, so every byte is
+// copied O(1) times amortized, and in the common case -- the buffer drained by the previous feed --
+// bytes are copied in exactly once.
 class MessageFramer {
-    private var buffered: ByteArray = ByteArray(0)
+    private var buffered = ByteArray(0)
+
+    // The unconsumed window: buffered[start, end) holds the trailing partial message, if any.
+    private var start = 0
+    private var end = 0
 
     fun feed(chunk: ByteArray): List<ParsedMessage> {
-        buffered += chunk
+        append(chunk)
         val messages = mutableListOf<ParsedMessage>()
-        var offset = 0
         // A message is one header byte plus an int32 length that includes itself but not the header
-        while (buffered.size - offset >= 5) {
-            val length = ByteBuffer.wrap(buffered, offset + 1, 4).int
+        while (end - start >= 5) {
+            val length = ByteBuffer.wrap(buffered, start + 1, 4).int
             if (length < 4 || length > MAX_MESSAGE_LENGTH) {
                 throw Exception(
-                    "Invalid length $length for message of type '${buffered[offset].toInt().toChar()}'",
+                    "Invalid length $length for message of type '${buffered[start].toInt().toChar()}'",
                 )
             }
-            if (buffered.size - offset < 1 + length) {
+            if (end - start < 1 + length) {
                 break
             }
-            val header = buffered[offset].toInt().toChar()
-            val content = buffered.copyOfRange(offset + 5, offset + 1 + length)
+            val header = buffered[start].toInt().toChar()
+            val content = buffered.copyOfRange(start + 5, start + 1 + length)
             messages.add(ParsedMessage.fromBytes(header, length, content))
-            offset += 1 + length
+            start += 1 + length
         }
-        buffered = buffered.copyOfRange(offset, buffered.size)
+        if (start == end) {
+            // Fully drained: reset the window so the next append writes at the front and never
+            // needs to slide or grow while traffic consists of complete, ordinary-sized messages.
+            start = 0
+            end = 0
+            if (buffered.size > SHRINK_THRESHOLD) {
+                // Don't let one huge message (up to 1GB) stay pinned as this connection's buffer
+                // for the rest of the session.
+                buffered = ByteArray(0)
+            }
+        }
         return messages
+    }
+
+    private fun append(chunk: ByteArray) {
+        val unconsumed = end - start
+        if (end + chunk.size > buffered.size) {
+            if (unconsumed + chunk.size <= buffered.size) {
+                // Enough capacity overall, just none left behind `end`: slide the unconsumed
+                // bytes to the front instead of growing.
+                System.arraycopy(buffered, start, buffered, 0, unconsumed)
+            } else {
+                // Doubling (not grow-to-fit) is what makes the copying amortized linear while a
+                // large message accumulates.
+                val grown = ByteArray(maxOf(buffered.size * 2, unconsumed + chunk.size))
+                System.arraycopy(buffered, start, grown, 0, unconsumed)
+                buffered = grown
+            }
+            start = 0
+            end = unconsumed
+        }
+        System.arraycopy(chunk, 0, buffered, end, chunk.size)
+        end += chunk.size
     }
 }

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyFramingTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyFramingTest.kt
@@ -86,6 +86,43 @@ class PostgresProxyFramingTest {
     }
 
     @Test
+    fun `messages of varying sizes fed in uneven chunks are all reassembled in order`() {
+        // Exercises every path of the internal buffer window: tiny chunks that split headers,
+        // chunks holding several messages, and partial messages carried across many feeds.
+        val framer = MessageFramer()
+        val queries = (0 until 50).map { i -> "SELECT '" + "x".repeat(i * i * 7 % 9001) + "' -- $i" }
+        val bytes = queries.map { queryMessageBytes(it) }.reduce(ByteArray::plus)
+        val chunkSizes = listOf(1, 7, 8192, 3, 4096, 13, 977)
+        val parsed = mutableListOf<QueryMessage>()
+        var offset = 0
+        var i = 0
+        while (offset < bytes.size) {
+            val next = minOf(offset + chunkSizes[i % chunkSizes.size], bytes.size)
+            framer.feed(bytes.copyOfRange(offset, next)).forEach { parsed.add(it as QueryMessage) }
+            offset = next
+            i++
+        }
+        assertEquals(queries, parsed.map { it.query })
+    }
+
+    @Test
+    fun `small messages still parse after a message large enough to grow and shrink the buffer`() {
+        // A >64KB message forces the internal buffer to grow and then be released on drain;
+        // everything after it must still frame correctly on the fresh buffer.
+        val framer = MessageFramer()
+        val bigQuery = "SELECT '" + "y".repeat(200_000) + "'"
+        val bytes = queryMessageBytes(bigQuery) +
+            queryMessageBytes("SELECT 1") +
+            queryMessageBytes("SELECT 2")
+        val parsed = mutableListOf<QueryMessage>()
+        for (offset in bytes.indices step 8192) {
+            val chunk = bytes.copyOfRange(offset, minOf(offset + 8192, bytes.size))
+            framer.feed(chunk).forEach { parsed.add(it as QueryMessage) }
+        }
+        assertEquals(listOf(bigQuery, "SELECT 1", "SELECT 2"), parsed.map { it.query })
+    }
+
+    @Test
     fun `every parsed message reserializes to exactly the bytes that were fed`() {
         // The relay forwards ParsedMessage.toByteArray() to the server, so a faithful relay
         // requires that reserializing a parsed message reproduces the original wire bytes.


### PR DESCRIPTION
`MessageFramer` accumulated the trailing partial message with `buffered += chunk`, which reallocates and copies the whole buffer on every 8KB socket read, plus a second full `copyOfRange` per feed. That makes framing O(n²) in message size: a legal large message (big `Bind` parameter, `COPY FROM STDIN` data, up to the 1GB protocol cap) costs roughly n²/8KB bytes of memcpy — ~13GB of copying for a 10MB message, effectively a hang near the cap, and cheap quadratic CPU burn for an authenticated client.

The framer now keeps an explicit `[start, end)` window over a growable array (doubling growth, slide-to-front only when the tail is exhausted), matching the approach the MySQL `MySqlPacketFramer` already uses. Every byte is copied O(1) times amortized, and in the common drained-buffer case exactly once. A buffer grown past 64KB by a large message is released once drained so it doesn't stay pinned for the rest of the connection.

Adds two framing tests: messages of varying sizes fed in uneven chunk sizes (exercising every window path), and small messages parsing correctly after a message large enough to grow and shrink the buffer.