### PR TITLE
Proxy hardening: TLS boot safety, SASL framing, handshake deadline, cap refusals

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/Config.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/Config.kt
@@ -53,16 +53,18 @@ class WebSocketConfig : WebSocketConfigurer {
 
 @Configuration
 class TLSCerts(
+    // The defaults must be the SpEL "#{null}", not a bare "null": a bare one injects the literal string
+    // "null", which passes the factory's null-checks and ends in File("null").readLines() at boot.
     @Value("\${proxy.tls_certificate_source:NONE}")
     private val certificateSource: String,
-    @Value("\${proxy.tls_certificate_cert:null}")
-    private val certificateCert: String,
-    @Value("\${proxy.tls_certificate_key:null}")
-    private val certificateKey: String,
-    @Value("\${proxy.tls_certificate_cert_file:null}")
-    private val certificateCertFile: String,
-    @Value("\${proxy.tls_certificate_key_file:null}")
-    private val certificateKeyFile: String,
+    @Value("\${proxy.tls_certificate_cert:#{null}}")
+    private val certificateCert: String?,
+    @Value("\${proxy.tls_certificate_key:#{null}}")
+    private val certificateKey: String?,
+    @Value("\${proxy.tls_certificate_cert_file:#{null}}")
+    private val certificateCertFile: String?,
+    @Value("\${proxy.tls_certificate_key_file:#{null}}")
+    private val certificateKeyFile: String?,
 ) {
     @Bean
     @Primary

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/core/ProxyProtocol.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/core/ProxyProtocol.kt
@@ -30,4 +30,10 @@ interface ProxyProtocol {
     // post-authentication finalization the protocol requires, and wraps both sockets in a ready-to-run relay.
     // Throws (after closing anything it opened) if the upstream cannot be established.
     fun connect(authenticatedClient: AuthenticatedClient): ProxyConnection
+
+    // Tells an authenticated client the server cannot take its connection (a relay cap was reached), in the
+    // protocol's own error vocabulary, so the client reports a clear "too many connections" instead of a
+    // bare connection reset. Called instead of connect(), so no upstream exists yet; best-effort, the caller
+    // closes the socket afterwards either way.
+    fun refuseOverCapacity(authenticatedClient: AuthenticatedClient)
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/core/ProxyServer.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/core/ProxyServer.kt
@@ -26,6 +26,11 @@ class ProxyServer(
     // forever. Set on the accepted socket before the protocol handshake runs; the handshake honours it as its
     // total budget.
     private val handshakeTimeoutMs: Int = 10_000,
+    // Relay caps, applied only to authenticated connections (reserveConnectionSlot). The per-session cap is
+    // the pre-single-port budget each request used to get on its own port, so one client's JDBC pool can no
+    // longer starve everyone else; the global cap is a total-resource ceiling across all sessions.
+    private val maxConnectionsPerSession: Int = 15,
+    private val maxConnections: Int = 100,
 ) {
     private val threadPool = Executors.newCachedThreadPool()
 
@@ -45,12 +50,6 @@ class ProxyServer(
     private val clientConnections = CopyOnWriteArrayList<ProxyConnection>()
 
     private lateinit var serverSocket: ServerSocket
-
-    // Relay caps, applied only to authenticated connections (registerConnection). The per-session cap is the
-    // pre-single-port budget each request used to get on its own port, so one client's JDBC pool can no longer
-    // starve everyone else; the global cap is a total-resource ceiling across all sessions.
-    private val maxConnectionsPerSession = 15
-    private val maxConnections = 100
 
     // Bounds concurrent in-flight handshakes (pre-auth), independent of the relay caps: unauthenticated sockets
     // get their own small budget so a connect flood cannot spawn unbounded handshake threads, yet cannot
@@ -240,18 +239,39 @@ class ProxyServer(
         val session = authenticatedClient.session
 
         // The access window may have closed (server shutdown or session expiry) while the client was still
-        // handshaking; do not open a credentialed upstream connection. registerConnection re-checks this
+        // handshaking; do not open a credentialed upstream connection. attachConnection re-checks this
         // atomically below to also cover a close that fires during the upstream connect itself.
         if (!isRunning || !session.active) return
 
-        // Only now that the client is authenticated does the protocol open the upstream connection and build the
-        // relay. It closes anything it opened if this throws.
-        val clientConnection = protocol.connect(authenticatedClient)
+        // Reserve the relay slot BEFORE the protocol opens the upstream and finishes the client-facing
+        // startup: a cap refusal can then be delivered as a proper protocol error while the client is still
+        // in its connect phase, instead of a silent TCP close right after a successful startup (which pools
+        // surface as "connection reset" on first use). It also avoids opening an upstream connection only
+        // to tear it straight down again.
+        when (reserveConnectionSlot(session)) {
+            SlotReservation.SESSION_GONE -> return
 
-        // Register atomically against shutdown and expiry: if either fired after the check above (e.g. during
-        // the upstream connect), this returns false and we close the just-opened session rather than leaving it
-        // relaying past the access window.
-        if (!registerConnection(session, clientConnection)) {
+            SlotReservation.OVER_CAPACITY -> {
+                runCatching { protocol.refuseOverCapacity(authenticatedClient) }
+                return
+            }
+
+            SlotReservation.RESERVED -> {}
+        }
+
+        // Only now does the protocol open the upstream connection and build the relay. It closes anything
+        // it opened if this throws; the reservation must be handed back too.
+        val clientConnection = try {
+            protocol.connect(authenticatedClient)
+        } catch (e: Exception) {
+            releaseReservedSlot(session)
+            throw e
+        }
+
+        // Attach atomically against shutdown and expiry: if either fired after the reservation (e.g. during
+        // the upstream connect), this returns false and we close the just-opened session rather than leaving
+        // it relaying past the access window.
+        if (!attachConnection(session, clientConnection)) {
             clientConnection.close()
             return
         }
@@ -262,30 +282,51 @@ class ProxyServer(
         }
     }
 
-    // Adds a fully set-up relay to both the session and the global tracking list, but only if the server is
-    // still running, the session still active, and neither the per-session nor the global relay cap is reached.
-    // Returns false otherwise so the caller tears the new session down (nothing else would close it). Counting
-    // authenticated relays here -- not on accept -- is what keeps unauthenticated sockets off the relay budget;
-    // the per-session cap keeps one client's connection pool from starving other sessions.
+    private enum class SlotReservation { RESERVED, OVER_CAPACITY, SESSION_GONE }
+
+    // Claims a relay slot against both caps before the upstream connect. Counting authenticated clients
+    // here -- not on accept -- is what keeps unauthenticated sockets off the relay budget; the per-session
+    // cap keeps one client's connection pool from starving other sessions. The reservation counts toward
+    // currentConnections immediately so the accept-loop gate and the global cap see in-flight connects.
     @Synchronized
-    private fun registerConnection(session: ProxySession, connection: ProxyConnection): Boolean {
+    private fun reserveConnectionSlot(session: ProxySession): SlotReservation {
         if (!isRunning || !session.active) {
-            return false
+            return SlotReservation.SESSION_GONE
         }
         if (currentConnections >= maxConnections) {
             logger.warn("Global proxy connection cap ($maxConnections) reached, refusing a connection")
-            return false
+            return SlotReservation.OVER_CAPACITY
         }
-        if (session.connections.size >= maxConnectionsPerSession) {
+        if (session.connections.size + session.reservedConnections >= maxConnectionsPerSession) {
             logger.warn(
                 "Per-session proxy connection cap ($maxConnectionsPerSession) reached for ${session.username}, " +
                     "refusing a connection",
             )
+            return SlotReservation.OVER_CAPACITY
+        }
+        session.reservedConnections++
+        currentConnections++
+        return SlotReservation.RESERVED
+    }
+
+    @Synchronized
+    private fun releaseReservedSlot(session: ProxySession) {
+        session.reservedConnections--
+        currentConnections--
+    }
+
+    // Converts a reservation into a registered relay, adding it to both the session and the global tracking
+    // list -- but only if the server is still running and the session still active. Returns false otherwise
+    // (handing the reservation back) so the caller tears the new relay down; nothing else would close it.
+    @Synchronized
+    private fun attachConnection(session: ProxySession, connection: ProxyConnection): Boolean {
+        if (!isRunning || !session.active) {
+            releaseReservedSlot(session)
             return false
         }
+        session.reservedConnections--
         clientConnections.add(connection)
         session.connections.add(connection)
-        currentConnections++
         return true
     }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/core/ProxySession.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/core/ProxySession.kt
@@ -35,6 +35,11 @@ class ProxySession(
     // expiry task / shutdown.
     val connections = CopyOnWriteArrayList<ProxyConnection>()
 
+    // Relay slots reserved against the caps whose upstream connect is still in flight (reserved before the
+    // protocol opens the upstream, converted into an entry in [connections] once the relay is built).
+    // Guarded by the owning ProxyServer's monitor, like connection registration itself.
+    internal var reservedConnections: Int = 0
+
     // Flipped to false on expiry or server shutdown. Read during auth routing and connection registration
     // (both under the server monitor) so a connection that authenticated just as the window closed is refused
     // instead of left relaying.

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/core/TLSCertificate.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/core/TLSCertificate.kt
@@ -1,6 +1,7 @@
 // This file is not MIT licensed
 package dev.kviklet.kviklet.proxy.core
 
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -74,9 +75,20 @@ class TlsCertEnvConfig(
     var PROXY_TLS_CERTIFICATE_CERT: String? = null,
 )
 
+// Never throws: this runs during eager proxy bean creation, so a bad cert path or a malformed PEM/key
+// must degrade to "no TLS" (logged) rather than propagate as a BeanCreationException that fails the whole
+// application boot -- matching how a listener bind failure is handled in ProxyServer.start().
 fun tlsCertificateFactory(env: TlsCertEnvConfig = TlsCertEnvConfig()): TLSCertificate? {
     val logger = LoggerFactory.getLogger("TLSCertificate")
+    return try {
+        loadTlsCertificate(env, logger)
+    } catch (e: Exception) {
+        logger.error("Failed to load the proxy TLS certificate; the proxy will run without TLS", e)
+        null
+    }
+}
 
+private fun loadTlsCertificate(env: TlsCertEnvConfig, logger: Logger): TLSCertificate? {
     when (env.PROXY_TLS_CERTIFICATE_SOURCE.lowercase()) {
         "file" -> {
             if (env.PROXY_TLS_CERTIFICATE_FILE == null || env.PROXY_TLS_CERTIFICATE_KEY_FILE == null) {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProtocol.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProtocol.kt
@@ -80,12 +80,28 @@ class MySqlProtocol(
 
     // The MySQL handshake has already answered the client with its OK packet, so the refusal is delivered
     // as the ERR the client reads in response to its first command (1040 Too many connections) -- still a
-    // clear error instead of the silent close it used to get. Sequence id 1 matches a first-command reply.
+    // clear error instead of the silent close it used to get.
+    //
+    // The client's first command must actually be READ before the ERR goes out: the caller closes the
+    // socket right after this, and closing with unread inbound bytes makes the kernel send an RST that
+    // discards the buffered ERR, so the client would race between seeing the error and a bare connection
+    // reset. Consuming the command also gives the ERR the sequence id of a real reply to it.
     override fun refuseOverCapacity(authenticatedClient: AuthenticatedClient) {
+        val socket = authenticatedClient.socket
+        val sequenceId = try {
+            socket.soTimeout = REFUSAL_READ_TIMEOUT_MS
+            readPacket(socket.getInputStream()).first
+        } catch (e: Exception) {
+            0 // no command arrived in time; deliver the ERR unsolicited as a best effort
+        }
         writePacket(
-            authenticatedClient.socket.getOutputStream(),
-            1,
+            socket.getOutputStream(),
+            sequenceId + 1,
             buildErrPacket(1040, "08004", "Too many connections through the Kviklet proxy, try again later"),
         )
     }
 }
+
+// How long a refused client gets to send the first command its ERR answers. Bounds the handler thread's
+// stay in the refusal path; a client that sends nothing gets the ERR unsolicited after this.
+private const val REFUSAL_READ_TIMEOUT_MS = 1000

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProtocol.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/mysql/MySqlProtocol.kt
@@ -77,4 +77,15 @@ class MySqlProtocol(
             throw e
         }
     }
+
+    // The MySQL handshake has already answered the client with its OK packet, so the refusal is delivered
+    // as the ERR the client reads in response to its first command (1040 Too many connections) -- still a
+    // clear error instead of the silent close it used to get. Sequence id 1 matches a first-command reply.
+    override fun refuseOverCapacity(authenticatedClient: AuthenticatedClient) {
+        writePacket(
+            authenticatedClient.socket.getOutputStream(),
+            1,
+            buildErrPacket(1040, "08004", "Too many connections through the Kviklet proxy, try again later"),
+        )
+    }
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/ClientConnectionSetup.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/ClientConnectionSetup.kt
@@ -22,6 +22,7 @@ import dev.kviklet.kviklet.proxy.postgres.messages.tlsSupportedMessage
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
+import java.net.SocketTimeoutException
 import java.nio.ByteBuffer
 
 // Postgres' own cap on a startup packet (PQ_MAX_STARTUP_PACKET_LENGTH). A declared length beyond what
@@ -54,9 +55,7 @@ fun authenticateClient(
     unknownUserPassword: String,
     resolveSession: (String) -> ProxySession?,
 ): AuthenticatedClient? {
-    // The caller's soTimeout is the TOTAL handshake budget, not just a per-read timeout: the socket timeout
-    // is shrunk to the remaining budget before every read below, so the whole handshake -- including a slow
-    // client dribbling one valid frame just under each timeout -- cannot outlast it and hold its slot forever.
+    // The caller's soTimeout is the TOTAL handshake budget, not just a per-read timeout.
     val budgetMs = if (client.soTimeout > 0) client.soTimeout.toLong() else DEFAULT_HANDSHAKE_BUDGET_MS
     val deadline = System.currentTimeMillis() + budgetMs
     var socket = client
@@ -64,70 +63,95 @@ fun authenticateClient(
     var output = socket.getOutputStream()
     var preStartupFrames = 0
 
-    while (true) {
+    // Invoked before EVERY read below, including the partial reads inside readFully and the SASL
+    // exchange: re-checks the deadline and re-shrinks the socket timeout to the remaining budget. A plain
+    // soTimeout resets on every byte received, so without the re-check a client dribbling one byte per
+    // just-under-the-timeout interval could hold a handshake slot for hours; with it the whole handshake
+    // cannot outlast its budget. Reads `socket` through the var so it survives the TLS upgrade.
+    val checkDeadline = {
         val remaining = deadline - System.currentTimeMillis()
         if (remaining <= 0) {
             throw Exception("Client handshake exceeded its deadline, aborting the connection")
         }
         socket.soTimeout = remaining.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+    }
 
-        // Read the whole frame before dispatching. A single read is not guaranteed to be a single
-        // frame: TCP can split one, and the fixed-offset detectors below would misread a half-frame
-        // (throwing on a split header, or auth-failing a valid user and feeding the tail to SASL on a
-        // split StartupMessage).
-        val frame = readStartupFrame(input) ?: return null // client closed before a complete frame
+    fun handshakeLoop(): AuthenticatedClient? {
+        while (true) {
+            // Read the whole frame before dispatching. A single read is not guaranteed to be a single
+            // frame: TCP can split one, and the fixed-offset detectors below would misread a half-frame
+            // (throwing on a split header, or auth-failing a valid user and feeding the tail to SASL on a
+            // split StartupMessage).
+            val frame = readStartupFrame(input, checkDeadline) ?: return null // client closed before a complete frame
 
-        when {
-            isSSLRequest(frame) -> {
-                socket = handleSSLRequest(socket, tlsCert)
-                input = socket.getInputStream()
-                output = socket.getOutputStream()
-                preStartupFrames++
+            when {
+                isSSLRequest(frame) -> {
+                    socket = handleSSLRequest(socket, tlsCert)
+                    input = socket.getInputStream()
+                    output = socket.getOutputStream()
+                    preStartupFrames++
+                }
+
+                isGSSENCRequest(frame) -> {
+                    // We do not offer GSSAPI encryption, decline it and let the client fall back to a
+                    // plain StartupMessage instead of discarding the request and deadlocking.
+                    output.writeAndFlush(gssEncNotSupportedMessage())
+                    preStartupFrames++
+                }
+
+                isCancelRequest(frame) -> {
+                    // A CancelRequest opens a throwaway connection carrying no startup message and never
+                    // authenticates. The proxy hands out zeroed backend key data, so there is nothing to
+                    // cancel: drop it rather than block forever waiting for a startup message.
+                    return null
+                }
+
+                isStartupMessage(frame) -> {
+                    val requestedUser = startupMessageUser(frame, frame.size)
+                    val session = requestedUser?.let { resolveSession(it) }
+                    sendAuthRequest(output)
+                    // Unknown user -> isUserValid=false and a placeholder password, so SASL fails exactly
+                    // like a wrong password. waitUntilAuthenticated throws on failure, so the return below
+                    // is only reached when a real session authenticated successfully.
+                    waitUntilAuthenticated(
+                        input,
+                        output,
+                        session?.password ?: unknownUserPassword,
+                        session != null,
+                        checkDeadline,
+                    )
+                    // socket is the (possibly TLS-wrapped) stream the client now speaks on; client is the
+                    // raw accepted TCP socket the relay must close to unblock its threads on teardown.
+                    return AuthenticatedClient(socket, client, session!!)
+                }
+
+                else -> throw Exception("Unexpected message during the client handshake, aborting the connection")
             }
 
-            isGSSENCRequest(frame) -> {
-                // We do not offer GSSAPI encryption, decline it and let the client fall back to a
-                // plain StartupMessage instead of discarding the request and deadlocking.
-                output.writeAndFlush(gssEncNotSupportedMessage())
-                preStartupFrames++
+            if (preStartupFrames > MAX_PRE_STARTUP_FRAMES) {
+                throw Exception("Too many pre-startup frames before a StartupMessage, aborting the connection")
             }
-
-            isCancelRequest(frame) -> {
-                // A CancelRequest opens a throwaway connection carrying no startup message and never
-                // authenticates. The proxy hands out zeroed backend key data, so there is nothing to
-                // cancel: drop it rather than block forever waiting for a startup message.
-                return null
-            }
-
-            isStartupMessage(frame) -> {
-                val requestedUser = startupMessageUser(frame, frame.size)
-                val session = requestedUser?.let { resolveSession(it) }
-                sendAuthRequest(output)
-                // Unknown user -> isUserValid=false and a placeholder password, so SASL fails exactly like a
-                // wrong password. waitUntilAuthenticated throws on failure, so the return below is only
-                // reached when a real session authenticated successfully.
-                waitUntilAuthenticated(input, output, session?.password ?: unknownUserPassword, session != null)
-                // socket is the (possibly TLS-wrapped) stream the client now speaks on; client is the raw
-                // accepted TCP socket the relay must close to unblock its threads on teardown.
-                return AuthenticatedClient(socket, client, session!!)
-            }
-
-            else -> throw Exception("Unexpected message during the client handshake, aborting the connection")
         }
+    }
 
-        if (preStartupFrames > MAX_PRE_STARTUP_FRAMES) {
-            throw Exception("Too many pre-startup frames before a StartupMessage, aborting the connection")
-        }
+    // A read that blocks with the shrunk timeout throws SocketTimeoutException exactly when the budget
+    // runs out mid-read; surface it under the same deadline message as the between-reads check so the
+    // log tells the real story (slow client, not a network hiccup).
+    try {
+        return handshakeLoop()
+    } catch (e: SocketTimeoutException) {
+        throw Exception("Client handshake exceeded its deadline, aborting the connection", e)
     }
 }
 
 // Reads exactly one startup-phase frame (SSLRequest, GSSENCRequest, CancelRequest or StartupMessage),
 // accumulating across TCP-split reads until the length declared in the first four bytes is satisfied.
 // Each of these frames is followed by a server response the client waits for, so only one frame is ever
-// in flight. Returns null on EOF before a complete frame; the socket timeout still bounds each read.
-fun readStartupFrame(input: InputStream): ByteArray? {
+// in flight. Returns null on EOF before a complete frame; beforeRead runs before every read so the
+// caller's handshake deadline bounds even a byte-by-byte dribble.
+fun readStartupFrame(input: InputStream, beforeRead: () -> Unit = {}): ByteArray? {
     val header = ByteArray(4)
-    if (!readFully(input, header, 0, 4)) {
+    if (!readFully(input, header, 0, 4, beforeRead)) {
         return null
     }
     // The length is a big-endian int32 that includes the four length bytes themselves; the smallest
@@ -138,16 +162,17 @@ fun readStartupFrame(input: InputStream): ByteArray? {
     }
     val frame = ByteArray(declaredLength)
     header.copyInto(frame)
-    if (!readFully(input, frame, 4, declaredLength)) {
+    if (!readFully(input, frame, 4, declaredLength, beforeRead)) {
         return null
     }
     return frame
 }
 
 // Fills buffer[from until to], looping over partial reads. Returns false on EOF before `to` is reached.
-private fun readFully(input: InputStream, buffer: ByteArray, from: Int, to: Int): Boolean {
+private fun readFully(input: InputStream, buffer: ByteArray, from: Int, to: Int, beforeRead: () -> Unit): Boolean {
     var offset = from
     while (offset < to) {
+        beforeRead()
         val read = input.read(buffer, offset, to - offset)
         if (read == -1) {
             return false
@@ -183,8 +208,14 @@ fun sendAuthRequest(output: OutputStream) {
  * flow, which cancels authentication once a password is sent, so an attacker cannot tell a wrong
  * username from a wrong password and enumerate valid users.
  */
-fun waitUntilAuthenticated(input: InputStream, output: OutputStream, password: String, isUserValid: Boolean) {
-    val handler = SASLAuthHandler(output, input, password, isUserValid)
+fun waitUntilAuthenticated(
+    input: InputStream,
+    output: OutputStream,
+    password: String,
+    isUserValid: Boolean,
+    beforeRead: () -> Unit = {},
+) {
+    val handler = SASLAuthHandler(output, input, password, isUserValid, beforeRead = beforeRead)
     handler.handle()
 }
 

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/Connection.kt
@@ -8,14 +8,12 @@ import dev.kviklet.kviklet.proxy.postgres.messages.BindMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.CloseMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.ExecuteMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.MessageFramer
-import dev.kviklet.kviklet.proxy.postgres.messages.MessageOrBytes
 import dev.kviklet.kviklet.proxy.postgres.messages.ParseMessage
+import dev.kviklet.kviklet.proxy.postgres.messages.ParsedMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.QueryMessage
 import dev.kviklet.kviklet.proxy.postgres.messages.Statement
 import dev.kviklet.kviklet.proxy.postgres.messages.errorResponse
-import dev.kviklet.kviklet.proxy.postgres.messages.isTermination
 import dev.kviklet.kviklet.proxy.postgres.messages.readyForQuery
-import dev.kviklet.kviklet.proxy.postgres.messages.writableBytes
 import dev.kviklet.kviklet.service.EventService
 import dev.kviklet.kviklet.service.dto.ExecutionRequest
 import org.slf4j.LoggerFactory
@@ -159,7 +157,7 @@ class Connection(
         // and each message is audited immediately before it is forwarded, so the audit log
         // only ever contains queries that were at least attempted.
         val messages = try {
-            clientFramer.feed(clientBuffer).map { MessageOrBytes(it, null) }
+            clientFramer.feed(clientBuffer)
         } catch (e: Exception) {
             logger.warn("Failed to parse client message, blocking it and closing the session", e)
             abortSession(
@@ -167,8 +165,8 @@ class Connection(
             )
             return
         }
-        for (messageOrBytes in messages) {
-            if (messageOrBytes.message?.header == 'F') {
+        for (message in messages) {
+            if (message.header == 'F') {
                 logger.warn("Client sent a fast-path FunctionCall message, blocking it and closing the session")
                 abortSession(
                     "Kviklet proxy does not support fast-path function calls because they bypass the audit log. " +
@@ -177,7 +175,7 @@ class Connection(
                 return
             }
             try {
-                auditMessage(messageOrBytes)
+                auditMessage(message)
             } catch (e: UnknownStatementException) {
                 logger.warn("Client referenced a statement or portal unknown to the proxy, closing the session", e)
                 abortSession(
@@ -192,13 +190,13 @@ class Connection(
                 )
                 return
             }
-            terminationMessageReceived = terminationMessageReceived || messageOrBytes.isTermination()
-            serverOutput.writeAndFlush(messageOrBytes.writableBytes())
+            terminationMessageReceived = terminationMessageReceived || message.isTermination()
+            serverOutput.writeAndFlush(message.toByteArray())
         }
     }
 
-    private fun auditMessage(messageOrBytes: MessageOrBytes) {
-        when (val message = messageOrBytes.message) {
+    private fun auditMessage(message: ParsedMessage) {
+        when (message) {
             is QueryMessage -> handleQuery(message)
             is ParseMessage -> handleParseMessage(message)
             is BindMessage -> handleBindMessage(message)

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/PostgresProtocol.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/PostgresProtocol.kt
@@ -7,6 +7,8 @@ import dev.kviklet.kviklet.proxy.core.ProxyProtocol
 import dev.kviklet.kviklet.proxy.core.ProxySession
 import dev.kviklet.kviklet.proxy.core.TLSCertificate
 import dev.kviklet.kviklet.proxy.core.tlsCertificateFactory
+import dev.kviklet.kviklet.proxy.core.writeAndFlush
+import dev.kviklet.kviklet.proxy.postgres.messages.errorResponse
 import dev.kviklet.kviklet.service.EventService
 import java.net.Socket
 
@@ -71,5 +73,14 @@ class PostgresProtocol(
             runCatching { forwardSocket.close() }
             throw e
         }
+    }
+
+    // The client has completed SASL but not yet received AuthenticationOk (that happens in connect()), so
+    // an ErrorResponse here surfaces as a clean connect-time failure in the client -- the same 53300 a real
+    // postgres over its connection limit reports.
+    override fun refuseOverCapacity(authenticatedClient: AuthenticatedClient) {
+        authenticatedClient.socket.getOutputStream().writeAndFlush(
+            errorResponse("too many connections through the Kviklet proxy, try again later", "53300"),
+        )
     }
 }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/SASLAuth.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/SASLAuth.kt
@@ -20,6 +20,10 @@ import javax.crypto.spec.SecretKeySpec
 // Shared thread-safe CSPRNG for nonces and salts; constructing a SecureRandom per call re-seeds needlessly.
 private val secureRandom = SecureRandom()
 
+// Generous cap on a client SASL frame. Real SCRAM messages are a few hundred bytes; a declared length
+// beyond this can only be garbage or an attack, so it is rejected instead of buffered.
+private const val MAX_SASL_MESSAGE_LENGTH = 10_000
+
 enum class AuthenticationState {
     WAITING_CLIENT_FIRST,
     WAITING_CLIENT_PROOF,
@@ -38,6 +42,10 @@ class SASLAuthHandler(
     private val password: String,
     private val isUserValid: Boolean,
     private val iterations: Int = 4096,
+    // Invoked before every read. The handshake passes a hook that re-checks the total deadline and
+    // re-shrinks the socket timeout, so a client dribbling bytes cannot stretch the SASL phase past
+    // the handshake budget.
+    private val beforeRead: () -> Unit = {},
 ) {
     private val serverNonce = getRandomString()
     private val salt = Salt()
@@ -46,26 +54,53 @@ class SASLAuthHandler(
     private var serverFirst: String = ""
     fun handle() {
         while (state != AuthenticationState.DONE) {
-            val buff = ByteArray(8192)
-            val read = input.read(buff)
+            val (length, body) = readSaslFrame()
+            handleMessage(length, body)
+        }
+    }
+
+    // Reads exactly one client SASL frame ('p', int32 length, body), accumulating across TCP-split reads
+    // until the declared length is satisfied: a single read() is not guaranteed to deliver a whole frame,
+    // so a valid login whose SASL message spans two TCP segments must not be rejected.
+    private fun readSaslFrame(): Pair<Int, ByteArray> {
+        val header = ByteArray(5)
+        readFully(header)
+        if (header[0] != 'p'.code.toByte()) {
+            throw Exception("Unexpected message type during SASL authentication")
+        }
+        // length counts itself but not the header byte. It is attacker-controlled and this runs pre-auth,
+        // so bound it before allocating for it.
+        val length = ByteBuffer.wrap(header, 1, 4).int
+        if (length < 4 || length > MAX_SASL_MESSAGE_LENGTH) {
+            throw Exception("Invalid SASL message length $length")
+        }
+        val body = ByteArray(length - 4)
+        readFully(body)
+        return length to body
+    }
+
+    private fun readFully(buffer: ByteArray) {
+        var offset = 0
+        while (offset < buffer.size) {
+            beforeRead()
+            val read = input.read(buffer, offset, buffer.size - offset)
             if (read == -1) {
                 // The client aborted mid-SASL. Treat EOF as terminal so the handshake thread does not
                 // hot-spin on a closed stream.
                 throw Exception("Client closed the connection during SASL authentication")
             }
-            if (read > 0) {
-                handleMessage(buff, read)
-            }
+            offset += read
         }
     }
-    private fun handleMessage(buff: ByteArray, read: Int) {
+
+    private fun handleMessage(length: Int, body: ByteArray) {
         when (state) {
             AuthenticationState.WAITING_CLIENT_FIRST -> {
-                handleClientFirstMessage(buff, read)
+                handleClientFirstMessage(length, body)
             }
 
             AuthenticationState.WAITING_CLIENT_PROOF -> {
-                handleClientProof(buff, read)
+                handleClientProof(length, body)
             }
 
             AuthenticationState.DONE -> {
@@ -73,28 +108,13 @@ class SASLAuthHandler(
             }
         }
     }
-    private fun handleClientFirstMessage(buff: ByteArray, read: Int) {
-        val (length, body) = messageBody(buff, read)
+    private fun handleClientFirstMessage(length: Int, body: ByteArray) {
         clientFirst = SASLInitialResponse.fromBytes(length, body)
         serverFirst = "r=${clientFirst!!.getClientNonce() + serverNonce},s=${salt.base64Encoded},i=$iterations"
         sendServerFirstMessage()
     }
 
-    // Extracts (declaredLength, body) from a raw SASL read, matching the contract the relay MessageFramer
-    // uses: the header byte and the int32 length are stripped, and length includes the 4 length bytes.
-    private fun messageBody(buff: ByteArray, read: Int): Pair<Int, ByteArray> {
-        if (read < 5) throw Exception("Incomplete SASL message header")
-        val length = ByteBuffer.wrap(buff, 1, 4).int
-        // length counts itself but not the header byte, so it must be at least 4 and no larger than the
-        // bytes actually read. Comparing against read - 1 avoids the 1 + length overflow for a huge length.
-        if (length < 4 || length > read - 1) {
-            throw Exception("Invalid SASL message length $length")
-        }
-        return length to buff.copyOfRange(5, 1 + length)
-    }
-
-    private fun handleClientProof(buff: ByteArray, read: Int) {
-        val (length, body) = messageBody(buff, read)
+    private fun handleClientProof(length: Int, body: ByteArray) {
         val clientResp = SASLResponse.fromBytes(length, body)
         // Always run the full proof verification (PBKDF2 + HMAC) before deciding, so an unknown user and a
         // known user with a wrong password take the same time and cannot be told apart by an attacker

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/proxy/postgres/messages/Messages.kt
@@ -205,13 +205,6 @@ class TerminationMessage(header: Char = 'X', length: Int = 4, originalContent: B
     }
 }
 
-class MessageOrBytes(val message: ParsedMessage?, val bytes: ByteArray?, val response: ByteArray? = null)
-
-// todo: move MessageOrBytes.writableBytes() and MessageOrBytes.isTermination() to the class
-fun MessageOrBytes.writableBytes(): ByteArray = this.message?.toByteArray() ?: this.bytes!!
-
-fun MessageOrBytes.isTermination(): Boolean = this.message?.isTermination() ?: false
-
 class QueryMessage(
     override val header: Char = 'Q',
     override val length: Int,

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/TLSCertsConfigTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/TLSCertsConfigTest.kt
@@ -1,0 +1,45 @@
+package dev.kviklet.kviklet
+
+import dev.kviklet.kviklet.proxy.core.TlsCertEnvConfig
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+// KVI-183: @Value defaults written as "${...:null}" resolve to the literal string "null", not a null
+// reference. The null-checks in tlsCertificateFactory then pass and the factory proceeds to
+// File("null").readLines() / base64-decode "null" -- which, since the factory runs during eager proxy
+// bean creation, crashes the application at boot.
+class TLSCertsConfigTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withUserConfiguration(TLSCerts::class.java)
+
+    @Test
+    fun `unset TLS certificate properties resolve to real nulls, not the string null`() {
+        contextRunner.run { context ->
+            val config = context.getBean(TlsCertEnvConfig::class.java)
+            assertEquals("NONE", config.PROXY_TLS_CERTIFICATE_SOURCE)
+            assertNull(config.PROXY_TLS_CERTIFICATE_FILE)
+            assertNull(config.PROXY_TLS_CERTIFICATE_KEY_FILE)
+            assertNull(config.PROXY_TLS_CERTIFICATE_KEY)
+            assertNull(config.PROXY_TLS_CERTIFICATE_CERT)
+        }
+    }
+
+    @Test
+    fun `set TLS certificate properties are passed through unchanged`() {
+        contextRunner.withPropertyValues(
+            "proxy.tls_certificate_source=env",
+            "proxy.tls_certificate_cert=cert-data",
+            "proxy.tls_certificate_key=key-data",
+        ).run { context ->
+            val config = context.getBean(TlsCertEnvConfig::class.java)
+            assertEquals("env", config.PROXY_TLS_CERTIFICATE_SOURCE)
+            assertEquals("cert-data", config.PROXY_TLS_CERTIFICATE_CERT)
+            assertEquals("key-data", config.PROXY_TLS_CERTIFICATE_KEY)
+            assertNull(config.PROXY_TLS_CERTIFICATE_FILE)
+            assertNull(config.PROXY_TLS_CERTIFICATE_KEY_FILE)
+        }
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyConnectionLifecycleTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/MySqlProxyConnectionLifecycleTest.kt
@@ -14,6 +14,7 @@ import dev.kviklet.kviklet.service.dto.DatasourceType
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.params.ParameterizedTest
@@ -29,6 +30,7 @@ import org.testcontainers.utility.DockerImageName
 import java.net.Socket
 import java.sql.Connection
 import java.sql.DriverManager
+import java.sql.SQLException
 import java.util.Properties
 
 @SpringBootTest
@@ -86,13 +88,18 @@ class MySqlProxyConnectionLifecycleTest {
         startedProxies.clear()
     }
 
-    private fun startProxy(type: DatasourceType, handshakeTimeoutMs: Int = 10_000): MySqlProxyInstance {
+    private fun startProxy(
+        type: DatasourceType,
+        handshakeTimeoutMs: Int = 10_000,
+        maxConnectionsPerSession: Int = 15,
+    ): MySqlProxyInstance {
         val instance = mysqlProxyServerFactory(
             container(type),
             type,
             executionRequestAdapter,
             eventAdapter,
             handshakeTimeoutMs = handshakeTimeoutMs,
+            maxConnectionsPerSession = maxConnectionsPerSession,
         )
         startedProxies.add(instance.proxy)
         return instance
@@ -216,6 +223,34 @@ class MySqlProxyConnectionLifecycleTest {
         } finally {
             socket.close()
         }
+    }
+
+    // KVI-247 #5: a connection over the cap used to be silently closed after the client had fully
+    // authenticated (the MySQL handshake ends with an OK packet), so pools saw "connection reset" on
+    // first use. The slot is now reserved before the upstream connect, and a refusal is answered with a
+    // proper ERR packet (1040 Too many connections) the client reads on its first command.
+    @ParameterizedTest
+    @MethodSource("datasourceTypes")
+    fun `a connection over the per-session cap is refused with a too many connections error`(type: DatasourceType) {
+        val proxy = startProxy(type, maxConnectionsPerSession = 1)
+        val first = proxy.connect().also { openedConnections.add(it) }
+        first.createStatement().executeQuery("SELECT 1").close()
+
+        val thrown = assertThrows(SQLException::class.java) {
+            proxy.connect().use { conn ->
+                conn.createStatement().executeQuery("SELECT 1").close()
+            }
+        }
+        val messages = generateSequence<Throwable>(thrown) { it.cause }
+            .mapNotNull { it.message }
+            .joinToString(" | ")
+        assertTrue(
+            messages.contains("Too many connections"),
+            "expected a too-many-connections refusal, got: $messages",
+        )
+
+        // The refusal must not have damaged the connection that legitimately holds the slot.
+        first.createStatement().executeQuery("SELECT 1").close()
     }
 
     @ParameterizedTest

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyConnectionLifecycleTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyConnectionLifecycleTest.kt
@@ -9,12 +9,14 @@ import dev.kviklet.kviklet.proxy.helpers.directConnectionFactory
 import dev.kviklet.kviklet.proxy.helpers.proxyServerFactory
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.postgresql.core.PGStream
 import org.postgresql.core.QueryExecutorBase
 import org.postgresql.jdbc.PgConnection
+import org.postgresql.util.PSQLException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -208,6 +210,37 @@ class PostgresProxyConnectionLifecycleTest {
         } finally {
             shortProxy.proxy.shutdownServer()
             runCatching { shortProxy.connection.close() }
+        }
+    }
+
+    // KVI-247 #5: a connection over the cap used to be silently closed AFTER the client had fully
+    // authenticated and received ReadyForQuery, so pools saw "connection reset" on first use. The slot
+    // is now reserved before the client startup finishes, and a refusal is a proper 53300 ErrorResponse.
+    @Test
+    fun `a connection over the per-session cap is refused with a too_many_connections error`() {
+        val cappedProxy = proxyServerFactory(
+            postgresContainer,
+            executionRequestAdapter,
+            eventAdapter,
+            maxConnectionsPerSession = 1,
+        )
+        try {
+            // The factory's own connection occupies the single allowed slot.
+            cappedProxy.connection.createStatement().executeQuery("SELECT 1;").close()
+
+            val thrown = assertThrows(PSQLException::class.java) {
+                val props = Properties()
+                props.setProperty("user", "proxyUser")
+                props.setProperty("password", "proxyPassword")
+                DriverManager.getConnection(cappedProxy.connectionString, props).close()
+            }
+            assertEquals("53300", thrown.sqlState, "expected too_many_connections, got: ${thrown.message}")
+
+            // The refusal must not have damaged the connection that legitimately holds the slot.
+            cappedProxy.connection.createStatement().executeQuery("SELECT 1;").close()
+        } finally {
+            cappedProxy.proxy.shutdownServer()
+            runCatching { cappedProxy.connection.close() }
         }
     }
 

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyHandshakeDeadlineTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyHandshakeDeadlineTest.kt
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit
 class PostgresProxyHandshakeDeadlineTest {
 
     private val budgetMs = 1000
+
     // Well past the budget, but short enough that a slow abort (a per-read timeout instead of the total
     // deadline) is caught as a failure rather than hiding behind a generous margin.
     private val maxAcceptableMs = 4000L

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyHandshakeDeadlineTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxyHandshakeDeadlineTest.kt
@@ -1,0 +1,126 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.proxy.postgres.authenticateClient
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+// KVI-247 #6: the handshake budget (the caller's soTimeout) must bound the WHOLE handshake. A plain socket
+// timeout resets on every byte, so a slow-loris client dribbling one byte per interval would otherwise hold
+// a handshake slot indefinitely -- the deadline has to be re-checked before every read, including the
+// partial reads inside a frame and the SASL exchange.
+class PostgresProxyHandshakeDeadlineTest {
+
+    private val budgetMs = 1000
+    // Well past the budget, but short enough that a slow abort (a per-read timeout instead of the total
+    // deadline) is caught as a failure rather than hiding behind a generous margin.
+    private val maxAcceptableMs = 4000L
+
+    // Runs authenticateClient on a background thread the way ProxyServer does: budget as soTimeout.
+    private fun runHandshake(serverSide: Socket): CompletableFuture<Pair<Long, Throwable?>> {
+        val outcome = CompletableFuture<Pair<Long, Throwable?>>()
+        Thread {
+            val start = System.currentTimeMillis()
+            val thrown = runCatching {
+                serverSide.soTimeout = budgetMs
+                authenticateClient(serverSide, null, "placeholder-password") { null }
+            }.exceptionOrNull()
+            outcome.complete(Pair(System.currentTimeMillis() - start, thrown))
+        }.start()
+        return outcome
+    }
+
+    // Writes one byte per interval, stopping once the handshake thread has given up.
+    private fun dribble(socket: Socket, bytes: ByteArray, outcome: CompletableFuture<*>) {
+        val output = socket.getOutputStream()
+        for (byte in bytes) {
+            if (outcome.isDone) return
+            try {
+                output.write(byte.toInt())
+                output.flush()
+            } catch (e: Exception) {
+                return // the server side closed on us, which is the expected abort
+            }
+            Thread.sleep(100)
+        }
+    }
+
+    private fun assertAbortedOnDeadline(outcome: CompletableFuture<Pair<Long, Throwable?>>) {
+        val (elapsed, thrown) = outcome.get(30, TimeUnit.SECONDS)
+        assertNotNull(thrown, "expected the handshake to be aborted")
+        assertTrue(
+            thrown!!.message?.contains("deadline") == true,
+            "expected a deadline abort, got: ${thrown::class.simpleName}: ${thrown.message}",
+        )
+        assertTrue(
+            elapsed < maxAcceptableMs,
+            "handshake held its slot for ${elapsed}ms against a ${budgetMs}ms budget",
+        )
+    }
+
+    @Test
+    fun `a client dribbling its startup message byte by byte cannot outlast the handshake deadline`() {
+        ServerSocket(0).use { listener ->
+            Socket("localhost", listener.localPort).use { client ->
+                val serverSide = listener.accept()
+                val outcome = runHandshake(serverSide)
+                // Declare a 500-byte startup message but dribble only the first bytes of it, one every
+                // 100ms: each byte resets a plain per-read timeout, so only a re-checked total deadline
+                // ends this within the budget.
+                val frame = ByteBuffer.allocate(60)
+                frame.putInt(500)
+                frame.putInt(196608)
+                dribble(client, frame.array(), outcome)
+                assertAbortedOnDeadline(outcome)
+            }
+        }
+    }
+
+    @Test
+    fun `a client dribbling its SASL response byte by byte cannot outlast the handshake deadline`() {
+        ServerSocket(0).use { listener ->
+            Socket("localhost", listener.localPort).use { client ->
+                val serverSide = listener.accept()
+                val outcome = runHandshake(serverSide)
+
+                // Complete the startup phase promptly, so the dribbling happens inside the SASL exchange.
+                client.getOutputStream().apply {
+                    write(startupMessage("someUser"))
+                    flush()
+                }
+                client.soTimeout = 5000
+                client.getInputStream().read(ByteArray(64)) // the AuthenticationSASL request
+
+                // Declare a 200-byte SASL response, then dribble its first bytes one every 100ms.
+                val frame = ByteBuffer.allocate(40)
+                frame.put('p'.code.toByte())
+                frame.putInt(200)
+                frame.put("SCRAM-SHA-256".toByteArray(Charsets.UTF_8))
+                dribble(client, frame.array(), outcome)
+                assertAbortedOnDeadline(outcome)
+            }
+        }
+    }
+
+    private fun startupMessage(user: String): ByteArray {
+        val body = ByteArrayOutputStream()
+        body.write("user".toByteArray(Charsets.UTF_8))
+        body.write(0)
+        body.write(user.toByteArray(Charsets.UTF_8))
+        body.write(0)
+        body.write(0)
+        val bodyBytes = body.toByteArray()
+        val buffer = ByteBuffer.allocate(8 + bodyBytes.size)
+        buffer.putInt(8 + bodyBytes.size)
+        buffer.putInt(196608) // protocol 3.0
+        buffer.put(bodyBytes)
+        return buffer.array()
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxySASLAuthHandlerTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/PostgresProxySASLAuthHandlerTest.kt
@@ -1,0 +1,129 @@
+// This file is not MIT licensed
+package dev.kviklet.kviklet.proxy
+
+import dev.kviklet.kviklet.proxy.postgres.SASLAuthHandler
+import dev.kviklet.kviklet.proxy.postgres.hmacSha256
+import dev.kviklet.kviklet.proxy.postgres.pbkdf2
+import dev.kviklet.kviklet.proxy.postgres.sha256
+import dev.kviklet.kviklet.proxy.postgres.xorBytes
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.util.Base64
+
+// KVI-247 #2: the SASL exchange must not assume one read() delivers one whole frame. TCP can split a
+// valid login's SASL messages across segments, so the handler has to accumulate until the declared frame
+// length is satisfied -- the scripted client below delivers ONE byte per read to force the worst case.
+class PostgresProxySASLAuthHandlerTest {
+
+    // A complete SCRAM-SHA-256 client speaking against the handler's output buffer. It serves its two
+    // messages (SASLInitialResponse, then the client-final computed from the server-first the handler
+    // wrote) one byte per read() call, simulating maximal TCP fragmentation.
+    private class OneByteAtATimeScramClient(
+        private val password: String,
+        private val serverOutput: ByteArrayOutputStream,
+        private val clientNonce: String = "clientNonceABC123",
+    ) : InputStream() {
+        private var pending = clientFirstMessage()
+        private var offset = 0
+        private var finalSent = false
+
+        override fun read(): Int {
+            if (offset >= pending.size) {
+                if (finalSent) return -1
+                pending = clientFinalMessage()
+                offset = 0
+                finalSent = true
+            }
+            return pending[offset++].toInt() and 0xFF
+        }
+
+        // Deliver at most one byte no matter how large a buffer is offered.
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            val value = read()
+            if (value == -1) return -1
+            b[off] = value.toByte()
+            return 1
+        }
+
+        private fun clientFirstMessage(): ByteArray {
+            val saslData = "n,,n=,r=$clientNonce".toByteArray(Charsets.UTF_8)
+            val body = ByteArrayOutputStream()
+            body.write("SCRAM-SHA-256".toByteArray(Charsets.UTF_8))
+            body.write(0)
+            body.write(ByteBuffer.allocate(4).putInt(saslData.size).array())
+            body.write(saslData)
+            return saslMessage(body.toByteArray())
+        }
+
+        // By the time the client-first bytes are exhausted the handler has written its
+        // AuthenticationSASLContinue, so the server-first can be read back out of the output buffer.
+        private fun clientFinalMessage(): ByteArray {
+            val written = serverOutput.toByteArray()
+            assertEquals('R'.code.toByte(), written[0], "expected an authentication message from the handler")
+            assertEquals(11, ByteBuffer.wrap(written, 5, 4).int, "expected an AuthenticationSASLContinue")
+            val serverFirst = String(written, 9, written.size - 9, Charsets.UTF_8)
+
+            val fields = serverFirst.split(',').associate { it.substringBefore('=') to it.substringAfter('=') }
+            val combinedNonce = fields.getValue("r")
+            val salt = Base64.getDecoder().decode(fields.getValue("s"))
+            val iterations = fields.getValue("i").toInt()
+
+            val withoutProof = "c=biws,r=$combinedNonce"
+            val authMessage = "n=,r=$clientNonce,$serverFirst,$withoutProof"
+            val saltedPassword = pbkdf2(password, salt, iterations)
+            val clientKey = hmacSha256(saltedPassword, "Client Key")
+            val storedKey = sha256(clientKey)
+            val clientSignature = hmacSha256(storedKey, authMessage)
+            val proof = Base64.getEncoder().encodeToString(xorBytes(clientKey, clientSignature))
+            return saslMessage("$withoutProof,p=$proof".toByteArray(Charsets.UTF_8))
+        }
+
+        private fun saslMessage(body: ByteArray): ByteArray {
+            val message = ByteBuffer.allocate(5 + body.size)
+            message.put('p'.code.toByte())
+            message.putInt(4 + body.size)
+            message.put(body)
+            return message.array()
+        }
+    }
+
+    @Test
+    fun `a valid SASL exchange split into one-byte reads completes successfully`() {
+        val output = ByteArrayOutputStream()
+        val client = OneByteAtATimeScramClient("s3cretPassword", output)
+        val handler = SASLAuthHandler(output, client, "s3cretPassword", isUserValid = true)
+
+        handler.handle()
+
+        // After the continue message the handler must have written an AuthenticationSASLFinal.
+        val written = output.toByteArray()
+        val continueLength = 1 + ByteBuffer.wrap(written, 1, 4).int
+        assertTrue(written.size > continueLength, "expected a second message after the SASLContinue")
+        assertEquals('R'.code.toByte(), written[continueLength])
+        assertEquals(12, ByteBuffer.wrap(written, continueLength + 5, 4).int, "expected an AuthenticationSASLFinal")
+    }
+
+    @Test
+    fun `a wrong password still fails with a 28P01 error when the exchange is split into one-byte reads`() {
+        val output = ByteArrayOutputStream()
+        val client = OneByteAtATimeScramClient("wrongPassword", output)
+        val handler = SASLAuthHandler(output, client, "actualPassword", isUserValid = true)
+
+        val thrown = assertThrows(Exception::class.java) { handler.handle() }
+
+        assertTrue(
+            thrown.message?.contains("Authentication failed") == true,
+            "expected an authentication failure, got: ${thrown::class.simpleName}: ${thrown.message}",
+        )
+        // The last message written must be the ErrorResponse, not a bare connection reset.
+        val written = output.toByteArray()
+        val continueLength = 1 + ByteBuffer.wrap(written, 1, 4).int
+        assertEquals('E'.code.toByte(), written[continueLength], "expected an ErrorResponse after the proof")
+        assertTrue(String(written, Charsets.ISO_8859_1).contains("28P01"))
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/ProxyServerSessionReuseTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/ProxyServerSessionReuseTest.kt
@@ -29,6 +29,9 @@ class ProxyServerSessionReuseTest {
 
         override fun connect(authenticatedClient: AuthenticatedClient): ProxyConnection =
             throw UnsupportedOperationException("not used in registry tests")
+
+        override fun refuseOverCapacity(authenticatedClient: AuthenticatedClient) =
+            throw UnsupportedOperationException("not used in registry tests")
     }
 
     private val requestFactory = ExecutionRequestFactory()

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/TLSCertificateTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/TLSCertificateTest.kt
@@ -94,6 +94,20 @@ CJC2+PPy2deEXgREkGk/jpo=
     }
 
     @Test
+    fun `tlsCertificateFactory must return null instead of throwing when the certificate files are missing`() {
+        // A bad cert path must not propagate: the factory runs during eager proxy bean creation, so an
+        // uncaught FileNotFoundException would crash the whole application at boot.
+        val env = TlsCertEnvConfig("file", "/nonexistent/cert.pem", "/nonexistent/key.pem")
+        assert(tlsCertificateFactory(env) == null)
+    }
+
+    @Test
+    fun `tlsCertificateFactory must return null instead of throwing when the PEM content is malformed`() {
+        val env = TlsCertEnvConfig("env", null, null, "not-a-valid-key", "not-a-valid-cert")
+        assert(tlsCertificateFactory(env) == null)
+    }
+
+    @Test
     @Suppress("ktlint:standard:max-line-length")
     fun `preprocessPEMObject must remove lines with ----- and new lines`() {
         val expectedKey = """MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDOIyXVB4f0rBjysnbvXtVRXTO0GIojh52O7CnSRig8Ni7L46LFYGO+Ehj01Iwae0G9o5fw4tpgm3DPcQcx2I+vD2Z5YbCxCWkeZFW+M65D6diDEO/bH4rjWoP5KUU5r3VfA9qiMN3X6T7/nmIgTFi++TCE2earc3yltRTy8R9zPMnX0NyJrLdGhekEqwRmMigpAGVDOVSdXOAYeLWDMbuFBCQEZgdCW6vKhrcxjv2yuJ74AR/gf4dk50XgSmEKO/YmZHuCQifu683A93B3DuF9P9oEhYsblMAnfRmkWY7D9GY/2LPWhcvyTG49lFV1fZTdOwcQt2LYs3FeH4j7hdUxAgMBAAECggEAHEuu0cMq4mcNNaNRuCHoXjbQ9hO4QpBHDGtWgkqnEzzMx6gDm9xTVK/fRRw37xqkN4fRP3ukRkaQAameNzVm47zVcCv8uRB1oXpcWrN1ZFUhJzyX8BgwVG0EWJtVqUlwbw50YHccvJqDz0rKZWyVcgF6q4HNrBM6NPTaX07B5mteS5LYeoGmdn+bIPdIike2dgPLx2h8MiwH19r+if+qVESyo2cbuKjncCXFG7nslO3t0dqybcleeKknqO5jZrlYsd+7xcdf1t2u05cSd9qqPq1Y0OR9VerJMTZKGUBbrKVsDtfXLHy+cBo479xtGUMmSwRPRnRNfXdPi76DwxsyEQKBgQDOWwVLiTqK18upenFC/HUkokg7Zts9JU/1jq8fFn3GRB8R7Movg7zFf3LRrlGmL3MpVaC9XJpmGX571oEPAprozXZxYHGbqyzviyPimDuXqVZEBwWvIVf8WH69KTLGbRCLzunCMPKYYk0GDHLMFgRpVL4p88hTl/Ft3YKNzgXrvwKBgQD/uq9zBsKCQUBKrckFx4aVLWnpkge1C63tC7LeG7VQi7UuF1TWugy9vY3/po3PSvf6XUSaRwCrT4SN4KLWREdCEnU4h/Fl9F0ntQhP3VA2Uy8mQsilYp1REdNajx2JP/q2dr3TljXkiqEDgiNUn1Lvtiw1QFixor3F8rlzyig7DwKBgAiQfofECkn46tr92fWNxM7gbV8Jxc+j3M20PlBr/oxcB24XBc0zCoKn53wMYBcloQH2K9WwIjhaloVNQc39rbA71s6d0hlD4XmPrM2aw95niM0J/ZJnL9+pTJlNPG4/2I/05n7IyUjJy6iUm68cutIkUkArfgT6KWsF5oU8J8LBAoGBAPcRETMrg76+dfPwhLfNtkvoDVx5FnMm7omHdO87i+heodP+/JtcMrUaLtegvX9Zqc08UOxQzuezspg0QH6Mht/h31iXlnTvKxUSxQ4L/tQNeA8aFKocZWsOssjaXindI0cn32xNwpGkEb3G/IVkTIeF1J46JbaxSXG2eM/Srx2nAoGAC/rjYVJ+eDAKz867hTNu9fw+vdX1Yl/ph59oY851QeKxL7KMTb0FDLbrvfhBCiLAn4Xk0NUwhgRhCP80UDv/OirQUFE5QvnbBZ0BZeZGcz2lW62jzpvng5N6NwK2Nxm+qEdtLGJjjhfvy9iTX7p2CJC2+PPy2deEXgREkGk/jpo="""

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/MySqlFactories.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/MySqlFactories.kt
@@ -63,13 +63,19 @@ fun mysqlProxyServerFactory(
     handshakeTimeoutMs: Int = 10_000,
     username: String = "proxyUser",
     password: String = "proxyPassword",
+    maxConnectionsPerSession: Int = 15,
 ): MySqlProxyInstance {
     val connAuth = AuthenticationDetails.UserPassword("test", "test")
     val executionRequestFactory = ExecutionRequestFactory()
     val request = executionRequestFactory.createDatasourceExecutionRequest()
     val eventService = eventServiceOverride ?: EventServiceMock(executionRequestAdapter, eventAdapter, request)
     val port = (12000..20000).random()
-    val proxy = ProxyServer(port, MySqlProtocol(eventService, tlsCertificate), handshakeTimeoutMs)
+    val proxy = ProxyServer(
+        port,
+        MySqlProtocol(eventService, tlsCertificate),
+        handshakeTimeoutMs,
+        maxConnectionsPerSession,
+    )
     proxy.start()
     waitForProxyStart(proxy)
     proxy.registerSession(

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/PgFactories.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/proxy/helpers/PgFactories.kt
@@ -42,13 +42,19 @@ fun proxyServerFactory(
     tlsCertificate: TLSCertificate? = null,
     eventServiceOverride: EventServiceMock? = null,
     handshakeTimeoutMs: Int = 10_000,
+    maxConnectionsPerSession: Int = 15,
 ): ProxyInstance {
     val connAuth = AuthenticationDetails.UserPassword("test", "test")
     val executionRequestFactory = ExecutionRequestFactory()
     val request = executionRequestFactory.createDatasourceExecutionRequest()
     val eventService = eventServiceOverride ?: EventServiceMock(executionRequestAdapter, eventAdapter, request)
     val port = (12000..20000).random()
-    val proxy = ProxyServer(port, PostgresProtocol(eventService, tlsCertificate), handshakeTimeoutMs)
+    val proxy = ProxyServer(
+        port,
+        PostgresProtocol(eventService, tlsCertificate),
+        handshakeTimeoutMs,
+        maxConnectionsPerSession,
+    )
     proxy.start()
     waitForProxyStart(proxy)
     proxy.registerSession(


### PR DESCRIPTION
Fixes the remaining verified findings on the proxy stack:

- **TLS misconfiguration no longer crashes the app at boot.** `tlsCertificateFactory` runs during eager proxy bean creation; a bad cert path or malformed PEM now logs and runs without TLS instead of failing the whole ApplicationContext. The `${...:null}` @Value defaults (which injected the literal string `"null"` and triggered `File("null")`) are now SpEL `#{null}` on nullable fields.
- **SASL messages survive TCP splits.** The SASL handler read once per state and aborted valid logins whose frames spanned two segments; it now accumulates whole frames readFully-style like the rest of the proxy.
- **The handshake deadline is enforced through every read.** The budget is re-checked and the socket timeout re-shrunk before each partial read, including inside the SASL exchange, so a slow-loris client dribbling one byte per interval can no longer hold a handshake slot past the budget.
- **Over-cap connections get a proper protocol error.** The relay slot is reserved before the upstream connect and client startup finish; a refusal now answers with Postgres ErrorResponse 53300 / MySQL ERR 1040 instead of a silent TCP close after full authentication. The caps are constructor parameters so tests can exercise them.
- **Removed the dead `MessageOrBytes` indirection** — the relay iterates `ParsedMessage` directly.