### PR TITLE
Resolve demo chart dependency at deploy time instead of from a committed lock

### DIFF
--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Deploy Demo Chart
         run: |
           cd charts/kviklet-demo
-          helm dependency build
+          helm dependency update
           helm upgrade --install kviklet-demo . \
             --namespace kviklet \
             --create-namespace \

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ lib
 *.tgz
 .idea
 .aider*.DS_Store
+charts/kviklet-demo/Chart.lock

--- a/charts/kviklet-demo/Chart.lock
+++ b/charts/kviklet-demo/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: kviklet
-  repository: file://../kviklet
-  version: 0.2.0
-digest: sha256:dd209083aecdd05fc60a088d85a0a8740c2fc8bea1e65a602bd2c1f46a6bb7a3
-generated: "2026-08-09T03:20:28.347237+02:00"


### PR DESCRIPTION
The demo chart's `Chart.lock` pinned kviklet 0.2.0, so the chart bump in #557 broke the Deploy Demo job with `can't get a valid version for dependency kviklet`. Every future chart bump would have needed the lock regenerated by hand.

- Remove `charts/kviklet-demo/Chart.lock` and gitignore it
- Deploy workflow runs `helm dependency update` instead of `helm dependency build`, resolving from the `>=0.1.0` range in `Chart.yaml`