### PR TITLE
Return to the originally requested page after login

### DIFF
--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/LoginRedirectTargetFilter.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/LoginRedirectTargetFilter.kt
@@ -1,0 +1,65 @@
+package dev.kviklet.kviklet.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * Remembers which page the user wanted to open before an SSO login.
+ *
+ * The frontend starts OIDC and SAML logins with a top-level navigation to
+ * /oauth2/authorization/{id} or /saml2/authenticate/{id}, so it cannot keep state of its
+ * own across the round trip to the identity provider. It passes the page to return to as
+ * a `redirect` query parameter instead; this filter stores it in the HTTP session and the
+ * login success handlers redirect there afterwards (see [consume]).
+ *
+ * Both of Spring's login flows already rely on the session surviving the round trip (the
+ * pending authorization request lives there), so the target is at least as durable as the
+ * login itself. Only relative paths are accepted; anything that could point off-site is
+ * dropped so the login can't be turned into an open redirector.
+ */
+class LoginRedirectTargetFilter : OncePerRequestFilter() {
+
+    companion object {
+        const val REDIRECT_PARAM = "redirect"
+        const val SESSION_ATTRIBUTE = "kviklet.loginRedirectTarget"
+        private const val MAX_LENGTH = 2048
+
+        private val loginStartPrefixes = listOf("/oauth2/authorization/", "/saml2/authenticate/")
+
+        /** The target as a path relative to the frontend origin, or null if it is unusable. */
+        fun sanitize(target: String?): String? {
+            if (target.isNullOrEmpty() || target.length > MAX_LENGTH) return null
+            // "//host" and "/\host" are treated as protocol-relative URLs by browsers.
+            if (!target.startsWith("/") || target.startsWith("//") || target.startsWith("/\\")) return null
+            if (target.any { it.isISOControl() }) return null
+            return target
+        }
+
+        /** Returns the stored target and forgets it, so it applies to exactly one login. */
+        fun consume(request: HttpServletRequest): String? {
+            val session = request.getSession(false) ?: return null
+            val target = session.getAttribute(SESSION_ATTRIBUTE) as? String
+            if (target != null) session.removeAttribute(SESSION_ATTRIBUTE)
+            return target
+        }
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        if (request.method == "GET" && loginStartPrefixes.any { request.requestURI.startsWith(it) }) {
+            val target = sanitize(request.getParameter(REDIRECT_PARAM))
+            if (target != null) {
+                request.getSession(true).setAttribute(SESSION_ATTRIBUTE, target)
+            } else {
+                // A login started without a target must not pick up one left behind earlier.
+                request.getSession(false)?.removeAttribute(SESSION_ATTRIBUTE)
+            }
+        }
+        filterChain.doFilter(request, response)
+    }
+}

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/SecurityConfig.kt
@@ -42,6 +42,7 @@ import org.springframework.security.ldap.authentication.BindAuthenticator
 import org.springframework.security.ldap.authentication.LdapAuthenticationProvider
 import org.springframework.security.ldap.search.FilterBasedLdapUserSearch
 import org.springframework.security.ldap.userdetails.UserDetailsContextMapper
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.access.AccessDeniedHandler
@@ -187,6 +188,9 @@ class SecurityConfig(
             // Don't add ApiKeyAuthFilter here - it's handled by the API key chain
             addFilterBefore<WebAsyncManagerIntegrationFilter>(ForwardedHeaderFilter())
             addFilterBefore<UsernamePasswordAuthenticationFilter>(CsrfHeaderFilter())
+            // Must run before the OAuth2 and SAML filters that start the SSO redirect (the
+            // SAML one is ordered right after the OAuth2 one in Spring's filter order).
+            addFilterBefore<OAuth2AuthorizationRequestRedirectFilter>(LoginRedirectTargetFilter())
             if (corsSettings.allowedOrigins.isNotEmpty()) {
                 cors { }
             }

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/oidc/OidcLoginSuccessHandler.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/oidc/OidcLoginSuccessHandler.kt
@@ -1,6 +1,7 @@
 package dev.kviklet.kviklet.security.oidc
 
 import dev.kviklet.kviklet.security.KvikletOAuthPrincipal
+import dev.kviklet.kviklet.security.LoginRedirectTargetFilter
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.transaction.Transactional
@@ -32,8 +33,9 @@ class OidcLoginSuccessHandler : SimpleUrlAuthenticationSuccessHandler() {
         }
 
         val baseUrl = request?.let { getBaseUrl(it) }
-        val redirectUrl = "$baseUrl/requests"
-        redirectStrategy.sendRedirect(request, response, redirectUrl)
+        // Back to the page that sent the user to the login, or the frontend's index page.
+        val target = request?.let { LoginRedirectTargetFilter.consume(it) } ?: "/"
+        redirectStrategy.sendRedirect(request, response, "$baseUrl$target")
     }
 
     private fun getBaseUrl(request: HttpServletRequest): String {

--- a/backend/src/main/kotlin/dev/kviklet/kviklet/security/saml/SamlLoginSuccessHandler.kt
+++ b/backend/src/main/kotlin/dev/kviklet/kviklet/security/saml/SamlLoginSuccessHandler.kt
@@ -1,6 +1,7 @@
 // This file is not MIT licensed
 package dev.kviklet.kviklet.security.saml
 
+import dev.kviklet.kviklet.security.LoginRedirectTargetFilter
 import dev.kviklet.kviklet.security.PolicyGrantedAuthority
 import dev.kviklet.kviklet.security.UserDetailsWithId
 import jakarta.servlet.http.HttpServletRequest
@@ -60,8 +61,9 @@ class SamlLoginSuccessHandler(private val samlUserService: SamlUserService) :
         }
 
         val baseUrl = getBaseUrl(request)
-        val redirectUrl = "$baseUrl/requests"
-        redirectStrategy.sendRedirect(request, response, redirectUrl)
+        // Back to the page that sent the user to the login, or the frontend's index page.
+        val target = LoginRedirectTargetFilter.consume(request) ?: "/"
+        redirectStrategy.sendRedirect(request, response, "$baseUrl$target")
     }
 
     private fun getBaseUrl(request: HttpServletRequest): String {

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/OIDCTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/OIDCTest.kt
@@ -5,6 +5,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlInput
 import com.gargoylesoftware.htmlunit.html.HtmlPage
 import dev.kviklet.kviklet.db.User
 import dev.kviklet.kviklet.db.UserAdapter
+import dev.kviklet.kviklet.helper.FrontendStub
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -118,7 +119,7 @@ class OIDCTest {
             try {
                 val returnPage = appPage.getElementsByTagName("button").get(0).click<HtmlPage>()
                 // Assert it redirect to the app on successful login
-                assertThat(returnPage.url.toString()).isEqualTo("http://localhost:5173/requests")
+                assertThat(returnPage.url.toString()).isEqualTo("http://localhost:5173/")
             } catch (e: Exception) {
                 // If the frontend hasn't started this exception is expected but the redirect worked
                 assertThat(e.message).contains("HttpHostConnectException: Connect to localhost:5173")
@@ -130,6 +131,63 @@ class OIDCTest {
 
         // Assert that a new user was created
         assertThat(userAdapter.listUsers().size).isEqualTo(userCountBeforeOIDC + 1)
+    }
+
+    @Test
+    fun `OIDC login returns to the page that was requested before the login`() {
+        val webClient = WebClient().apply {
+            options.apply {
+                isRedirectEnabled = true
+                isJavaScriptEnabled = false
+                isThrowExceptionOnScriptError = false
+                isUseInsecureSSL = true
+                isCssEnabled = false
+            }
+        }
+        val frontend = FrontendStub(webClient)
+
+        try {
+            // The frontend appends the page to return to when it links to the login start.
+            val loginUrl = "http://localhost:$port/oauth2/authorization/dex?redirect=%2Frequests%2Fabc%3Ftab%3Dcomments"
+
+            val dexLoginPage = webClient.getPage<HtmlPage>(loginUrl)
+            dexLoginPage.getElementByName<HtmlInput>("login").type("admin@example.com")
+            dexLoginPage.getElementByName<HtmlInput>("password").type("password")
+            val appPage = dexLoginPage.getElementById("submit-login").click<HtmlPage>()
+            appPage.getElementsByTagName("button").get(0).click<HtmlPage>()
+
+            assertThat(frontend.lastFrontendUrl).isEqualTo("http://localhost:5173/requests/abc?tab=comments")
+        } finally {
+            webClient.close()
+        }
+    }
+
+    @Test
+    fun `OIDC login drops redirect targets that point off-site`() {
+        val webClient = WebClient().apply {
+            options.apply {
+                isRedirectEnabled = true
+                isJavaScriptEnabled = false
+                isThrowExceptionOnScriptError = false
+                isUseInsecureSSL = true
+                isCssEnabled = false
+            }
+        }
+        val frontend = FrontendStub(webClient)
+
+        try {
+            val loginUrl = "http://localhost:$port/oauth2/authorization/dex?redirect=%2F%2Fevil.example%2Fphish"
+
+            val dexLoginPage = webClient.getPage<HtmlPage>(loginUrl)
+            dexLoginPage.getElementByName<HtmlInput>("login").type("admin@example.com")
+            dexLoginPage.getElementByName<HtmlInput>("password").type("password")
+            val appPage = dexLoginPage.getElementById("submit-login").click<HtmlPage>()
+            appPage.getElementsByTagName("button").get(0).click<HtmlPage>()
+
+            assertThat(frontend.lastFrontendUrl).isEqualTo("http://localhost:5173/")
+        } finally {
+            webClient.close()
+        }
     }
 
     @Test
@@ -175,7 +233,7 @@ class OIDCTest {
             try {
                 val returnPage = appPage.getElementsByTagName("button").get(0).click<HtmlPage>()
                 // Assert it redirect to the app on successful login
-                assertThat(returnPage.url.toString()).isEqualTo("http://localhost:5173/requests")
+                assertThat(returnPage.url.toString()).isEqualTo("http://localhost:5173/")
             } catch (e: Exception) {
                 // If the frontend hasn't started this exception is expected but the redirect worked
                 assertThat(e.message).contains("HttpHostConnectException: Connect to localhost:5173")
@@ -235,7 +293,7 @@ class OIDCTest {
             try {
                 val returnPage = appPage.getElementsByTagName("button").get(0).click<HtmlPage>()
                 // Assert it redirect to the app on successful login
-                assertThat(returnPage.url.toString()).isEqualTo("http://localhost:5173/requests")
+                assertThat(returnPage.url.toString()).isEqualTo("http://localhost:5173/")
             } catch (e: Exception) {
                 // If the frontend hasn't started this exception is expected but the redirect worked
                 assertThat(e.message).contains("HttpHostConnectException: Connect to localhost:5173")

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/SAMLTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/SAMLTest.kt
@@ -7,6 +7,7 @@ import dev.kviklet.kviklet.db.LicenseAdapter
 import dev.kviklet.kviklet.db.RoleAdapter
 import dev.kviklet.kviklet.db.RoleSyncConfigAdapter
 import dev.kviklet.kviklet.db.UserAdapter
+import dev.kviklet.kviklet.helper.FrontendStub
 import dev.kviklet.kviklet.service.dto.LicenseFile
 import dev.kviklet.kviklet.service.dto.Role
 import dev.kviklet.kviklet.service.dto.RoleId
@@ -491,6 +492,48 @@ class SAMLTest {
         assertThat(createdUser?.samlNameId).isNotNull()
         assertThat(createdUser?.fullName).isNotNull()
         assertThat(createdUser?.password).isNull()
+    }
+
+    @Test
+    fun `SAML login returns to the page that was requested before the login`() {
+        val webClient = WebClient().apply {
+            options.apply {
+                isRedirectEnabled = true
+                isJavaScriptEnabled = false
+                isThrowExceptionOnScriptError = false
+                isUseInsecureSSL = true
+                isCssEnabled = false
+            }
+        }
+        val frontend = FrontendStub(webClient)
+
+        try {
+            // The frontend appends the page to return to when it links to the login start.
+            val loginUrl = "http://localhost:$port/saml2/authenticate/saml?redirect=%2Fsettings%2Fusers"
+
+            val samlRedirectPage = webClient.getPage<HtmlPage>(loginUrl)
+            val keycloakLoginPage = samlRedirectPage.forms[0].getElementsByTagName("input")
+                .filterIsInstance<HtmlInput>()
+                .find { it.getAttribute("type") == "submit" }
+                ?.click<HtmlPage>() ?: throw RuntimeException("Could not find submit button in SAML form")
+
+            (keycloakLoginPage.getElementById("username") as HtmlInput).type("testuser")
+            (keycloakLoginPage.getElementById("password") as HtmlInput).type("testpass")
+            val redirectPage = keycloakLoginPage.getElementsByTagName("input")
+                .filterIsInstance<HtmlInput>()
+                .find { it.getAttribute("type") == "submit" }
+                ?.click<HtmlPage>() ?: throw RuntimeException("Could not find submit button on Keycloak page")
+
+            // Keycloak answers with a self-submitting form carrying the SAML response.
+            if (redirectPage.asXml().contains("Authentication Redirect")) {
+                val inputs = redirectPage.forms[0].getElementsByTagName("input").filterIsInstance<HtmlInput>()
+                (inputs.find { it.getAttribute("type") == "submit" } ?: inputs[0]).click<HtmlPage>()
+            }
+
+            assertThat(frontend.lastFrontendUrl).isEqualTo("http://localhost:5173/settings/users")
+        } finally {
+            webClient.close()
+        }
     }
 
     @Test

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/helper/FrontendStub.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/helper/FrontendStub.kt
@@ -1,0 +1,32 @@
+package dev.kviklet.kviklet.helper
+
+import com.gargoylesoftware.htmlunit.WebClient
+import com.gargoylesoftware.htmlunit.WebRequest
+import com.gargoylesoftware.htmlunit.WebResponse
+import com.gargoylesoftware.htmlunit.WebResponseData
+import com.gargoylesoftware.htmlunit.util.NameValuePair
+import com.gargoylesoftware.htmlunit.util.WebConnectionWrapper
+
+/**
+ * Answers requests to the frontend dev server (localhost:5173) with an empty page, so the
+ * final redirect of an SSO login can be asserted without a running frontend. Installs itself
+ * as the client's connection.
+ */
+class FrontendStub(webClient: WebClient) : WebConnectionWrapper(webClient) {
+
+    var lastFrontendUrl: String? = null
+
+    override fun getResponse(request: WebRequest): WebResponse {
+        if (request.url.port == 5173) {
+            lastFrontendUrl = request.url.toString()
+            val data = WebResponseData(
+                "<html><body></body></html>".toByteArray(),
+                200,
+                "OK",
+                listOf(NameValuePair("Content-Type", "text/html")),
+            )
+            return WebResponse(data, request, 0)
+        }
+        return super.getResponse(request)
+    }
+}

--- a/backend/src/test/kotlin/dev/kviklet/kviklet/security/LoginRedirectTargetFilterTest.kt
+++ b/backend/src/test/kotlin/dev/kviklet/kviklet/security/LoginRedirectTargetFilterTest.kt
@@ -1,0 +1,111 @@
+package dev.kviklet.kviklet.security
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+class LoginRedirectTargetFilterTest {
+
+    private val filter = LoginRedirectTargetFilter()
+
+    private fun run(request: MockHttpServletRequest): MockHttpServletRequest {
+        val chain = MockFilterChain()
+        filter.doFilter(request, MockHttpServletResponse(), chain)
+        assertThat(chain.request).describedAs("filter passes the request on").isNotNull()
+        return request
+    }
+
+    private fun storedTarget(request: MockHttpServletRequest): String? =
+        request.getSession(false)?.getAttribute(LoginRedirectTargetFilter.SESSION_ATTRIBUTE) as String?
+
+    @Test
+    fun `stores the target when an oauth2 login is started`() {
+        val request = MockHttpServletRequest("GET", "/oauth2/authorization/google")
+        request.addParameter("redirect", "/requests/abc?tab=comments#top")
+
+        run(request)
+
+        assertThat(storedTarget(request)).isEqualTo("/requests/abc?tab=comments#top")
+    }
+
+    @Test
+    fun `stores the target when a saml login is started`() {
+        val request = MockHttpServletRequest("GET", "/saml2/authenticate/saml")
+        request.addParameter("redirect", "/settings/users")
+
+        run(request)
+
+        assertThat(storedTarget(request)).isEqualTo("/settings/users")
+    }
+
+    @Test
+    fun `ignores the parameter on other endpoints`() {
+        val request = MockHttpServletRequest("GET", "/status")
+        request.addParameter("redirect", "/settings/users")
+
+        run(request)
+
+        assertThat(request.getSession(false)).isNull()
+    }
+
+    @Test
+    fun `does not create a session without a target`() {
+        val request = MockHttpServletRequest("GET", "/oauth2/authorization/google")
+
+        run(request)
+
+        assertThat(request.getSession(false)).isNull()
+    }
+
+    @Test
+    fun `a login without a target forgets an earlier one`() {
+        val request = MockHttpServletRequest("GET", "/oauth2/authorization/google")
+        request.getSession(true)!!.setAttribute(LoginRedirectTargetFilter.SESSION_ATTRIBUTE, "/settings/users")
+
+        run(request)
+
+        assertThat(storedTarget(request)).isNull()
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "https://evil.example/requests",
+            "//evil.example/requests",
+            "/\\evil.example",
+            "requests/abc",
+            "javascript:alert(1)",
+            "/requests\r\nSet-Cookie: x=y",
+            "",
+        ],
+    )
+    fun `drops targets that could leave the site`(target: String) {
+        val request = MockHttpServletRequest("GET", "/oauth2/authorization/google")
+        request.addParameter("redirect", target)
+
+        run(request)
+
+        assertThat(storedTarget(request)).isNull()
+    }
+
+    @Test
+    fun `consume returns the target once`() {
+        val request = MockHttpServletRequest()
+        request.getSession(true)!!.setAttribute(LoginRedirectTargetFilter.SESSION_ATTRIBUTE, "/new")
+
+        assertThat(LoginRedirectTargetFilter.consume(request)).isEqualTo("/new")
+        assertThat(LoginRedirectTargetFilter.consume(request)).isNull()
+    }
+
+    @Test
+    fun `consume does not create a session`() {
+        val request = MockHttpServletRequest()
+
+        assertThat(LoginRedirectTargetFilter.consume(request)).isNull()
+        assertThat(request.getSession(false)).isNull()
+    }
+}

--- a/e2e/tests/e2e.spec.ts
+++ b/e2e/tests/e2e.spec.ts
@@ -7,6 +7,22 @@ import {
   SettingsPage,
 } from "./pages";
 
+test.describe("Login redirect", () => {
+  test("Opening a page while logged out returns there after login", async ({
+    page,
+  }) => {
+    await page.goto("/settings/users");
+    await page.waitForURL(/\/login\?redirect=/);
+
+    await page.getByTestId("email-input").fill("admin@admin.com");
+    await page.getByTestId("password-input").fill("admin");
+    await page.getByTestId("login-button").click();
+
+    await expect(page).toHaveURL(/\/settings\/users$/);
+    await expect(page.getByTestId("user-admin@admin.com")).toBeVisible();
+  });
+});
+
 test.describe("E2E Tests for Multiple Databases", () => {
   let loginPage: LoginPage;
   let settingsPage: SettingsPage;
@@ -95,7 +111,7 @@ test.describe("E2E Tests for Multiple Databases", () => {
           db.host,
           db.port,
           db.database,
-          db.additionalOptions
+          db.additionalOptions,
         );
         // Verify the connection appears in the table
         await expect(page.locator(`text=${connectionName}`)).toBeVisible();
@@ -106,12 +122,12 @@ test.describe("E2E Tests for Multiple Databases", () => {
           connectionName,
           requestName,
           `Testing ${db.name} connection`,
-          db.testQuery
+          db.testQuery,
         );
         // Creating a request lands on its detail page
         await page.waitForURL("**/requests/*");
         await expect(
-          page.getByRole("heading", { name: requestName })
+          page.getByRole("heading", { name: requestName }),
         ).toBeVisible();
       });
 
@@ -126,14 +142,12 @@ test.describe("E2E Tests for Multiple Databases", () => {
         await requestsPage.createSession(
           connectionName,
           liveSessionName,
-          `Testing ${db.name} live session`
+          `Testing ${db.name} live session`,
         );
         // The connection requires no reviews, so the session editor is
         // ready right on the new request's page
         await page.waitForURL("**/requests/*");
-        await expect(
-          page.getByTestId("monaco-editor-wrapper")
-        ).toBeVisible();
+        await expect(page.getByTestId("monaco-editor-wrapper")).toBeVisible();
       });
 
       test(`Execute ${db.name} Live Session`, async ({ page }) => {
@@ -182,9 +196,9 @@ test.describe("Kubernetes Connection Timeout Settings", () => {
     await expect(
       page.getByTestId("kubernetes-exec-initial-wait-timeout-seconds"),
     ).toHaveValue("5");
-    await expect(page.getByTestId("kubernetes-exec-timeout-minutes")).toHaveValue(
-      "60",
-    );
+    await expect(
+      page.getByTestId("kubernetes-exec-timeout-minutes"),
+    ).toHaveValue("60");
 
     // Update values
     await page
@@ -203,9 +217,9 @@ test.describe("Kubernetes Connection Timeout Settings", () => {
     await expect(
       page.getByTestId("kubernetes-exec-initial-wait-timeout-seconds"),
     ).toHaveValue("2");
-    await expect(page.getByTestId("kubernetes-exec-timeout-minutes")).toHaveValue(
-      "30",
-    );
+    await expect(
+      page.getByTestId("kubernetes-exec-timeout-minutes"),
+    ).toHaveValue("30");
   });
 });
 
@@ -238,7 +252,7 @@ test.describe("User Management Tests", () => {
     await settingsPage.addUser(
       "Developer Account",
       "developer@example.com",
-      "developerpass"
+      "developerpass",
     );
     await settingsPage.addDeveloperRoleToUser("developer@example.com");
     await expect(page.getByText("developer@example.com")).toBeVisible();
@@ -251,7 +265,6 @@ test.describe("User Management Tests", () => {
     await expect(page.getByTestId("requests-list")).toBeVisible();
   });
 });
-
 
 test.describe("Connection Review Workflow", () => {
   let adminLoginPage: LoginPage;
@@ -276,7 +289,7 @@ test.describe("Connection Review Workflow", () => {
     await settingsPage.addUser(
       "Developer Review Account",
       developerEmail,
-      developerPassword
+      developerPassword,
     );
     await settingsPage.addDeveloperRoleToUser(developerEmail);
     await page.getByTestId("settings-dropdown").click();
@@ -299,7 +312,7 @@ test.describe("Connection Review Workflow", () => {
       "5432",
       "postgres",
       undefined,
-      1 // Set required reviews to 1
+      1, // Set required reviews to 1
     );
 
     // Admin creates a request
@@ -307,7 +320,7 @@ test.describe("Connection Review Workflow", () => {
       "Review Required Connection",
       "Test Review Request",
       "This request requires a review",
-      "SELECT 1 AS result;"
+      "SELECT 1 AS result;",
     );
 
     // Admin logs out

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -9,7 +9,7 @@ import {
 import App from "./App";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 
 const handleStatusNotLoggedIn = http.get("http://localhost:8081/status", () => {
@@ -38,6 +38,10 @@ const handleLogin = http.post("http://localhost:8081/login", () => {
   );
 });
 
+const handleLogout = http.post("http://localhost:8081/logout", () => {
+  return new HttpResponse(null, { status: 200 });
+});
+
 const handleGetExecutionRequests = http.get(
   "http://localhost:8081/execution-requests/",
   () => {
@@ -56,9 +60,12 @@ const handleConfig = http.get("http://localhost:8081/config/", () => {
   return HttpResponse.json(
     {
       licenseValid: false,
-      oauthProvider: "GOOGLE",
+      oauthProvider: "google",
       ldapEnabled: false,
       samlEnabled: false,
+      version: "test",
+      buildDate: "2020-01-01",
+      gitCommit: "abc",
     },
     { status: 200 },
   );
@@ -67,6 +74,7 @@ const handleConfig = http.get("http://localhost:8081/config/", () => {
 const server = setupServer(
   handleStatusNotLoggedIn,
   handleLogin,
+  handleLogout,
   handleGetExecutionRequests,
   handleConfig,
 );
@@ -86,6 +94,34 @@ beforeAll(() => {
 });
 afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
+
+// Renders the current router location so tests can assert where the app navigated to.
+const LocationDisplay = () => {
+  const location = useLocation();
+  return (
+    <div data-testid="location">
+      {location.pathname + location.search + location.hash}
+    </div>
+  );
+};
+
+// The config mock enables Google SSO, so the email form is behind a toggle.
+const signIn = () => {
+  const showEmailForm = screen.queryByRole("button", {
+    name: "Sign in with email instead",
+  });
+  if (showEmailForm) {
+    userEvent.click(showEmailForm);
+  }
+  const emailInput = screen.getByLabelText("Email");
+  userEvent.type(emailInput, "some@email.com");
+  const passwordInput = screen.getByLabelText("Password");
+  userEvent.type(passwordInput, "somePassword");
+  const loginButton = screen.getByRole("button", { name: "Sign in" });
+  act(() => {
+    fireEvent.click(loginButton);
+  });
+};
 
 describe("App not logged in", () => {
   test("renders sign in text", async () => {
@@ -119,18 +155,81 @@ describe("App not logged in", () => {
     expect(element).toBeInTheDocument();
 
     server.use(handleStatusLoggedIn);
-    const emailInput = screen.getByLabelText("Email");
-    userEvent.type(emailInput, "some@email.com");
-    const passwordInput = screen.getByLabelText("Password");
-    userEvent.type(passwordInput, "somePassword");
-    const loginButton = screen.getByRole("button", { name: "Sign in" });
-    act(() => {
-      fireEvent.click(loginButton);
-    });
+    signIn();
 
     await waitFor(() => {
       const element = screen.queryByText("Sign in to Kviklet");
       expect(element).not.toBeInTheDocument();
+    });
+  });
+
+  test("remembers the requested page in the login url", async () => {
+    render(
+      <MemoryRouter initialEntries={["/settings/profile?tab=1#top"]}>
+        <App />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+    await screen.findByText("Sign in to Kviklet");
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      "/login?redirect=%2Fsettings%2Fprofile%3Ftab%3D1%23top",
+    );
+  });
+
+  test("passes the requested page on to the SSO login", async () => {
+    render(
+      <MemoryRouter initialEntries={["/login?redirect=%2Fsettings%2Fusers"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    await screen.findByText("Sign in to Kviklet");
+    const ssoLink = screen
+      .getAllByRole("link")
+      .find((link) => link.getAttribute("href")?.includes("/oauth2/"));
+    expect(ssoLink).toHaveAttribute(
+      "href",
+      "http://localhost:8081/oauth2/authorization/google?redirect=%2Fsettings%2Fusers",
+    );
+  });
+
+  test("returns to the requested page after login", async () => {
+    render(
+      <MemoryRouter initialEntries={["/settings/profile"]}>
+        <App />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+    await screen.findByText("Sign in to Kviklet");
+
+    server.use(handleStatusLoggedIn);
+    signIn();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/settings/profile",
+      );
+    });
+    expect(screen.queryByText("Sign in to Kviklet")).not.toBeInTheDocument();
+  });
+
+  test("ignores redirect targets that leave the site", async () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/login?redirect=" + encodeURIComponent("//evil.example"),
+        ]}
+      >
+        <App />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+    await screen.findByText("Sign in to Kviklet");
+
+    server.use(handleStatusLoggedIn);
+    signIn();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent(/^\/$/);
     });
   });
 });
@@ -162,5 +261,41 @@ describe("App logged in", () => {
     );
     const element = screen.queryByText("Sign in to Kviklet");
     expect(element).not.toBeInTheDocument();
+  });
+
+  test("logout lands on a plain login page", async () => {
+    server.use(handleStatusLoggedIn);
+    render(
+      <MemoryRouter initialEntries={["/settings/profile"]}>
+        <App />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+    const dropdown = await screen.findByTestId("settings-dropdown");
+    userEvent.click(dropdown);
+    const logoutButton = await screen.findByRole("button", { name: "Logout" });
+
+    server.use(handleStatusNotLoggedIn);
+    userEvent.click(logoutButton);
+
+    await screen.findByText("Sign in to Kviklet");
+    expect(screen.getByTestId("location")).toHaveTextContent(/^\/login$/);
+  });
+
+  test("login page forwards to the requested page when already logged in", async () => {
+    // The top-level afterEach resets the handlers, so the describe's beforeAll only
+    // covers its first test.
+    server.use(handleStatusLoggedIn);
+    render(
+      <MemoryRouter initialEntries={["/login?redirect=%2Fsettings%2Fprofile"]}>
+        <App />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/settings/profile",
+      );
+    });
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,10 @@
-import { Route, Navigate, Routes, useParams } from "react-router-dom";
+import {
+  Route,
+  Navigate,
+  Routes,
+  useLocation,
+  useParams,
+} from "react-router-dom";
 import Settings from "./routes/settings/Settings";
 import RootLayout from "./layout/RootLayout";
 import { Requests } from "./routes/Requests";
@@ -18,6 +24,7 @@ import { useHasPermission, useUserStatusLoading } from "./hooks/permissions";
 import RequirePermission from "./components/RequirePermission";
 import NotAuthorized from "./components/NotAuthorized";
 import Spinner from "./components/Spinner";
+import { loginPathFor } from "./hooks/loginRedirect";
 
 export interface ProtectedRouteProps {
   children: ReactElement;
@@ -42,12 +49,20 @@ export const ProtectedRoute = ({
   children,
 }: ProtectedRouteProps): ReactElement => {
   const userContext = useContext(UserStatusContext);
+  const location = useLocation();
 
   if (userContext.userStatus === undefined) {
     return <div>Loading...</div>;
   }
   if (userContext.userStatus === false) {
-    return <Navigate to="/login" />;
+    // Remember where the user wanted to go so the login page can send them back there —
+    // unless they just logged out, in which case the next login starts from the index page.
+    return (
+      <Navigate
+        to={userContext.loggedOut ? "/login" : loginPathFor(location)}
+        replace
+      />
+    );
   }
   return children;
 };

--- a/frontend/src/components/UserStatusProvider.tsx
+++ b/frontend/src/components/UserStatusProvider.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useRef } from "react";
 import { StatusResponse, checklogin } from "../api/StatusApi";
 import { useLocation } from "react-router-dom";
 import { Permission } from "../api/Permissions";
+import { logout } from "../api/LoginApi";
 
 type UserContext = {
   userStatus: StatusResponse | false | undefined;
@@ -11,12 +12,22 @@ type UserContext = {
    * still loading, so permission-gated controls never flash before we know.
    */
   hasPermission: (permission: Permission) => boolean;
+  /** Ends the session and commits the logged-out status. */
+  logout: () => Promise<void>;
+  /**
+   * True after a deliberate logout, until the next login. ProtectedRoute uses this to send the
+   * user to a plain /login rather than one that would bring them back to the page they just
+   * left.
+   */
+  loggedOut: boolean;
 };
 
 const UserStatusContext = React.createContext<UserContext>({
   userStatus: undefined,
   refreshState: async () => {},
   hasPermission: () => false,
+  logout: async () => {},
+  loggedOut: false,
 });
 
 type Props = {
@@ -31,6 +42,8 @@ export const UserStatusProvider: React.FC<Props> = ({ children }) => {
     userStatus: undefined,
     refreshState: async () => {},
   });
+
+  const [loggedOut, setLoggedOut] = useState(false);
 
   const location = useLocation();
   // Status fetches fire on every navigation and on login, and responses can come back out of
@@ -49,9 +62,22 @@ export const UserStatusProvider: React.FC<Props> = ({ children }) => {
         refreshState: fetchStatus,
       };
       setUserStatus(statusObject);
+      if (status) {
+        setLoggedOut(false);
+      }
     } catch (error) {
       console.error("Failed to fetch user status:", error);
     }
+  };
+
+  const logoutUser = async () => {
+    await logout();
+    // Flag first: the status refresh below commits the logged-out state, and ProtectedRoute
+    // must already know it was a logout when it redirects. Don't navigate to /login
+    // imperatively here — with the stale logged-in status still in context the login page
+    // would bounce straight back to "/" (and fire unauthenticated fetches there).
+    setLoggedOut(true);
+    await fetchStatus();
   };
 
   const handleVisibilityChange = () => {
@@ -78,8 +104,10 @@ export const UserStatusProvider: React.FC<Props> = ({ children }) => {
     return {
       ...userStatus,
       hasPermission: (permission: Permission) => permissions.has(permission),
+      logout: logoutUser,
+      loggedOut,
     };
-  }, [userStatus]);
+  }, [userStatus, loggedOut]);
 
   return (
     <UserStatusContext.Provider value={contextValue}>

--- a/frontend/src/hooks/loginRedirect.test.ts
+++ b/frontend/src/hooks/loginRedirect.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import {
+  loginPathFor,
+  safeRedirectTarget,
+  withRedirectTarget,
+} from "./loginRedirect";
+
+describe("safeRedirectTarget", () => {
+  test("keeps relative paths including query and hash", () => {
+    expect(safeRedirectTarget("/requests/abc?tab=1#top")).toBe(
+      "/requests/abc?tab=1#top",
+    );
+    expect(safeRedirectTarget("/settings/users")).toBe("/settings/users");
+  });
+
+  test("falls back to the index page when nothing is given", () => {
+    expect(safeRedirectTarget(null)).toBe("/");
+    expect(safeRedirectTarget(undefined)).toBe("/");
+    expect(safeRedirectTarget("")).toBe("/");
+  });
+
+  test("rejects anything that could leave the site", () => {
+    expect(safeRedirectTarget("https://evil.example/requests")).toBe("/");
+    expect(safeRedirectTarget("//evil.example")).toBe("/");
+    expect(safeRedirectTarget("/\\evil.example")).toBe("/");
+    expect(safeRedirectTarget("javascript:alert(1)")).toBe("/");
+    expect(safeRedirectTarget("requests/abc")).toBe("/");
+  });
+
+  test("rejects the login page itself", () => {
+    expect(safeRedirectTarget("/login")).toBe("/");
+    expect(safeRedirectTarget("/login?redirect=%2Fx")).toBe("/");
+    expect(safeRedirectTarget("/login/")).toBe("/");
+    expect(safeRedirectTarget("/loginish")).toBe("/loginish");
+  });
+});
+
+describe("loginPathFor", () => {
+  test("encodes the full location", () => {
+    expect(
+      loginPathFor({ pathname: "/requests/a b", search: "?x=1", hash: "#h" }),
+    ).toBe("/login?redirect=%2Frequests%2Fa%20b%3Fx%3D1%23h");
+  });
+
+  test("uses a plain login path for the index page", () => {
+    expect(loginPathFor({ pathname: "/", search: "", hash: "" })).toBe(
+      "/login",
+    );
+  });
+});
+
+describe("withRedirectTarget", () => {
+  test("appends the target to an SSO start url", () => {
+    expect(
+      withRedirectTarget("http://api/oauth2/authorization/google", "/new"),
+    ).toBe("http://api/oauth2/authorization/google?redirect=%2Fnew");
+  });
+
+  test("leaves the url alone for the index page", () => {
+    expect(withRedirectTarget("http://api/saml2/authenticate/saml", "/")).toBe(
+      "http://api/saml2/authenticate/saml",
+    );
+  });
+});

--- a/frontend/src/hooks/loginRedirect.ts
+++ b/frontend/src/hooks/loginRedirect.ts
@@ -1,0 +1,69 @@
+import { useSearchParams } from "react-router-dom";
+
+/**
+ * Query parameter on /login (and on the SSO start endpoints of the backend) that names the
+ * page to open once the user is logged in, e.g. `/login?redirect=%2Frequests%2Fabc`.
+ */
+const REDIRECT_PARAM = "redirect";
+
+const LOGIN_PATH = /^\/login(?:[/?#]|$)/;
+
+/**
+ * Validates a redirect target taken from the URL. Only same-origin paths are accepted: a
+ * relative path starting with a single slash. Protocol-relative URLs ("//evil.example"),
+ * backslash variants and absolute URLs fall back to "/" so the login page can never be used
+ * as an open redirector. The login page itself is rejected to avoid a redirect loop.
+ */
+function safeRedirectTarget(raw: string | null | undefined): string {
+  if (
+    !raw ||
+    !raw.startsWith("/") ||
+    raw.startsWith("//") ||
+    raw.startsWith("/\\") ||
+    LOGIN_PATH.test(raw)
+  ) {
+    return "/";
+  }
+  return raw;
+}
+
+/**
+ * The login URL that brings the user back to `location` afterwards. The index page is the
+ * default landing anyway, so it gets a plain /login.
+ */
+function loginPathFor(location: {
+  pathname: string;
+  search: string;
+  hash: string;
+}): string {
+  const target = location.pathname + location.search + location.hash;
+  if (target === "/") {
+    return "/login";
+  }
+  return `/login?${REDIRECT_PARAM}=${encodeURIComponent(target)}`;
+}
+
+/**
+ * Appends the redirect target to an SSO start URL so the backend can send the user back to
+ * it after the round trip to the identity provider.
+ */
+function withRedirectTarget(url: string, target: string): string {
+  if (target === "/") {
+    return url;
+  }
+  return `${url}?${REDIRECT_PARAM}=${encodeURIComponent(target)}`;
+}
+
+/** The validated page to send the user to after logging in. */
+function useLoginRedirectTarget(): string {
+  const [searchParams] = useSearchParams();
+  return safeRedirectTarget(searchParams.get(REDIRECT_PARAM));
+}
+
+export {
+  REDIRECT_PARAM,
+  safeRedirectTarget,
+  loginPathFor,
+  withRedirectTarget,
+  useLoginRedirectTarget,
+};

--- a/frontend/src/layout/TopBanner.tsx
+++ b/frontend/src/layout/TopBanner.tsx
@@ -13,7 +13,6 @@ import {
   PopoverPanel,
   Transition,
 } from "@headlessui/react";
-import { logout } from "../api/LoginApi";
 import { UserStatusContext } from "../components/UserStatusProvider";
 import RequirePermission from "../components/RequirePermission";
 
@@ -34,14 +33,8 @@ function TopBanner() {
     }
   };
 
-  const logoutHandler = async () => {
-    await logout();
-    // Don't navigate to /login imperatively: the user status in context is still the
-    // stale logged-in value, so the login page would immediately bounce back to "/"
-    // (and fire unauthenticated fetches there). Refreshing the status commits the
-    // logged-out state, and ProtectedRoute then redirects to /login on its own.
-    await userContext.refreshState();
-  };
+  // The provider commits the logged-out status and ProtectedRoute then redirects to /login.
+  const logoutHandler = () => userContext.logout();
 
   const loggedIn = userContext.userStatus !== undefined;
 

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -10,6 +10,10 @@ import Spinner from "../components/Spinner";
 import { isApiErrorResponse } from "../api/Errors";
 import useNotification from "../hooks/useNotification";
 import { attemptLogin } from "../api/LoginApi";
+import {
+  useLoginRedirectTarget,
+  withRedirectTarget,
+} from "../hooks/loginRedirect";
 
 const StyledInput = (props: {
   name: string;
@@ -45,6 +49,13 @@ const Login = () => {
 
   const { addNotification } = useNotification();
 
+  // Where to go after logging in: the page that bounced the user here, or the index page.
+  // SSO logins leave the app for the identity provider, so the backend has to carry the
+  // target through that round trip; it takes it as the same `redirect` parameter.
+  const redirectTarget = useLoginRedirectTarget();
+  const ssoUrl = (path: string) =>
+    withRedirectTarget(`${baseUrl}${path}`, redirectTarget);
+
   const hasSso = !!config?.oauthProvider || !!config?.samlEnabled;
   const showForm = !hasSso || showLocalLogin;
 
@@ -76,7 +87,7 @@ const Login = () => {
       if (config.oauthProvider === "google") {
         return (
           <a
-            href={`${baseUrl}/oauth2/authorization/google`}
+            href={ssoUrl("/oauth2/authorization/google")}
             className="block w-full"
           >
             <GoogleButton type="light" className="m-auto"></GoogleButton>
@@ -86,7 +97,7 @@ const Login = () => {
       if (config.oauthProvider === "keycloak") {
         return (
           <a
-            href={`${baseUrl}/oauth2/authorization/keycloak`}
+            href={ssoUrl("/oauth2/authorization/keycloak")}
             className="block w-full"
           >
             <Button className="mx-auto w-full">Login with Keycloak</Button>
@@ -95,7 +106,7 @@ const Login = () => {
       } else {
         return (
           <a
-            href={`${baseUrl}/oauth2/authorization/${config.oauthProvider}`}
+            href={ssoUrl(`/oauth2/authorization/${config.oauthProvider}`)}
             className="block w-full"
           >
             <Button className="mx-auto w-full">
@@ -110,7 +121,7 @@ const Login = () => {
   const samlButton = () => {
     if (config?.samlEnabled) {
       return (
-        <a href={`${baseUrl}/saml2/authenticate/saml`} className="block w-full">
+        <a href={ssoUrl("/saml2/authenticate/saml")} className="block w-full">
           <Button className="mx-auto w-full">Login with SAML</Button>
         </a>
       );
@@ -118,9 +129,9 @@ const Login = () => {
   };
 
   if (userContext.userStatus) {
-    // Already (or freshly) logged in — the index landing routes users without
-    // execution_request:get to their profile instead of the requests list.
-    return <Navigate to="/" replace />;
+    // Already (or freshly) logged in. Without a target this is the index landing, which
+    // routes users without execution_request:get to their profile instead of the requests list.
+    return <Navigate to={redirectTarget} replace />;
   }
 
   return (

--- a/frontend/src/routes/RequestFilters.test.tsx
+++ b/frontend/src/routes/RequestFilters.test.tsx
@@ -51,6 +51,8 @@ const renderFilterBar = () =>
         userStatus: currentUser,
         refreshState: async () => {},
         hasPermission: () => true,
+        logout: async () => {},
+        loggedOut: false,
       }}
     >
       <Harness />


### PR DESCRIPTION
Opening a link to any page while logged out now brings you back to that page after logging in, instead of always landing on the requests list. This works for every route (requests, a single request, new request, settings pages, audit log) and for all login methods.

**Frontend**
- `ProtectedRoute` sends logged-out users to `/login?redirect=<original path+query+hash>` instead of a plain `/login`.
- The login page navigates to that target after a successful username/password or LDAP login, and appends the same `redirect` parameter to the OIDC and SAML start links so the backend can carry it through the identity-provider round trip.
- Targets are validated (`safeRedirectTarget`): only a relative path starting with a single slash is accepted, so `//evil.example`, absolute URLs and `/login` itself all fall back to `/`.
- Logging out explicitly navigates to a plain `/login`, so the next login starts from the index page rather than the page you logged out from.

**Backend**
- New `LoginRedirectTargetFilter` stores a validated `redirect` parameter from `/oauth2/authorization/*` and `/saml2/authenticate/*` requests in the HTTP session. Both Spring login flows already rely on the session surviving the round trip, so the target is as durable as the login itself.
- `OidcLoginSuccessHandler` and `SamlLoginSuccessHandler` redirect to the stored target and forget it. Without a target they now redirect to `/` (the index landing, which handles users without `execution_request:get`) instead of `/requests`.

**Tests**
- Unit tests for the frontend helpers and the backend filter, App tests for the redirect round trip and the open-redirect guard, full OIDC (Dex) and SAML (Keycloak) round-trip tests that assert the final frontend URL, and an e2e test for the deep-link login flow.
