### PR TITLE
Show rejected temporary access sessions as rejected instead of expired

### DIFF
--- a/frontend/src/routes/Requests.test.ts
+++ b/frontend/src/routes/Requests.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach, MockedFunction } from "vitest";
-import { useRequests } from "./Requests";
+import { mapStatus, useRequests } from "./Requests";
 import {
   ExecutionRequestResponse,
   getRequestsPaginated,
@@ -40,6 +40,30 @@ const listResponse = (
   hasMore = false,
   cursor: Date | null = null,
 ): ListResult => ({ requests, hasMore, cursor }) as ListResult;
+
+describe("mapStatus", () => {
+  it("labels a temporary access window that ran out as expired", () => {
+    expect(mapStatus("APPROVED", "EXECUTED", "TemporaryAccess")).toBe(
+      "Expired",
+    );
+  });
+  it("labels a rejected temporary access session as rejected, not expired", () => {
+    // The backend closes a running session on rejection and reports it EXECUTED.
+    expect(mapStatus("REJECTED", "EXECUTED", "TemporaryAccess")).toBe(
+      "Rejected",
+    );
+  });
+  it("labels a rejected temporary access request that never started as rejected", () => {
+    expect(mapStatus("REJECTED", "EXECUTABLE", "TemporaryAccess")).toBe(
+      "Rejected",
+    );
+  });
+  it("labels an executed statement as executed", () => {
+    expect(mapStatus("APPROVED", "EXECUTED", "SingleExecution")).toBe(
+      "Executed",
+    );
+  });
+});
 
 describe("useRequests hook", () => {
   beforeEach(() => {

--- a/frontend/src/routes/Requests.tsx
+++ b/frontend/src/routes/Requests.tsx
@@ -57,11 +57,13 @@ function mapStatus(
 ) {
   if (reviewStatus === "AWAITING_APPROVAL" && executionStatus !== "EXECUTED")
     return "Pending";
-  // A temporary access window that has run out was not "executed" in the
-  // single-statement sense; it simply closed.
-  else if (executionStatus === "EXECUTED")
-    return type === "TemporaryAccess" ? "Expired" : "Executed";
-  else if (executionStatus === "ACTIVE") return "Active";
+  else if (executionStatus === "EXECUTED") {
+    if (type !== "TemporaryAccess") return "Executed";
+    // A temporary access window that has run out was not "executed" in the
+    // single-statement sense; it simply closed. A rejection closes a running
+    // session the same way, and then the rejection is the state that matters.
+    return reviewStatus === "REJECTED" ? "Rejected" : "Expired";
+  } else if (executionStatus === "ACTIVE") return "Active";
   else if (reviewStatus === "CHANGE_REQUESTED") return "Change Requested";
   else if (reviewStatus === "REJECTED") return "Rejected";
   else if (executionStatus === "EXECUTABLE") return "Ready";

--- a/frontend/src/routes/Review/sessionAccess.test.ts
+++ b/frontend/src/routes/Review/sessionAccess.test.ts
@@ -56,6 +56,31 @@ describe("temporary access window", () => {
     expect(access.expired).toBe(true);
     expect(access.label).toBe(`Expired at ${time(start + 60 * 60_000)}`);
   });
+  it("ends at the rejection time when a running session is rejected", () => {
+    const rejectedAt = start + 10 * 60_000;
+    const access = sessionAccess(
+      {
+        ...request,
+        reviewStatus: "REJECTED",
+        executionStatus: "EXECUTED",
+        events: [
+          execution(start),
+          {
+            _type: "REVIEW",
+            type: "REVIEW",
+            id: "reject",
+            comment: "",
+            action: "REJECT",
+            createdAt: new Date(rejectedAt),
+          },
+        ],
+      },
+      [],
+      rejectedAt + 60_000,
+    );
+    expect(access.expired).toBe(true);
+    expect(access.label).toBe(`Ended at ${time(rejectedAt)}`);
+  });
   it("honors a server-reported expiry even without execution history", () => {
     expect(
       sessionAccess({ ...request, executionStatus: "EXECUTED" }, [], start),

--- a/frontend/src/routes/Review/sessionAccess.ts
+++ b/frontend/src/routes/Review/sessionAccess.ts
@@ -32,6 +32,22 @@ export function sessionAccess(
     request.executionStatus === "EXECUTED" ||
     (expiresAt !== undefined && now >= expiresAt);
   if (expired) {
+    // Rejecting a running session ends it before its deadline, so the deadline
+    // never came and would read as a time in the future.
+    const rejection = request.events.find(
+      (event) => event._type === "REVIEW" && event.action === "REJECT",
+    );
+    if (
+      rejection !== undefined &&
+      firstExecution !== undefined &&
+      (expiresAt === undefined || rejection.createdAt.getTime() < expiresAt)
+    ) {
+      return {
+        expired,
+        expiresAt,
+        label: `Ended at ${formatTime(rejection.createdAt.getTime())}`,
+      };
+    }
     return {
       expired,
       expiresAt,


### PR DESCRIPTION
Since #562 the backend closes a running temporary access session when the request is rejected and reports it as `EXECUTED`. The frontend mapped every `EXECUTED` temporary access request to "Expired", so a rejected session showed up as expired in the request list and in the review sidebar, and the sidebar's access line could say "Expired at" a time that was still in the future.

- The status pill now shows "Rejected" for a rejected temporary access request, whether or not the session had already started.
- The sidebar access line shows "Ended at <rejection time>" for a session that was rejected while running, instead of the deadline it never reached.

Adds unit tests for the status mapping and the access window label.