### PR TITLE
Show rejected temporary access requests as Rejected

### DIFF
--- a/frontend/src/routes/Requests.test.ts
+++ b/frontend/src/routes/Requests.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach, MockedFunction } from "vitest";
-import { useRequests } from "./Requests";
+import { mapStatus, useRequests } from "./Requests";
 import {
   ExecutionRequestResponse,
   getRequestsPaginated,
@@ -40,6 +40,30 @@ const listResponse = (
   hasMore = false,
   cursor: Date | null = null,
 ): ListResult => ({ requests, hasMore, cursor }) as ListResult;
+
+describe("request status labels", () => {
+  it.each(["EXECUTABLE", "ACTIVE", "EXECUTED"])(
+    "shows rejected temporary access as Rejected when execution status is %s",
+    (executionStatus) => {
+      expect(mapStatus("REJECTED", executionStatus, "TemporaryAccess")).toBe(
+        "Rejected",
+      );
+    },
+  );
+
+  it.each([
+    ["ACTIVE", "Active"],
+    ["EXECUTED", "Expired"],
+    ["EXECUTABLE", "Ready"],
+  ])(
+    "keeps approved temporary access %s labeled %s",
+    (executionStatus, label) => {
+      expect(mapStatus("APPROVED", executionStatus, "TemporaryAccess")).toBe(
+        label,
+      );
+    },
+  );
+});
 
 describe("useRequests hook", () => {
   beforeEach(() => {

--- a/frontend/src/routes/Requests.tsx
+++ b/frontend/src/routes/Requests.tsx
@@ -55,6 +55,7 @@ function mapStatus(
   executionStatus: string,
   type?: string,
 ) {
+  if (reviewStatus === "REJECTED") return "Rejected";
   if (reviewStatus === "AWAITING_APPROVAL" && executionStatus !== "EXECUTED")
     return "Pending";
   // A temporary access window that has run out was not "executed" in the
@@ -63,7 +64,6 @@ function mapStatus(
     return type === "TemporaryAccess" ? "Expired" : "Executed";
   else if (executionStatus === "ACTIVE") return "Active";
   else if (reviewStatus === "CHANGE_REQUESTED") return "Change Requested";
-  else if (reviewStatus === "REJECTED") return "Rejected";
   else if (executionStatus === "EXECUTABLE") return "Ready";
   else return "Unknown";
 }


### PR DESCRIPTION
Rejected temporary access requests could display as Active or Expired because execution status took precedence over rejection. Show Rejected consistently in the request list and detail sidebar, with regression coverage for every execution status and unchanged approved-session labels.
