### PR TITLE
Expose the database access proxies in the helm chart

### DIFF
--- a/charts/kviklet/Chart.yaml
+++ b/charts/kviklet/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 description: Helm Chart for kviklet
 name: kviklet
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: 0.7.0

--- a/charts/kviklet/Chart.yaml
+++ b/charts/kviklet/Chart.yaml
@@ -3,4 +3,4 @@ description: Helm Chart for kviklet
 name: kviklet
 type: application
 version: 0.3.0
-appVersion: 0.7.0
+appVersion: 0.8.0

--- a/charts/kviklet/README.md
+++ b/charts/kviklet/README.md
@@ -44,6 +44,35 @@ Any other configuration can be put into the same Secret as the database credenti
 
 If you think some config should be supported natively by the chart and not required as a secret, please open an issue or a PR.
 
+## Database access proxies (experimental)
+
+Kviklet can proxy PostgreSQL and MySQL/MariaDB connections so that approved sessions can be used from a regular database client. The listeners are enabled by default inside the pod (`config.proxy.postgres` on 5432, `config.proxy.mysql` on 3306) but are not exposed outside the pod unless you enable the dedicated proxy service:
+
+```yaml
+proxyService:
+  enabled: true
+  type: LoadBalancer # database clients speak raw TCP, an HTTP ingress cannot carry this traffic
+```
+
+To disable a listener entirely, set e.g. `config.proxy.mysql.enabled: false`.
+
+### TLS
+
+Without a certificate the proxies accept unencrypted connections only. To serve TLS, add the certificate to the same secret as the other environment variables:
+
+```yaml
+stringData:
+  PROXY_TLS_CERTIFICATE_SOURCE: "env"
+  PROXY_TLS_CERTIFICATE_CERT: |
+    -----BEGIN CERTIFICATE-----
+    ...
+  PROXY_TLS_CERTIFICATE_KEY: |
+    -----BEGIN PRIVATE KEY-----
+    ...
+```
+
+The certificate must match the DNS name under which database clients reach the proxy service, which is usually different from the hostname of the web UI.
+
 ## Example
 
 There is a [demo deployment on GCS](../kviklet-demo/README.md) that makes use of this base chart.

--- a/charts/kviklet/templates/configmap.yaml
+++ b/charts/kviklet/templates/configmap.yaml
@@ -18,8 +18,13 @@ data:
           console: {{ .Values.config.logging.structuredFormat | quote }}
     {{- end }}
 
-    {{- if .Values.config.oidc.enabled }}
     kviklet:
+      proxy:
+        postgres:
+          port: {{ if .Values.config.proxy.postgres.enabled }}{{ .Values.config.proxy.postgres.port }}{{ else }}-1{{ end }}
+        mysql:
+          port: {{ if .Values.config.proxy.mysql.enabled }}{{ .Values.config.proxy.mysql.port }}{{ else }}-1{{ end }}
+    {{- if .Values.config.oidc.enabled }}
       identityProvider:
         type: {{ .Values.config.oidc.provider | quote }}
         {{- if .Values.config.oidc.issuer }}

--- a/charts/kviklet/templates/deployment.yaml
+++ b/charts/kviklet/templates/deployment.yaml
@@ -36,6 +36,16 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if .Values.config.proxy.postgres.enabled }}
+            - name: pg-proxy
+              containerPort: {{ .Values.config.proxy.postgres.port }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.config.proxy.mysql.enabled }}
+            - name: mysql-proxy
+              containerPort: {{ .Values.config.proxy.mysql.port }}
+              protocol: TCP
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ .Values.externalSecretName | quote }}

--- a/charts/kviklet/templates/proxy-service.yaml
+++ b/charts/kviklet/templates/proxy-service.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.proxyService.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fullname" . }}-proxy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kviklet.metaLabels" . | nindent 4 }}
+  {{- with .Values.proxyService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.proxyService.type }}
+  ports:
+    {{- if .Values.config.proxy.postgres.enabled }}
+    - name: pg-proxy
+      protocol: TCP
+      port: {{ .Values.config.proxy.postgres.port }}
+      targetPort: pg-proxy
+    {{- end }}
+    {{- if .Values.config.proxy.mysql.enabled }}
+    - name: mysql-proxy
+      protocol: TCP
+      port: {{ .Values.config.proxy.mysql.port }}
+      targetPort: mysql-proxy
+    {{- end }}
+  selector:
+      {{- include "kviklet.selectorLabels" . | nindent 8 }}
+{{- end }}

--- a/charts/kviklet/values.yaml
+++ b/charts/kviklet/values.yaml
@@ -30,6 +30,19 @@ config:
       userOu: "people"
       searchBase: "ou=people"
 
+  # Database access proxies (experimental). Each enabled proxy binds a
+  # long-lived listener inside the pod at startup; disabling one skips the
+  # bind entirely. To make the listeners reachable by database clients, also
+  # enable proxyService below.
+  proxy:
+    postgres:
+      enabled: true
+      port: 5432
+    # One listener serves both MySQL and MariaDB.
+    mysql:
+      enabled: true
+      port: 3306
+
 # Name of the secret containing the kviklets configuration
 # See README.md or the demo deployment for examples
 externalSecretName: "kviklet-secret"
@@ -44,6 +57,16 @@ image:
 service:
   type: ClusterIP
   port: 80
+
+# Separate service exposing the database proxy listeners. Database clients
+# speak raw TCP (an HTTP ingress cannot carry this traffic), so this is
+# typically a LoadBalancer (or NodePort / an ingress controller with TCP
+# passthrough). Kept separate from the HTTP service above so that one can
+# stay ClusterIP behind an ingress.
+proxyService:
+  enabled: false
+  type: LoadBalancer
+  annotations: {}
 
 # -- Define resources for kviklet pods.
 # see https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources


### PR DESCRIPTION
Adds helm chart support for the new Postgres and MySQL/MariaDB proxy listeners:

- `config.proxy.postgres` / `config.proxy.mysql` values (enabled + port, both on by default matching the app defaults); a disabled proxy renders port `-1` into `application.yaml` so the listener never binds.
- Named containerPorts for the proxy listeners on the deployment.
- A new optional, separate `proxyService` (default `LoadBalancer`, off by default) so the proxy TCP ports can be exposed independently of the HTTP service, which typically stays ClusterIP behind an ingress.
- README section covering exposure (raw TCP, so no HTTP ingress) and TLS certificate configuration via the existing secret, including the note that the cert has to match the DNS name of the proxy service rather than the web UI.
- Chart version bump to 0.3.0.